### PR TITLE
Fixed #74

### DIFF
--- a/src/Network/Send/idRO.pm
+++ b/src/Network/Send/idRO.pm
@@ -26,6 +26,7 @@ sub new {
 	my $self = $class->SUPER::new(@_);
 	
 	my %handlers = qw(
+		send_equip 00A9
 		storage_password 023B
 		sync 0360
 		character_move 035F
@@ -38,7 +39,6 @@ sub new {
 		skill_use_location 0366
 		party_setting 07D7
 		buy_bulk_vender 0801
-		send_equip 0998
 	);
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	


### PR DESCRIPTION
- [x] Code Review
- [ ] QA Review

* idRO uses `0x00A9` for `send_equip`

Signed-off-by: Cydh Ramdh <cydh@pservero.com>