### PR TITLE
Fix building on OS X

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -25,6 +25,9 @@ EXTRA_COMPILER_FLAGS = ['-Wall', '-O3', '-pipe']
 DARWIN_INCLUDE_DIRECTORIES = ['/usr/local/opt/readline/include']
 DARWIN_LIBRARY_DIRECTORIES = ['/usr/local/opt/readline/lib']
 
+# Fixes for OS X (src/auto/XSTools/darwin/include)
+DARWIN_INCLUDE_DIRECTORIES += ['darwin/include']
+
 ####################
 
 import os

--- a/src/Utils/Benchmark.pm
+++ b/src/Utils/Benchmark.pm
@@ -54,9 +54,21 @@ package Benchmark;
 use strict;
 use Time::HiRes;
 use Modules 'register';
+use Log qw(error);
+use Translation qw(T);
 use XSTools;
 
-XSTools::bootModule('Utils::Benchmark');
+eval {
+	XSTools::bootModule('Utils::Benchmark');
+};
+if ($@) {
+	error T("Benchmarking was not compiled on this system\n");
+	*begin = sub {};
+	*end = sub {};
+	*results = sub { T("Benchmarking was not compiled on this system\n") };
+	return 1;
+}
+
 init();
 
 # Note that some functions are implemented in src/auto/XSTools/utils/perl/Benchmark.xs

--- a/src/auto/XSTools/SConscript
+++ b/src/auto/XSTools/SConscript
@@ -100,12 +100,14 @@ sources += [
 	'utils/rijndael-alg-fst.c',
 	'utils/rijndael-api-fst.c',
 	'utils/aes-cfb.c',
-	'utils/perl/Benchmark.cpp'
 ]
-XS_sources['utils/perl/Benchmark.xs'] = 'utils/perl/Benchmark.cpp'
 XS_sources['utils/perl/HttpReader.xs'] = 'utils/perl/HttpReader.cpp'
 XS_sources['utils/perl/Whirlpool.xs'] = 'utils/perl/Whirlpool.c'
 XS_sources['utils/perl/Rijndael.xs'] = 'utils/perl/Rijndael.xs.cpp'
+
+if not darwin:
+	sources += ['utils/perl/Benchmark.cpp']
+	XS_sources['utils/perl/Benchmark.xs'] = 'utils/perl/Benchmark.cpp'
 
 if not win32:
 	perlenv.ParseConfig('curl-config --cflags --libs')

--- a/src/auto/XSTools/darwin/include/perl.h
+++ b/src/auto/XSTools/darwin/include/perl.h
@@ -1,0 +1,17 @@
+/*
+Include the original file
+*/
+#include "../CORE/perl.h"
+
+/*
+Fixes error: use of undeclared identifier 'dNOOP'
+
+Read more:
+http://www.veripool.org/issues/732-Verilog-Perl-Not-able-to-install-on-Verilog-Language-Mac-10-9-2
+*/
+#ifdef PERL_DARWIN
+#ifdef dNOOP
+#undef dNOOP
+#define dNOOP
+#endif
+#endif


### PR DESCRIPTION
Can't get Benchmark module to build correctly, so disabled that on OS X for now.

Run `make clean all` first.