### PR TITLE
Fix crash when server config option is invalid

### DIFF
--- a/src/Network/DirectConnection.pm
+++ b/src/Network/DirectConnection.pm
@@ -498,6 +498,7 @@ sub checkConnection {
 			if ($master->{charServer_ip}) {
 				$self->serverConnect($master->{charServer_ip}, $master->{charServer_port});
 			} elsif ($servers[$config{'server'}]) {
+				message TF("Selected server: %s\n", $servers[$config{server}]->{name}), 'connection';
 				$self->serverConnect($servers[$config{'server'}]{'ip'}, $servers[$config{'server'}]{'port'});
 			} else {
 				error TF("Invalid server specified, server %s does not exist...\n", $config{server}), "connection";

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -446,9 +446,6 @@ sub account_server_info {
 
 		} elsif ($masterServer->{charServer_ip}) {
 			message TF("Forcing connect to char server %s: %s\n", $masterServer->{charServer_ip}, $masterServer->{charServer_port}), 'connection';
-
-		} else {
-			message TF("Selected server: %s\n", @servers[$config{server}]->{name}), 'connection';
 		}
 	}
 


### PR DESCRIPTION
Message with server info should be displayed only if specified server exists in the list.