### PR TITLE
Allow using talknpc command with empty conversation sequence

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4983,7 +4983,7 @@ sub cmdTalk {
 sub cmdTalkNPC {
 	my (undef, $args) = @_;
 
-	my ($x, $y, $sequence) = $args =~ /^(\d+) (\d+) (.+)$/;
+	my ($x, $y, $sequence) = $args =~ /^(\d+) (\d+)(?: (.+))?$/;
 	unless (defined $x) {
 		error T("Syntax Error in function 'talknpc' (Talk to an NPC)\n" .
 			"Usage: talknpc <x> <y> <sequence>\n");


### PR DESCRIPTION
Useful for talking with NPCs whose sequence consists of only `c` (Next) items.