### PR TITLE
Enable profiles plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ errors.txt
 benchmark-results.txt
 logs
 
+# Plugin files
+/profiles
+
 # Backup files
 *~
 .#*

--- a/control/sys.txt
+++ b/control/sys.txt
@@ -49,7 +49,7 @@ loadPlugins 2
 # loadPlugins_list <list>
 #   if loadPlugins is set to 2, this comma-separated list of plugin names (filename without the extension)
 #   specifies which plugin files to load at startup or when the "plugin load all" command is used.
-loadPlugins_list macro
+loadPlugins_list macro,profiles
 
 # skipPlugins_list <list>
 #   if loadPlugins is set to 3, this comma-separated list of plugin names (filename without the extension)

--- a/openkore.pl
+++ b/openkore.pl
@@ -103,12 +103,9 @@ sub __start {
 # Parse command-line arguments.
 sub parseArguments {
 	eval {
-		if (!Settings::parseArguments()) {
-			if ($Settings::options{version}) {
-				print "$Settings::versionText\n";
-			} else {
-				print Settings::getUsageText();
-			}
+		Settings::parseArguments();
+		if ($Settings::options{version}) {
+			print "$Settings::versionText\n";
 			exit 1;
 		}
 	};
@@ -119,6 +116,30 @@ sub parseArguments {
 		}
 		exit 1;
 	} elsif ($@) {
+		die $@;
+	}
+}
+
+# Make sure there aren't any unhandled arguments left.
+sub checkEmptyArguments {
+	if ( $Settings::options{help} ) {
+		print Settings::getUsageText();
+		exit 1;
+	}
+	eval {
+		use Getopt::Long;
+		local $SIG{__WARN__} = sub { ArgumentException->throw( $_[0] ); };
+		# Turn off the "pass_through" option so any remaining options will be considered an error.
+		Getopt::Long::Configure( 'default' );
+		GetOptions();
+	};
+	if ( my $e = caught( 'IOException', 'ArgumentException' ) ) {
+		print "Error: $e\n";
+		if ( $e->isa( 'ArgumentException' ) ) {
+			print Settings::getUsageText();
+		}
+		exit 1;
+	} elsif ( $@ ) {
 		die $@;
 	}
 }

--- a/src/functions.pl
+++ b/src/functions.pl
@@ -126,6 +126,10 @@ sub loadPlugins {
 	} elsif ($@) {
 		die $@;
 	}
+
+	# Allow plugins to use command line arguments.
+	Plugins::callHook( 'parse_command_line' );
+	main::checkEmptyArguments();
 }
 
 sub loadDataFiles {


### PR DESCRIPTION
- [x] Code Review
- [x] QA testing

Turn on the profiles plugin by default. This requires at least that we don't prompt if there are no profiles.

As a stretch goal, I want to be able to pass in a profile via a command line option.