### PR TITLE
fix #1 detect git revision

### DIFF
--- a/openkore.pl
+++ b/openkore.pl
@@ -104,7 +104,11 @@ sub __start {
 sub parseArguments {
 	eval {
 		if (!Settings::parseArguments()) {
-			print Settings::getUsageText();
+			if ($Settings::options{version}) {
+				print "$Settings::versionText\n";
+			} else {
+				print Settings::getUsageText();
+			}
 			exit 1;
 		}
 	};

--- a/src/Git.pm
+++ b/src/Git.pm
@@ -1,0 +1,138 @@
+package Git;
+
+use strict;
+use warnings;
+
+use IO::Uncompress::Inflate qw( inflate );
+
+sub detect_git {
+    my ( $file ) = @_;
+
+    my $git_dir = find_git_dir( $file );
+    return if !$git_dir;
+
+    my $fp;
+    my $head_file = open( $fp, '<', "$git_dir/HEAD" ) && <$fp> =~ /ref: (.*)/ && $1;
+    return if !$head_file;
+
+    my $sha = open( $fp, '<', "$git_dir/$head_file" ) && <$fp>;
+    return if !$sha;
+    chomp $sha;
+
+    my $timestamp = commit_timestamp( git_get_commit( $git_dir, $sha ) );
+
+    return {
+        dir       => $git_dir,
+        sha       => $sha,
+        timestamp => $timestamp,
+    };
+}
+
+sub commit_timestamp {
+    my ( $commit ) = @_;
+    return if !$commit;
+    return if $commit !~ /^committer (.*) (\d+) [+-]\d+$/ms;
+    "$2";
+}
+
+# Extract a git commit from either "loose files" or a packfile.
+# http://schacon.github.io/gitbook/7_the_packfile.html
+sub git_get_commit {
+    my ( $git_dir, $sha ) = @_;
+
+    # The simple case: not in a pack file.
+    my $loose_path = sprintf '%s/objects/%s/%s', $git_dir, substr( $sha, 0, 2 ), substr $sha, 2;
+    if ( -f $loose_path ) {
+        open my $fp, '<', $loose_path;
+        my $out = '';
+        inflate( $fp, \$out );
+        return $out;
+    }
+
+    opendir DIR, "$git_dir/objects/pack" or return;
+    my $indexes = [ map { chomp;$_; } grep {/\.idx$/} readdir DIR ];
+    closedir DIR;
+    foreach my $idx ( @$indexes ) {
+        next if !open my $idx_fp, "$git_dir/objects/pack/$idx";
+        my $head_len = 4 + 4 + 256 * 4;
+        my $head     = '';
+        read $idx_fp, $head, $head_len;
+        next if !$head;
+        my ( $magic, $version, @fanout ) = unpack 'a4 N N256', $head;
+
+        if ( $magic ne "\xfftOc" || $version != 2 ) {
+
+            # Uh oh, unknown file magic or version. Hope this works...
+            print "Unknown pack file index header.\n";
+        }
+
+        my $key = ord pack 'H2', substr $sha, 0, 2;
+        my $min = $key ? $fanout[ $key - 1 ] : 0;
+        my $max = $fanout[$key];
+
+        my $sha_index;
+        seek $idx_fp, $head_len + $min * 20, 0;
+        my $packed_commit = pack 'H40', $sha;
+        for ( my $i = $min ; $i <= $max && !defined $sha_index ; $i++ ) {
+            my $str = '';
+            read $idx_fp, $str, 20;
+            $sha_index = $i if $str eq $packed_commit;
+        }
+        next if !defined $sha_index;
+
+        my $offset;
+        seek $idx_fp, $head_len + $fanout[255] * ( 20 + 4 ) + $sha_index * 4, 0;
+        read $idx_fp, $offset, 4;
+        $offset = unpack 'N', $offset;
+
+        # All done with the index file.
+        close $idx_fp;
+
+        my $packfile = $idx;
+        $packfile =~ s/\.idx$/.pack/;
+
+        my $pack_fp;
+        open $pack_fp, '<', "$git_dir/objects/pack/$packfile";
+
+        # Skip type and unpacked size.
+        seek $pack_fp, $offset, 0;
+        for ( my $i = 0xff ; $i & 0x80 ; $i = ord getc $pack_fp ) { }
+
+        # Extract data.
+        return git_inflate( $pack_fp );
+    }
+}
+
+sub git_inflate {
+    my ( $fp ) = @_;
+
+    my $data = '';
+    inflate( $fp, \$data );
+
+    $data;
+}
+
+sub git_commit_date {
+    my ( $commit ) = @_;
+}
+
+# Assume we're somewhere in the checked-out git tree. Hopefully this is true.
+sub find_git_dir {
+    my ( $dir ) = @_;
+
+    # Convert a file path to a directory.
+    $dir =~ s{[^/\\]+$}{} if -f $dir;
+
+    my $c = 40;
+    while ( --$c > 0 && opendir DIR, $dir ) {
+        my @files = readdir DIR;
+        closedir DIR;
+
+        my ( $git_dir ) = grep { $_ eq '.git' } @files;
+        return "$dir/$git_dir" if $git_dir;
+
+        $dir = "$dir/..";
+    }
+}
+
+1;

--- a/src/Settings.pm
+++ b/src/Settings.pm
@@ -79,7 +79,7 @@ our $VERSION = 'what-will-become-2.1';
 #our $SVN = T(" (SVN Version) ");
 our $WEBSITE = 'http://www.openkore.com/';
 # Translation Comment: Version String
-our $versionText = "*** $NAME ${VERSION} ( r" . (getSVNRevision() || '?') . ' ) - ' . T("Custom Ragnarok Online client") . " ***\n***   $WEBSITE   ***\n";
+our $versionText = "*** $NAME ${VERSION} ( version " . (getGitRevision() || '?') . ' ) - ' . T("Custom Ragnarok Online client") . " ***\n***   $WEBSITE   ***\n";
 our $welcomeText = TF("Welcome to %s.", $NAME);
 
 
@@ -179,6 +179,7 @@ sub parseArguments {
 		'interface=s',        \$interface,
 		'lockdown',           \$lockdown,
 		'help',	              \$options{help},
+		'version|v',          \$options{version},
 
 		'no-connect',         \$no_connect
 	);
@@ -217,6 +218,7 @@ sub parseArguments {
 	}
 
 	return 0 if ($options{help});
+	return 0 if ($options{version});
 	if (! -d $logs_folder) {
 		#if (!mkdir($logs_folder)) {
 		if (! make_path($logs_folder)) {
@@ -284,6 +286,7 @@ sub getUsageText {
 		--interface=NAME          Which interface to use at startup.
 		--lockdown                Disable potentially insecure features.
 		--help                    Displays this help message.
+		--version                 Displays the program version.
 
 		Developer options:
 		--no-connect              Do not connect to any servers.
@@ -538,6 +541,18 @@ sub getSVNRevision {
 	} else {
 		return;
 	}
+}
+
+##
+# int Settings::getGitRevision()
+#
+# Return OpenKore's Git revision number, or undef if that information cannot be retrieved.
+sub getGitRevision {
+    use Git;
+    my $git = Git::detect_git( $RealBin );
+    return if !$git;
+    my ( $sec, $min, $hour, $day, $month, $year ) = gmtime( $git->{timestamp} );
+    sprintf '%7.7s_%04d-%02d-%02d', $git->{sha}, $year + 1900, $month + 1, $day;
 }
 
 sub loadSysConfig {


### PR DESCRIPTION
- [x] Code Review
- [x] Test on Windows
- Re-build start.exe and wxstart.exe (unnecessary, because we're no longer adding any new module requirements)

Git version detection is actually pretty easy... but the hash isn't very informative by itself. Getting the commit date is much harder... but seems like a useful way of communicating whether the code is massively out of date.

This pull request generates a git revision which looks like SHA_YYYY-MM-DD. For example:
```
$ ./openkore.pl -v
*** OpenKore what-will-become-2.1 ( version 436478c_2016-02-29 ) - Custom Ragnarok Online client ***
***   http://www.openkore.com/   ***
```