### PR TITLE
reformat revision to include both git and file creation date

### DIFF
--- a/plugins/needs-review/leaveMeAlone/trunk/leaveMeAlone.pl
+++ b/plugins/needs-review/leaveMeAlone/trunk/leaveMeAlone.pl
@@ -144,11 +144,6 @@ sub turnOn {
 	
 
 sub start {
-	if (!&Settings::getSVNRevision()) {
-		msg("[".PLUGINNAME."] We couldn't check your OpenKore Revision. Please make sure that you're using at least revision 7970, or use version 4 for older revisions.", 3);
-	} elsif (&Settings::getSVNRevision() < 7970) {
-		msg("[".PLUGINNAME."] Seems like you're using OpenKore r".&Settings::getSVNRevision().". Please make sure that you're using at least revision 7970, otherwise some functions may not work properly.", 3);
-	}
 	my @ha = &Settings::getControlFolders();	
 	if ($config{leaveMeAlone_useControlFolder}) {
 		$blackListFile = &Settings::getControlFilename("blacklist.txt");

--- a/src/ErrorHandler.pm
+++ b/src/ErrorHandler.pm
@@ -75,12 +75,7 @@ sub errorHandler {
 	$log .= "\@ai_seq = @Globals::ai_seq\n" if (@Globals::ai_seq);
 	$log .= "Network state = $Globals::conState\n" if (defined $Globals::conState);
 	$log .= "Network handler = " . Scalar::Util::blessed($Globals::net) . "\n" if ($Globals::net);
-	my $revision = defined(&Settings::getSVNRevision) ? Settings::getSVNRevision() : undef;
-	if (defined $revision) {
-		$log .= "SVN revision: $revision\n";
-	} else {
-		$log .= "SVN revision: unknown\n";
-	}
+	$log .= "Revision: " . Settings::getRevisionString() . "\n";
 	if (@Plugins::plugins) {
 		$log .= "Loaded plugins:\n";
 		foreach my $plugin (@Plugins::plugins) {

--- a/src/Interface/Console/Curses.pm
+++ b/src/Interface/Console/Curses.pm
@@ -116,8 +116,7 @@ sub new {
 
 	$self->{time_start} = time;
 
-	$self->{revision} = Settings::getSVNRevision;
-	$self->{revision} = " (r$self->{revision})" if defined $self->{revision};
+	$self->{revision} = Settings::getRevisionString();
 
 	$self->{loading} = {
 		current => 0,
@@ -562,7 +561,7 @@ sub updateStatus {
 	if ($self->{loading} && $self->{loading}{finish} != 2) {
 		erase $self->{winStatus};
 		my $width = int($self->{winStatusWidth});
-		my $title = "$Settings::NAME ${Settings::VERSION}$self->{revision}";
+		my $title = "$Settings::NAME ${Settings::VERSION} $self->{revision}";
 		$self->printw($self->{winStatus}, 0, 0, "{bold|yellow}          @*{bold|blue} @".(">"x($width - length ($title) - 20)),
 			$title, $Settings::WEBSITE);
 		my $loadingbar = $self->makeBar($width-18, $self->{loading}{current}, $self->{loading}{total});

--- a/src/Settings.pm
+++ b/src/Settings.pm
@@ -598,29 +598,6 @@ sub getRevisionString {
 }
 
 ##
-# int Settings::getSVNRevision()
-#
-# Return OpenKore's SVN revision number, or undef if that information cannot be retrieved.
-sub getSVNRevision {
-	my $f;
-	if (open($f, "<", "$RealBin/.svn/entries")) {
-		my $revision;
-		eval {
-			die unless <$f> =~ /^\d+$/;	# We only support the non-XML format
-			die unless <$f> eq "\n";	# Empty string for current directory.
-			die unless <$f> eq "dir\n";	# We expect a directory entry.
-			$revision = <$f>;
-			$revision =~ s/[\r\n]//g;
-			undef $revision unless $revision =~ /^\d+$/;
-		};
-		close($f);
-		return $revision;
-	} else {
-		return;
-	}
-}
-
-##
 # int Settings::getGitRevision()
 #
 # Return OpenKore's Git revision number, or undef if that information cannot be retrieved.

--- a/src/Settings.pm
+++ b/src/Settings.pm
@@ -80,7 +80,7 @@ our $VERSION = 'what-will-become-2.1';
 #our $SVN = T(" (SVN Version) ");
 our $WEBSITE = 'http://www.openkore.com/';
 # Translation Comment: Version String
-our $versionText = "*** $NAME ${VERSION} ( version " . (getGitRevision() || '?') . ' ) - ' . T("Custom Ragnarok Online client") . " ***\n***   $WEBSITE   ***\n";
+our $versionText = "*** $NAME ${VERSION} ( version " . getRevisionString() . ' ) - ' . T("Custom Ragnarok Online client") . " ***\n***   $WEBSITE   ***\n";
 our $welcomeText = TF("Welcome to %s.", $NAME);
 
 
@@ -568,6 +568,33 @@ sub loadFiles {
     }
 
     Plugins::callHook('postloadfiles', {files => $files});
+}
+
+##
+# str Settings::getRevisionString()
+#
+# Return OpenKore's revision as a string to be displayed to the user.
+sub getRevisionString {
+	my @revisions;
+
+    # The best and most accurate version is the git commit sha, if available.
+	my $git = getGitRevision();
+	if ( $git ) {
+		push @revisions, "git:$git";
+	}
+
+    # "Download ZIP" on github sets the file creation times to (around) the
+    # last time a commit was uploaded to github. This can help make a good
+    # guess about what version is in use.
+	my $time = ( stat( __FILE__ ) )[10] || ( stat( _ ) )[9];
+	if ( $time ) {
+		my ( $sec, $min, $hour, $day, $month, $year ) = gmtime( $time );
+		push @revisions, sprintf 'ctime:%04d_%02d_%02d', $year + 1900, $month + 1, $day;
+	}
+
+	push @revisions, '?' if !@revisions;
+
+	join ' ', @revisions;
 }
 
 ##


### PR DESCRIPTION
- [x] Product Review (is it the right feature to add?)
- [x] QA Review (does it work?)
- [x] Code Review (does the code look good?)

We were not including the git sha (if available) in `errors.txt`. This pull fixes that.

In addition, as the git sha isn't always available (many users use "Download ZIP" instead of a git client to get the code), this pull adds the creation date of `Settings.pm` to the version string. Github sets the creation date of all files in downloaded zipfiles to (near?) the date of the last commit.

Before: `SVN revision: unknown`

After: `Revision: git:9ddeda4_2017-02-19 ctime:2017_02_19`