### PR TITLE
fix for autostorage bug

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1282,9 +1282,10 @@ sub processAutoStorage {
 					next if $item->{equipped};
 					next if ($item->{broken} && $item->{type} == 7); # dont store pet egg in use
 
-					if (defined($args->{lastInventoryCount}) &&  defined($args->{lastNameID}) &&
+					if (defined($args->{lastInventoryCount}) &&  defined($args->{lastNameID}) && defined($args->{lastAmount}) &&
 					    $args->{lastNameID} == $item->{nameID} &&
-					    $args->{lastInventoryCount} == @{$char->inventory->getItems()}
+					    $args->{lastInventoryCount} == @{$char->inventory->getItems()} &&
+						$args->{lastAmount} == $item->{amount}
 					) {
 						error TF("Unable to store %s.\n", $item->{name});
 						next;
@@ -1303,6 +1304,7 @@ sub processAutoStorage {
 						undef $args->{done};
 						$args->{lastIndex} = $item->{index};
 						$args->{lastNameID} = $item->{nameID};
+						$args->{lastAmount} = $item->{amount};
 						$args->{lastInventoryCount} = scalar(@{$char->inventory->getItems()});
 						$messageSender->sendStorageAdd($item->{index}, $item->{amount} - $control->{keep});
 						$timeout{ai_storageAuto}{time} = time;


### PR DESCRIPTION
When kore puts an item into storage but keeps some of it in inventory we
receive the error message "Unable to store", but the item was stored,
this is due to an error in the error message verification. this change
should fix it.

Image of error:
https://i.gyazo.com/f694972338c497f6b7dc9cef21b83432.png

After change: 
https://i.gyazo.com/2dd1c91d968cf410139edc35a3612313.png