### PR TITLE
Chat Commands Auth

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -40,6 +40,7 @@ adminPassword
 callSign
 commandPrefix ;
 callSignGM 0
+inGameAuth 0
 
 pauseCharServer 0
 pauseMapServer 0

--- a/src/ChatQueue.pm
+++ b/src/ChatQueue.pm
@@ -95,7 +95,7 @@ sub processFirst {
 	# If the user is not authorized to use chat commands,
 	# check whether he's trying to authenticate
 	if (( $type eq "pm" || $type eq "p" || $type eq "g" ) && !$overallAuth{$user} && $config{adminPassword}) {
-		if ($msg eq $config{adminPassword}) {
+		if ($msg eq $config{adminPassword} && $config{inGameAuth}) {
 			auth($user, 1);
 			sendMessage($messageSender, "pm", getResponse("authS"), $user);
 		}


### PR DESCRIPTION
- [x] Code review
- [x] QA review

There should be a way to prevent in-game auth to Chat Commands by sending a message with adminPassword, in order to prevent people from abusing an easy adminPassword

http://openkorebrasil.org/index.php?/topic/499-aonde-posso-pegar-atualiza%C3%A7%C3%A3o-segura/
http://openkorebrasil.org/index.php?/topic/490-logout/