### PR TITLE
Fix about partySkill distant choice condition.

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2504,14 +2504,14 @@ sub processPartySkillUse {
 				if (
 					( # range check
 						$party_skill{owner}{ID} eq $player->{ID}
-						|| inRange(distance($party_skill{owner}{pos_to}, $player->{pos}), $config{"partySkill_$i"."_dist"} || $config{partySkillDistance} || "0..8")
+						|| inRange(distance($party_skill{owner}{pos_to}, $player->{pos}), $config{"partySkill_$i"."_dist"} or $config{partySkillDistance} or "0..8")
 					)
 					&& ( # target check
 						!$config{"partySkill_$i"."_target"}
 						or existsInList($config{"partySkill_$i"."_target"}, $player->{name})
-						or $player->{ID} eq $char->{ID} && existsInList($config{"partySkill_$i"."_target"}, '@main')
-						or $char->{homunculus} && $player->{ID} eq $char->{homunculus}{ID} && existsInList($config{"partySkill_$i"."_target"}, '@homunculus')
-						or $char->{mercenary} && $player->{ID} eq $char->{mercenary}{ID} && existsInList($config{"partySkill_$i"."_target"}, '@mercenary')
+						or ($player->{ID} eq $char->{ID} && existsInList($config{"partySkill_$i"."_target"}, '@main'))
+						or ($char->{homunculus} && $player->{ID} eq $char->{homunculus}{ID} && existsInList($config{"partySkill_$i"."_target"}, '@homunculus'))
+						or ($char->{mercenary} && $player->{ID} eq $char->{mercenary}{ID} && existsInList($config{"partySkill_$i"."_target"}, '@mercenary'))
 					)
 					&& checkPlayerCondition("partySkill_$i"."_target", $ID)
 				){


### PR DESCRIPTION
(or, and) good for do calculate or do object, but (||, &&) good for do comparison. such as this line.
|| inRange(distance($party_skill{owner}{pos_to}, $player->{pos}), $config{"partySkill_$i"."_dist"} or $config{partySkillDistance} or "0..8")

that's you want value of '$player->{pos}), $config{"partySkill_$i"."_dist"} or $config{partySkillDistance} or "0..8'

'||' don't work this above line, becuase you do want any value of these you don't want comparison its.

if You do want logic calculate, '$Y = $a and ($b or $c)' good enough.

but you do want comparison (||, &&) good performance for 'if (a && (b || c))'.

that's recommended on perl tutorial website http://perldoc.perl.org/perlop.html.

maybe if you do want 'or' these lines. 
(
!$config{"partySkill_$i"."_target"}

or existsInList($config{"partySkill_$i"."_target"}, $player->{name})
or $player->{ID} eq $char->{ID} && existsInList($config{"partySkill_$i"."_target"}, '@main')
or $char->{homunculus} && $player->{ID} eq $char->{homunculus}{ID} && existsInList($config{"partySkill_$i"."_target"}, '@homunculus')
or $char->{mercenary} && $player->{ID} eq $char->{mercenary}{ID} && existsInList($config{"partySkill_$i"."_target"}, '@mercenary')
it's mean you do want value !$config{"partySkill_$i"."_target"}

or existsInList($config{"partySkill_$i"."_target"}, $player->{name})
or $player->{ID} eq $char->{ID} && existsInList($config{"partySkill_$i"."_target"}, '@main')
or $char->{homunculus} && $player->{ID} eq $char->{homunculus}{ID} && existsInList($config{"partySkill_$i"."_target"}, '@homunculus')
or $char->{mercenary} && $player->{ID} eq $char->{mercenary}{ID} && existsInList($config{"partySkill_$i"."_target"}, '@mercenary') )
That do you want any value for 'if', you don't want comparison it.

that why they is in () maybe good enough than.

You have got idea and understand my descriptions.