### PR TITLE
Add hook 'AI_start'

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -52,6 +52,8 @@ sub iterate {
 	processMisc();
 	processPortalRecording();
 	Benchmark::end("ai_prepare") if DEBUG;
+	
+	Plugins::callHook('AI_start', {state => $AI});
 
 	return if $AI == AI::OFF;
 	if ($net->clientAlive() && !$sentWelcomeMessage && timeOut($timeout{welcomeText})) {


### PR DESCRIPTION
With this we can hook something to all AI states and even execute stuff when AI is off or in manual, and only when we are connected and $timeout{ai} is off.

I think this is an awesome hook and may be way better than 'mainLoop_pre' in many situations.