### PR TITLE
Set loadPlugins back to 1

### DIFF
--- a/control/sys.txt
+++ b/control/sys.txt
@@ -44,7 +44,7 @@ panelTwo_fontsize 8
 #   1 : load all plugins
 #   2 : only load plugins that are listed in loadPlugins_list
 #   3 : load all plugins except those listed in skipPlugins_list
-loadPlugins 2
+loadPlugins 1
 
 # loadPlugins_list <list>
 #   if loadPlugins is set to 2, this comma-separated list of plugin names (filename without the extension)


### PR DESCRIPTION
Originally we wanted to only load certain plugins by default and those would be considered "officially supported and tested"

Unfortunately this means if you want to use your own plugins you have to modify the sys.txt config file which can potentially lead to merge conflicts.

Because all "untested" plugins are currently in the "needs-review" folder, there is no reason not to load all plugins by default.