### PR TITLE
add attackAuto -1

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2666,6 +2666,9 @@ sub processAutoEquip {
 
 ##### AUTO-ATTACK #####
 sub processAutoAttack {
+	# Don't even think about attacking if attackAuto is -1.
+	return if $config{attackAuto} && $config{attackAuto} eq -1;
+
 	# The auto-attack logic is as follows:
 	# 1. Generate a list of monsters that we are allowed to attack.
 	# 2. Pick the "best" monster out of that list, and attack it.


### PR DESCRIPTION
- [x] Product Review (is this something we should do?)
- [x] QA Review (does it work?)

Add option to turn off the `attackAuto` logic entirely.

Without this, the bot will spend time thinking about attacking nearby monsters even if it ultimately chooses not to attack. And more importantly, if a monster attacks the bot, the bot will stop and try to attack back. This is often a bad idea, particularly for priests trying to run past aggressive monsters.

With `attackAuto -1`, priests (and other support characters) can easily run past aggressive monsters without stopping.