### PR TITLE
Fix wrong AI setting in 'ai' command

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -517,7 +517,7 @@ sub cmdAI {
 	} elsif ($args eq '') {
 		# Toggle AI
 		if ($AI == AI::AUTO) {
-			undef $AI;
+			$AI = AI::OFF;
 			$AI_forcedOff = 1;
 			message T("AI turned off\n"), "success";
 		} elsif ($AI == AI::OFF) {


### PR DESCRIPTION
For some reason typing 'ai off' and 'ai' on auto mode creates different results.

I think it should set $AI to AI::OFF when setting it off.