### PR TITLE
XKore 2

### DIFF
--- a/src/Network/XKore2.pm
+++ b/src/Network/XKore2.pm
@@ -69,7 +69,7 @@ sub start {
 		die "Unable to start the X-Kore proxy ($publicIP:$port): $@\n"
 			. "Make sure no other servers are running on port $port.";
 	} else {
-		die $@;
+		die $@ if $@;
 	}
 	$hooks = Plugins::addHooks(
 		['packet_pre/sync_request_ex', \&sync_request_ex],

--- a/src/Network/XKore2/MapServer.pm
+++ b/src/Network/XKore2/MapServer.pm
@@ -111,9 +111,7 @@ sub onClientData {
 sub gameguard_reply {
 	my ($self, $args, $client) = @_;
 	if ($config{gameGuard} == 0) {
-		warning "Enviando reply do XKore2.\n";
-		warning "Se tiver DC's constantes apos esta mensagem poste no forum: \n";
-		error "http://forums.openkore-brasil.com.\n"
+		debug("Replying XKore 2's gameguard query");
 	} else {
 		# mangle, may be unsafe
 		$args->{mangle} = 2;


### PR DESCRIPTION
- [x] Code review
- [x] QA review

Make sure we've got an error before crashing, Network::XKore2 -  line 72
Remove Brazilian Portuguese message and broken link from source, Network::XKore2::MapServer - lines 114 to 116

Commit Logs
----
```
Unintended crash, reported by anarke and conkister. I can confirm it,
just open openkore configured with XKore 2, with a valid IP/port and
Kore will crash with no error message

http://openkorebrasil.org/index.php?/topic/1701-xkore2-bug-estranho/
(pt-br)
```
----

```
Removes message written in Brazilian Portuguese from MapServer.pm and
broken, not necessary, link to an old Forum
```