### PR TITLE
Run tests with `make test` instead of launching openkore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ bindist:
 	bash makedist.sh --bin
 
 test:
-	perl openkore.pl --control=../control --tables=../tables --fields=../fields $$ARGS
+	cd src/test && ./unittests.pl
 
 doc:
 	cd src/doc && ./createdoc.pl


### PR DESCRIPTION
It's common convention to run tests with just `make test`. I'm not sure what the current `test` target is used for.