### PR TITLE
Character zeny change moved to before hook call

### DIFF
--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -1780,6 +1780,8 @@ sub exp_zeny_info {
 		} elsif ($change < 0) {
 			message TF("You lost %s zeny.\n", formatNumber(-$change));
 		}
+		$char->{zeny} = $args->{val};
+		debug "zeny: $args->{val}\n", "parseMsg";
 		Plugins::callHook('zeny_change', {
 			zeny	=> $args->{val},
 			change	=> $change,
@@ -1790,8 +1792,6 @@ sub exp_zeny_info {
 			chatLog("k", T("*** You have no money, auto disconnect! ***\n"));
 			quit();
 		}
-		$char->{zeny} = $args->{val};
-		debug "zeny: $args->{val}\n", "parseMsg";
 	} elsif ($args->{type} == 22) {
 		$char->{exp_max_last} = $char->{exp_max};
 		$char->{exp_max} = $args->{val};


### PR DESCRIPTION
Hook calls and $char changes should be consistent across servertypes, in
ServerType0 $char is changed before the hook call, in Sakexe_0 it should
also be done this way.