### PR TITLE
notify users when they lose skills (typically due to equipment changes)

### DIFF
--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -5898,6 +5898,7 @@ sub skill_delete {
 	return if !$skill;
 	return if !$char->{skills}->{ $skill->getHandle };
 
+	message TF( "Lost skill: %s\n", $skill->getName ), 'skill';
 	delete $char->{skills}->{ $skill->getHandle };
 	binRemove( \@skillsID, $skill->getHandle );
 }


### PR DESCRIPTION
- [ ] QA (does it work?)
- [ ] Product Review (is this a good idea?)

Show a notice when the bot loses a skill. This usually happens when unequipping something which confers a skill (eg, unequipping a Vitata Card removes the Heal skill).