### PR TITLE
Overload array dereferencing for ObjectList

### DIFF
--- a/src/AI.pm
+++ b/src/AI.pm
@@ -294,7 +294,7 @@ sub ai_getAggressives {
 	my $num = 0;
 	my @agMonsters;
 
-	foreach my $monster (@{$monstersList->getItems()}) {
+	for my $monster (@$monstersList) {
 		my $control = Misc::mon_control($monster->name,$monster->{nameID}) if $type || !$wantArray;
 		my $ID = $monster->{ID};
 		next if (!timeOut($monster->{attack_failedLOS}, 6));
@@ -483,7 +483,7 @@ sub ai_route { $char->route(@_) }
 
 #sellAuto for items_control - chobit andy 20030210
 sub ai_sellAutoCheck {
-	foreach my $item (@{$char->inventory->getItems()}) {
+	for my $item (@{$char->inventory}) {
 		next if ($item->{equipped} || $item->{unsellable});
 		my $control = Misc::items_control($item->{name});
 		if ($control->{sell} && $item->{amount} > $control->{keep}) {
@@ -559,7 +559,7 @@ sub ai_storageAutoCheck {
 	if ($config{minStorageZeny}) {
 		return 0 if ($char->{zeny} < $config{minStorageZeny});
 	}
-	foreach my $item (@{$char->inventory->getItems()}) {
+	for my $item (@{$char->inventory}) {
 		next if ($item->{equipped});
 		my $control = Misc::items_control($item->{name});
 		if ($control->{storage} && $item->{amount} > $control->{keep}) {

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1039,7 +1039,7 @@ sub processAutoMakeArrow {
 		}
 		$messageSender->sendArrowCraft(-1) if ($nMake == 0 && $max > 0);
 		if ($nMake == 0 && !$useArrowCraft){
-			foreach my $item (@{$char->inventory->getItems()}) {
+			for my $item (@{$char->inventory}) {
 				if ($arrowcraft_items{lc($item->{name})}) {
 					$useArrowCraft = 1;
 					last;
@@ -1270,14 +1270,14 @@ sub processAutoStorage {
 
 				# inventory to storage
 				$args->{nextItem} = 0 unless $args->{nextItem};
-				for (my $i = $args->{nextItem}; $i < @{$char->inventory->getItems()}; $i++) {
-					my $item = $char->inventory->getItems()->[$i];
+				for (my $i = $args->{nextItem}; $i < $char->inventory->size; $i++) {
+					my $item = $char->inventory->[$i];
 					next if $item->{equipped};
 					next if ($item->{broken} && $item->{type} == 7); # dont store pet egg in use
 
 					if (defined($args->{lastInventoryCount}) &&  defined($args->{lastNameID}) && defined($args->{lastAmount}) &&
 					    $args->{lastNameID} == $item->{nameID} &&
-					    $args->{lastInventoryCount} == @{$char->inventory->getItems()} &&
+					    $args->{lastInventoryCount} == $char->inventory->size &&
 						$args->{lastAmount} == $item->{amount}
 					) {
 						error TF("Unable to store %s.\n", $item->{name});
@@ -1298,7 +1298,7 @@ sub processAutoStorage {
 						$args->{lastIndex} = $item->{index};
 						$args->{lastNameID} = $item->{nameID};
 						$args->{lastAmount} = $item->{amount};
-						$args->{lastInventoryCount} = scalar(@{$char->inventory->getItems()});
+						$args->{lastInventoryCount} = $char->inventory->size;
 						$messageSender->sendStorageAdd($item->{index}, $item->{amount} - $control->{keep});
 						$timeout{ai_storageAuto}{time} = time;
 						$args->{nextItem} = $i;
@@ -1310,8 +1310,8 @@ sub processAutoStorage {
 				# we don't really need to check if we have a cart
 				# if we don't have one it will not find any items to loop through
 				$args->{cartNextItem} = 0 unless $args->{cartNextItem};
-				for (my $i = $args->{cartNextItem}; $i < @{$char->cart->getItems()}; $i++) {
-					my $item = $char->cart->getItems()->[$i];
+				for (my $i = $args->{cartNextItem}; $i < $char->cart->size; $i++) {
+					my $item = $char->cart->[$i];
 					next unless ($item && %{$item});
 
 					my $control = items_control($item->{name});
@@ -1545,7 +1545,7 @@ sub processAutoSell {
 			
 			# Form list of items to sell
 			my @sellItems;
-			foreach my $item (@{$char->inventory->getItems()}) {
+			for my $item (@{$char->inventory}) {
 				next if ($item->{equipped});
 				next if (!$item->{sellable});
 
@@ -1777,7 +1777,7 @@ sub processAutoCart {
 			my $max;
 
 			if ($config{cartMaxWeight} && $char->cart->{weight} < $config{cartMaxWeight}) {
-				foreach my $invItem (@{$char->inventory->getItems()}) {
+				for my $invItem (@{$char->inventory}) {
 					next if ($invItem->{broken} && $invItem->{type} == 7); # dont auto-cart add pet eggs in use
 					next if ($invItem->{equipped});
 					my $control = items_control($invItem->{name});
@@ -1792,7 +1792,7 @@ sub processAutoCart {
 				cartAdd(\@addItems);
 			}
 
-			foreach my $cartItem (@{$char->cart->getItems()}) {
+			for my $cartItem (@{$char->cart}) {
 				my $control = items_control($cartItem->{name});
 				next unless ($control->{cart_get});
 
@@ -2040,7 +2040,7 @@ sub processFollow {
 
 	# if we are not following now but master is in the screen...
 	if (!defined $args->{'ID'}) {
-		foreach my Actor::Player $player (@{$playersList->getItems()}) {
+		for my Actor::Player $player (@$playersList) {
 			if (($player->name eq $config{followTarget}) && !$player->{'dead'}) {
 				$args->{'ID'} = $player->{ID};
 				$args->{'following'} = 1;
@@ -2681,7 +2681,7 @@ sub processAutoAttack {
 		# If we're in tanking mode, only attack something if the person we're tanking for is on screen.
 		my $foundTankee;
 		if ($config{'tankMode'}) {
-			for (@{$playersList->getItems}, @{$slavesList->getItems}) {
+			for (@$playersList, @$slavesList) {
 				if (
 					$config{tankModeTarget} eq $_->{name}
 					or $char->{homunculus} && $config{tankModeTarget} eq '@homunculus' && $_->{ID} eq $char->{homunculus}{ID}
@@ -2943,7 +2943,7 @@ sub processAutoTeleport {
 				$ok = 1;
 			}
 		} else {
-			foreach my Actor::Player $player (@{$playersList->getItems()}) {
+			for my Actor::Player $player (@$playersList) {
 				if (!existsInList($config{teleportAuto_notPlayers}, $player->{name}) && !existsInList($config{teleportAuto_notPlayers}, $player->{nameID})) {
 					$ok = 1;
 					last;

--- a/src/Actor/You.pm
+++ b/src/Actor/You.pm
@@ -272,7 +272,7 @@ sub attack {
 					if ($Leq && !$Leq->{equipped}) {
 						if ($Req == $Leq) {
 							undef $Leq;
-							foreach my $item (@{$char->inventory->getItems()}) {
+							for my $item (@{$char->inventory}) {
 								if ($item->{name} eq $config{"autoSwitch_${i}_leftHand"} && $item != $Req) {
 									$Leq = $item;
 									last;
@@ -341,7 +341,7 @@ sub attack {
 			if ($Leq && !$Leq->{equipped}) {
 				if ($Req == $Leq) {
 					undef $Leq;
-					foreach my $item (@{$char->inventory->getItems()}) {
+					for my $item (@{$char->inventory}) {
 						if ($item->{name} eq $config{"autoSwitch_default_leftHand"} && $item != $Req) {
 							$Leq = $item;
 							last;

--- a/src/Interface/Wx/ItemList.pm
+++ b/src/Interface/Wx/ItemList.pm
@@ -78,7 +78,7 @@ sub init {
 			       clearBeginID => $clearBeginID, clearEndID => $clearEndID };
 
 		# add already existing actors
-		for my $actor (@{$actorList->getItems}) {
+		for my $actor (@$actorList) {
 			$self->_onAdd(undef, [$actor, $actor->{binID} // $actor->{invIndex}]);
 		}
 	}
@@ -106,7 +106,7 @@ sub _getActorForIndex {
 	foreach my $l (@{$lists}) {
 		my $actorList = $l->{actorList};
 		if ($index >= $minIndex && $index < $minIndex + $actorList->size()) {
-			return $actorList->getItems()->[$index - $minIndex];
+			return $actorList->[$index - $minIndex];
 		} else {
 			$minIndex += $actorList->size();
 		}
@@ -142,9 +142,8 @@ sub _onRemove {
 
 sub _onClearBegin {
 	my ($self, $actorList) = @_;
-	my $actors = $actorList->getItems();
 
-	foreach my $actor (@{$actors}) {
+	foreach my $actor (@$actorList) {
 		my $addr = Scalar::Util::refaddr($actor);
 		my $ID = $self->{onNameChangeCallbacks}{$addr};
 		$actor->onNameChange->remove($ID);

--- a/src/InventoryList.pm
+++ b/src/InventoryList.pm
@@ -156,7 +156,7 @@ sub getByName {
 # If nothing is found, undef is returned.
 sub getByServerIndex {
 	my ($self, $serverIndex) = @_;
-	foreach my $item (@{$self->getItems()}) {
+	for my $item (@$self) {
 		if ($item->{index} == $serverIndex) {
 			return $item;
 		}
@@ -171,7 +171,7 @@ sub getByServerIndex {
 # If nothing is found, undef is returned.
 sub getByNameID {
 	my ($self, $nameID) = @_;
-	foreach my $item (@{$self->getItems()}) {
+	for my $item (@$self) {
 		if ($item->{nameID} eq $nameID) {
 			return $item;
 		}
@@ -189,7 +189,7 @@ sub getByNameID {
 # being checked.
 sub getByCondition {
 	my ($self, $condition) = @_;
-	foreach my $item (@{$self->getItems()}) {
+	for my $item (@$self) {
 		if ($condition->($item)) {
 			return $item;
 		}
@@ -284,7 +284,7 @@ sub removeByName {
 # overloaded
 sub doClear {
 	my ($self) = @_;
-	foreach my $item (@{$self->getItems()}) {
+	for my $item (@$self) {
 		assert(defined $item->{invIndex}, "invIndex must be defined") if DEBUG;
 		my $eventID = $self->{nameChangeEvents}{$item->{invIndex}};
 		delete $self->{nameChangeEvents}{$item->{invIndex}};
@@ -359,7 +359,7 @@ sub sumByName {
 	my ($self, $name) = @_;
 	assert(defined $name) if DEBUG;
 	my $sum = 0;
-	foreach my $item (@{$self->getItems()}) {
+	for my $item (@$self) {
 		if ($item->{name} eq $name) {
 			$sum = $sum + $item->{amount};
 		}

--- a/src/Match.pm
+++ b/src/Match.pm
@@ -53,11 +53,11 @@ sub player {
 		return $playersList->get($ID);
 	} elsif ($partial) {
 		$ID = quotemeta $ID;
-		foreach my $player (@{$playersList->getItems()}) {
+		for my $player (@$playersList) {
 			return $player if ($player->name =~ /^$ID/i);
 		}
 	} else {
-		foreach my $player (@{$playersList->getItems()}) {
+		for my $player (@$playersList) {
 			return $player if (lc($player->name) eq lc($ID));
 		}
 	}

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -780,8 +780,7 @@ sub objectIsMovingTowardsPlayer {
 		my %vec;
 		getVector(\%vec, $obj->{pos_to}, $obj->{pos});
 
-		my $players = $playersList->getItems();
-		foreach my $player (@{$players}) {
+		for my $player (@$playersList) {
 			my $ID = $player->{ID};
 			next if (
 			     ($ignore_party_members && $char->{party} && $char->{party}{users}{$ID})
@@ -2250,8 +2249,7 @@ sub positionNearPlayer {
 	my $r_hash = shift;
 	my $dist = shift;
 
-	my $players = $playersList->getItems();
-	foreach my $player (@{$players}) {
+	for my $player (@$playersList) {
 		my $ID = $player->{ID};
 		next if ($char->{party} && $char->{party}{users} &&
 			$char->{party}{users}{$ID});
@@ -2265,8 +2263,7 @@ sub positionNearPortal {
 	my $r_hash = shift;
 	my $dist = shift;
 
-	my $portals = $portalsList->getItems();
-	foreach my $portal (@{$portals}) {
+	for my $portal (@$portalsList) {
 		return 1 if (distance($r_hash, $portal->{pos}) <= $dist);
 	}
 	return 0;
@@ -3234,7 +3231,7 @@ sub writeStorageLog {
 
 	if (open($f, ">:utf8", $Settings::storage_log_file)) {
 		print $f TF("---------- Storage %s -----------\n", getFormattedDate(int(time)));
-		foreach my $item (@{$char->storage->getItems()}) {
+		for my $item (@{$char->storage}) {
 
 			my $display = sprintf "%2d %s x %s", $item->{invIndex}, $item->{name}, $item->{amount};
 			# Translation Comment: Mark to show not identified items
@@ -3541,8 +3538,7 @@ sub percent_weight {
 #######################################
 
 sub avoidGM_near {
-	my $players = $playersList->getItems();
-	foreach my $player (@{$players}) {
+	for my $player (@$playersList) {
 		# skip this person if we dont know the name
 		next if (!defined $player->{name});
 
@@ -3600,8 +3596,7 @@ sub avoidGM_near {
 sub avoidList_near {
 	return if ($config{avoidList_inLockOnly} && $field->baseName ne $config{lockMap});
 
-	my $players = $playersList->getItems();
-	foreach my $player (@{$players}) {
+	for my $player (@$playersList) {
 		my $avoidPlayer = $avoid{Players}{lc($player->{name})};
 		my $avoidID = $avoid{ID}{$player->{nameID}};
 		if (!$net->clientAlive() && ( ($avoidPlayer && $avoidPlayer->{disconnect_on_sight}) || ($avoidID && $avoidID->{disconnect_on_sight}) )) {
@@ -4015,8 +4010,7 @@ sub checkSelfCondition {
     if (defined $config{$prefix . "_monstersCount"}) {
 		my $nowMonsters = $monstersList->size();
 			if ($nowMonsters > 0 && $config{$prefix . "_notMonsters"}) {
-				my $monsters = $monstersList->getItems();
-				foreach my $monster (@{$monsters}) {
+				for my $monster (@$monstersList) {
 					$nowMonsters-- if (existsInList($config{$prefix . "_notMonsters"}, $monster->{name}));
                 }
             }

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2783,9 +2783,8 @@ sub chat_newowner {
 		if ($user eq $char->{name}) {
 			$chatRooms{$currentChatRoom}{ownerID} = $accountID;
 		} else {
-			my $players = $playersList->getItems();
 			my $player;
-			foreach my $p (@{$players}) {
+			for my $p (@$playersList) {
 				if ($p->{name} eq $user) {
 					$player = $p;
 					last;
@@ -3578,7 +3577,7 @@ sub item_disappeared {
 	my $item = $itemsList->getByID($args->{ID});
 	if ($item) {
 		if ($config{attackLooters} && AI::action ne "sitAuto" && pickupitems(lc($item->{name})) > 0) {
-			foreach my Actor::Monster $monster (@{$monstersList->getItems()}) { # attack looter code
+			for my Actor::Monster $monster (@$monstersList) { # attack looter code
 				if (my $control = mon_control($monster->name,$monster->{nameID})) {
 					next if ( ($control->{attack_auto}  ne "" && $control->{attack_auto} == -1)
 						|| ($control->{attack_lvl}  ne "" && $control->{attack_lvl} > $char->{lv})

--- a/src/Utils/ObjectList.pm
+++ b/src/Utils/ObjectList.pm
@@ -67,6 +67,9 @@ use Carp::Assert;
 use Scalar::Util;
 use Utils::CallbackList;
 
+use overload 'bool' => sub { 1 };
+use overload '@{}' => \&getItems;
+
 ### CATEGORY: Class ObjectList
 
 ##

--- a/src/test/ObjectListTest.pm
+++ b/src/test/ObjectListTest.pm
@@ -81,7 +81,8 @@ sub testAdd {
 		$indices{$index} = 1;
 	}
 
-	is_deeply($self->{list}->getItems(), \@items);
+	is_deeply(\@{$self->{list}}, \@items);
+	is_deeply($self->{list}->getItems, \@{$self->{list}});
 	$self->{list}->onAdd()->remove($ID);
 }
 
@@ -118,7 +119,8 @@ sub testRemove {
 	is($self->{list}->find($self->{item4}), $index4);
 	is($self->{list}->find($self->{item5}), $index5);
 	is($self->{list}->find($self->{item6}), -1);
-	is_deeply($self->{list}->getItems(), [$self->{item1}, $self->{item3}, $self->{item4}, $self->{item5}]);
+	is_deeply(\@{$self->{list}}, [$self->{item1}, $self->{item3}, $self->{item4}, $self->{item5}]);
+	is_deeply($self->{list}->getItems, \@{$self->{list}});
 	$self->{list}->checkValidity();
 
 	# Delete item 4
@@ -137,7 +139,8 @@ sub testRemove {
 	is($self->{list}->find($self->{item4}), -1);
 	is($self->{list}->find($self->{item5}), $index5);
 	is($self->{list}->find($self->{item6}), -1);
-	is_deeply($self->{list}->getItems(), [$self->{item1}, $self->{item3}, $self->{item5}]);
+	is_deeply(\@{$self->{list}}, [$self->{item1}, $self->{item3}, $self->{item5}]);
+	is_deeply($self->{list}->getItems, \@{$self->{list}});
 	$self->{list}->checkValidity();
 
 	# Put back item 2
@@ -155,7 +158,8 @@ sub testRemove {
 	is($self->{list}->find($self->{item4}), -1);
 	is($self->{list}->find($self->{item5}), $index5);
 	is($self->{list}->find($self->{item6}), -1);
-	is_deeply($self->{list}->getItems(), [$self->{item1}, $self->{item2}, $self->{item3}, $self->{item5}]);
+	is_deeply(\@{$self->{list}}, [$self->{item1}, $self->{item2}, $self->{item3}, $self->{item5}]);
+	is_deeply($self->{list}->getItems, \@{$self->{list}});
 	$self->{list}->checkValidity();
 
 	# Remove nonexistant item
@@ -172,7 +176,8 @@ sub testRemove {
 	is($self->{list}->find($self->{item4}), -1);
 	is($self->{list}->find($self->{item5}), $index5);
 	is($self->{list}->find($self->{item6}), -1);
-	is_deeply($self->{list}->getItems(), [$self->{item1}, $self->{item2}, $self->{item3}, $self->{item5}]);
+	is_deeply(\@{$self->{list}}, [$self->{item1}, $self->{item2}, $self->{item3}, $self->{item5}]);
+	is_deeply($self->{list}->getItems, \@{$self->{list}});
 	$self->{list}->checkValidity();
 
 	# Put back item 4
@@ -190,7 +195,8 @@ sub testRemove {
 	is($self->{list}->find($self->{item4}), $index4);
 	is($self->{list}->find($self->{item5}), $index5);
 	is($self->{list}->find($self->{item6}), -1);
-	is_deeply($self->{list}->getItems(), [$self->{item1}, $self->{item2}, $self->{item3}, $self->{item4}, $self->{item5}]);
+	is_deeply(\@{$self->{list}}, [$self->{item1}, $self->{item2}, $self->{item3}, $self->{item4}, $self->{item5}]);
+	is_deeply($self->{list}->getItems, \@{$self->{list}});
 	$self->{list}->checkValidity();
 }
 
@@ -222,7 +228,8 @@ sub testClear {
 	for (my $i = 0; $i < 15; $i++) {
 		ok(!defined $self->{list}->get($i));
 	}
-	is_deeply($self->{list}->getItems(), []);
+	is_deeply(\@{$self->{list}}, []);
+	is_deeply($self->{list}->getItems, \@{$self->{list}});
 }
 
 # Test addition and removal of duplicate items.
@@ -242,7 +249,8 @@ sub testDuplicate {
 	ok(!defined $self->{list}->get($index2));
 	ok($self->{list}->get($index3) == $self->{item1});
 	ok($self->{list}->get($index4) == $self->{item3});
-	is_deeply($self->{list}->getItems(), [$self->{item1}, $self->{item3}]);
+	is_deeply(\@{$self->{list}}, [$self->{item1}, $self->{item3}]);
+	is_deeply($self->{list}->getItems, \@{$self->{list}});
 	$self->{list}->checkValidity();
 }
 


### PR DESCRIPTION
`@$playersList` is much shorter than `@{$playersList->getItems}` and IMO doesn't hurt readability.

Also, if `$list` is undefined, `@$list` would successfully evaluate to empty array, so in some situations it's not even needed to check if `$list` is defined.

- [ ] QA review
- [ ] code review
- [ ] test AI features