### PR TITLE
Use git commit hash instead of "SVN Revision"

### DIFF
--- a/src/ErrorHandler.pm
+++ b/src/ErrorHandler.pm
@@ -75,11 +75,11 @@ sub errorHandler {
 	$log .= "\@ai_seq = @Globals::ai_seq\n" if (@Globals::ai_seq);
 	$log .= "Network state = $Globals::conState\n" if (defined $Globals::conState);
 	$log .= "Network handler = " . Scalar::Util::blessed($Globals::net) . "\n" if ($Globals::net);
-	my $revision = defined(&Settings::getSVNRevision) ? Settings::getSVNRevision() : undef;
+	my $revision = defined(&Settings::getGitRevision) ? Settings::getGitRevision() : undef;
 	if (defined $revision) {
-		$log .= "SVN revision: $revision\n";
+		$log .= "Git commit: $revision\n";
 	} else {
-		$log .= "SVN revision: unknown\n";
+		$log .= "Git commit: unknown\n";
 	}
 	if (@Plugins::plugins) {
 		$log .= "Loaded plugins:\n";

--- a/src/Interface/Console/Curses.pm
+++ b/src/Interface/Console/Curses.pm
@@ -116,8 +116,8 @@ sub new {
 
 	$self->{time_start} = time;
 
-	$self->{revision} = Settings::getSVNRevision;
-	$self->{revision} = " (r$self->{revision})" if defined $self->{revision};
+	$self->{revision} = Settings::getGitRevision;
+	$self->{revision} = " ($self->{revision})" if defined $self->{revision};
 
 	$self->{loading} = {
 		current => 0,

--- a/src/Settings.pm
+++ b/src/Settings.pm
@@ -571,29 +571,6 @@ sub loadFiles {
 }
 
 ##
-# int Settings::getSVNRevision()
-#
-# Return OpenKore's SVN revision number, or undef if that information cannot be retrieved.
-sub getSVNRevision {
-	my $f;
-	if (open($f, "<", "$RealBin/.svn/entries")) {
-		my $revision;
-		eval {
-			die unless <$f> =~ /^\d+$/;	# We only support the non-XML format
-			die unless <$f> eq "\n";	# Empty string for current directory.
-			die unless <$f> eq "dir\n";	# We expect a directory entry.
-			$revision = <$f>;
-			$revision =~ s/[\r\n]//g;
-			undef $revision unless $revision =~ /^\d+$/;
-		};
-		close($f);
-		return $revision;
-	} else {
-		return;
-	}
-}
-
-##
 # int Settings::getGitRevision()
 #
 # Return OpenKore's Git revision number, or undef if that information cannot be retrieved.


### PR DESCRIPTION
Found via reading user posted issues on Github, where the errors.txt
reports that were still showing a misdirecting/distracting
"SVN revision: unknown".

We let this one slip through - we're still checking the SVN revision
when we should be checking the git commit hash instead.  The code,
getGitRevision, already exists, so let's get rid of the old, onto the
new!

Modified:
src/ErrorHandler.pm
- changed out SVN references/calls for Git in the errors.txt output
src/Interface/Console/Curses.pm
- swapped out same SVN for Git references calls, minor format change
so we're not prepending an "r" on the git commit hash.
src/Settings.pm
- removed getSVNRevision - no longer called in the two places above.