### PR TITLE
let the server know that we're done buying/selling so we can move

### DIFF
--- a/src/Network/Receive/iRO.pm
+++ b/src/Network/Receive/iRO.pm
@@ -63,6 +63,15 @@ sub received_characters_info {
 	$self->received_characters($args);
 }
 
+sub npc_store_begin {
+	my $self = shift;
+
+	# The server won't let us move until we send the sell complete packet.
+	$messageSender->{sell_mode} = 1;
+
+	$self->SUPER::npc_store_begin(@_);
+}
+
 *parse_quest_update_mission_hunt = *Network::Receive::parse_quest_update_mission_hunt_v2;
 *reconstruct_quest_update_mission_hunt = *Network::Receive::reconstruct_quest_update_mission_hunt_v2;
 

--- a/src/Network/Send/iRO.pm
+++ b/src/Network/Send/iRO.pm
@@ -44,6 +44,8 @@ sub new {
 		send_equip 0998
 	);
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+
+	$self->{sell_mode} = 0;
 	
 	return $self;
 }
@@ -53,6 +55,21 @@ sub sendCharDelete {
 	my $msg = pack("C*", 0xFB, 0x01) .
 			$charID . pack("a50", stringToBytes($email));
 	$self->sendToServer($msg);
+}
+
+sub sendMove {
+	my $self = shift;
+
+	# The server won't let us move until we send the sell complete packet.
+	$self->sendSellComplete if $self->{sell_mode};
+
+	$self->SUPER::sendMove(@_);
+}
+
+sub sendSellComplete {
+	my ($self) = @_;
+	$messageSender->sendToServer(pack 'C*', 0xD4, 0x09);
+	$self->{sell_mode} = 0;
 }
 
 1;


### PR DESCRIPTION
- [x] QA Review

iRO now does the same thing fRO does: after talking to an NPC vendor, we must send a 09D4 packet before we can move.

This pull request solves the problem in a different way from the fRO solution, so that it will (hopefully) work in more use cases. Here we keep track of whether we started talking to an NPC vendor and send the packet along with the next move packet, regardless of whether we tried to buy or sell something.