### PR TITLE
fix updating config.txt with !include

### DIFF
--- a/src/test/FileParsersTest.pm
+++ b/src/test/FileParsersTest.pm
@@ -6,6 +6,7 @@ use Test::More;
 use FileParsers;
 use Globals;
 use Misc;
+use File::Copy;
 
 use constant NOT_CONFIGURED_ITEM => 'Random Item';
 
@@ -63,6 +64,64 @@ sub start {
 			is(pickupitems(NOT_CONFIGURED_ITEM), 1, 'all');
 			is(pickupitems($_), 2, $_) for grep {!/Bowman Scroll 1/} @{$item_names_part[0]};
 			is(pickupitems($_), -1, $_) for @{$item_names_part[1]};
+		};
+
+		subtest 'writeDataFileIntact' => sub {
+			my $config = {};
+			parseConfigFile('data/write_config.txt', $config);
+
+			my $expected = {
+				parent_child_unchanged => 2,
+				parent_child_changed => 2,
+				block_0 => 'a',
+				block_0_test => 1,
+				block_1 => 'b',
+				block_1_test => 2,
+				leading => 'tab a',
+				no_val_unchanged => undef,
+				no_val_changed => undef,
+				child_unchanged => 1,
+				child_changed => 1,
+				# TODO: Fix this? Not allowing tabs between key and value is probably a bug.
+				"tab\ta" => undef,
+			};
+			is_deeply($config, $expected);
+
+			$config->{parent_child_changed}++;
+			$config->{block_0} = 'A';
+			$config->{block_0_test}++;
+			$config->{block_1} = 'B';
+			$config->{block_1_test}++;
+			$config->{no_val_changed}++;
+			$config->{child_changed}++;
+
+            File::Copy::cp 'data/write_config.txt' => 'data/write_config.out.txt';
+			writeDataFileIntact('data/write_config.out.txt', $config);
+
+			my $reader = Utils::TextReader->new( 'data/write_config.out.txt', { hide_includes => 0 } );
+			is( $reader->readLine, "parent_child_unchanged 2\n" );
+			is( $reader->readLine, "parent_child_changed 3\n" );
+			is( $reader->readLine, "block A {\n" );
+			is( $reader->readLine, "\ttest 2\n" );
+			is( $reader->readLine, "}\n" );
+			is( $reader->readLine, "!include write_config_a.txt\n" );
+			is( $reader->readLine, "parent_child_unchanged 2\n" );
+			is( $reader->readLine, "parent_child_changed 2\n" );
+			is( $reader->readLine, "block b {\n" );
+			is( $reader->readLine, "  test 2\n" );
+			is( $reader->readLine, "}\n" );
+			is( $reader->readLine, "child_unchanged 1\n" );
+			is( $reader->readLine, "child_changed 1\n" );
+			is( $reader->readLine, "leading tab a\n" );
+			is( $reader->readLine, "leading tab a\n" );
+			is( $reader->readLine, "tab\ta\n" );
+			is( $reader->readLine, "no_val_unchanged\n" );
+			is( $reader->readLine, "no_val_changed 1\n" );
+			is( $reader->readLine, "child_changed 2\n" );
+			is( $reader->readLine, "parent_child_changed 3\n" );
+			is( $reader->eof, 1 );
+
+			unlink 'data/write_config.out.txt';
 		};
 	}}
 }

--- a/src/test/Utils/TextReaderTest.pm
+++ b/src/test/Utils/TextReaderTest.pm
@@ -7,13 +7,44 @@ use Test::More;
 use Utils::TextReader;
 
 sub start {
-	my $reader = Utils::TextReader->new( 'data/parent.txt' );
 	subtest '!include support' => sub {
+		my $reader = Utils::TextReader->new( 'data/parent.txt' );
+
 		is( $reader->readLine, "parent A\n" );
 		is( $reader->readLine, "child\n" );
 		is( $reader->readLine, "parent B\n" );
 		is( $reader->readLine, "a\n" );
 		is( $reader->readLine, "child\n" );
+		is( $reader->readLine, "parent C\n" );
+		is( $reader->readLine, undef );
+
+		is( $reader->eof, 1 );
+	};
+
+	subtest 'hide_includes=0' => sub {
+		my $reader = Utils::TextReader->new( 'data/parent.txt', { hide_includes => 0 } );
+
+		is( $reader->readLine, "parent A\n" );
+		is( $reader->readLine, "!include child.txt\n" );
+		is( $reader->readLine, "child\n" );
+		is( $reader->readLine, "parent B\n" );
+		is( $reader->readLine, "!include child/a.txt\n" );
+		is( $reader->readLine, "a\n" );
+		is( $reader->readLine, "!include ../child.txt\n" );
+		is( $reader->readLine, "child\n" );
+		is( $reader->readLine, "parent C\n" );
+		is( $reader->readLine, undef );
+
+		is( $reader->eof, 1 );
+	};
+
+	subtest 'process_includes=0' => sub {
+		my $reader = Utils::TextReader->new( 'data/parent.txt', { process_includes => 0 } );
+
+		is( $reader->readLine, "parent A\n" );
+		is( $reader->readLine, "!include child.txt\n" );
+		is( $reader->readLine, "parent B\n" );
+		is( $reader->readLine, "!include child/a.txt\n" );
 		is( $reader->readLine, "parent C\n" );
 		is( $reader->readLine, undef );
 

--- a/src/test/data/write_config.txt
+++ b/src/test/data/write_config.txt
@@ -1,0 +1,26 @@
+# Test: Value defined here, overridden in !include, and not changed should not be updated.
+parent_child_unchanged 1
+
+# Test: Value defined here, overridden in !include, and changed should be updated, and another copy inserted after the !include.
+parent_child_changed 1
+
+# Test: Changed block values should be updated.
+block a {
+  # Test: Leading whitespace should be replaced with a single tab.
+  test 1
+}
+
+!include write_config_a.txt
+
+# Test: Leading space should be removed.
+ leading space a
+	leading tab a
+
+# Test: Tabs are considered part of the key. (Is this a bug?)
+tab	a
+
+# Test: Keys with no value and not changed should not be updated.
+no_val_unchanged
+
+# Test: Keys with no value and changed should be updated.
+no_val_changed

--- a/src/test/data/write_config_a.txt
+++ b/src/test/data/write_config_a.txt
@@ -1,0 +1,13 @@
+parent_child_unchanged 2
+parent_child_changed 2
+
+# Test: Changed block values in !include files should not be updated.
+block b {
+  test 2
+}
+
+# Test: Value defined in !include and not changed should not be inserted in parent.
+child_unchanged 1
+
+# Test: Value defined in !include and changed should be inserted in parent.
+child_changed 1


### PR DESCRIPTION
- [x] Code Review
- [x] QA Review

Making a config change inside kore auto-saves the config. Since the recent change to `Utils::TextReader`, that re-save would cause all included files to be inlined into the config, instead of being preserved as includes.

This pull request fixes that.