### PR TITLE
Follow up 81406f44ff1eb4a69d00d2c2d76bdf0f1bfc49f5

### DIFF
--- a/src/Network/Send/idRO.pm
+++ b/src/Network/Send/idRO.pm
@@ -26,6 +26,7 @@ sub new {
 	my $self = $class->SUPER::new(@_);
 	
 	my %handlers = qw(
+		storage_password 023B
 		sync 0360
 		character_move 035F
 		actor_info_request 0368


### PR DESCRIPTION
- [x] Code review
- [ ] QA review

* Since `Send.pm::sendStoragePassword` looking for packet_lut, `storage_password 023B` need to be redefined.

Signed-off-by: Cydh Ramdh <cydh@pservero.com>