### PR TITLE
Fix formatting for NPC talk response choices #271

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4828,7 +4828,7 @@ sub cmdTalk {
 			TF("#  Response\n");
 		for (my $i = 0; $i < @{$talk{'responses'}}; $i++) {
 			$msg .= swrite(
-			"@> @*",
+			"@< @*",
 			[$i, $talk{responses}[$i]]);
 		}
 		$msg .= ('-'x40) . "\n";

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4828,7 +4828,7 @@ sub cmdTalk {
 			TF("#  Response\n");
 		for (my $i = 0; $i < @{$talk{'responses'}}; $i++) {
 			$msg .= swrite(
-			"@< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<",
+			"@> @*",
 			[$i, $talk{responses}[$i]]);
 		}
 		$msg .= ('-'x40) . "\n";


### PR DESCRIPTION
***Fixed two issues outlined in Ticket #271:***

**Issue A** - Text for the NPC talk response choices were cut off if they
were longer than 36 characters.

**Issue B** - Numeric response codes for the choices need to be right
justified because up to two digit codes (i.e. more than 0-9 choices)
are possible.

Fixed by referencing: http://perldoc.perl.org/perlform.html

ticket:   #271
branch:   talk_response
modified: src/Commands.pm