### PR TITLE
fix #443 cart should only be removed for map server changes

### DIFF
--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -2097,6 +2097,10 @@ sub map_changed {
 		delete $char->{encoreSkill};
 	}
 	undef %guild;
+	if ( $char->cartActive ) {
+		$char->cart->close;
+		$char->cart->clear;
+	}
 
 	Plugins::callHook('Network::Receive::map_changed', {
 		oldMap => $oldMap,

--- a/src/functions.pl
+++ b/src/functions.pl
@@ -619,7 +619,6 @@ sub initMapChangeVars {
 		delete $char->{casting};
 		delete $char->{homunculus}{appear_time} if $char->{homunculus};
 		$char->inventory->onMapChange();
-		$char->cart->onMapChange() if ($char->cartActive());
 		$char->storage->close() if ($char->storage->isReady());
 	}
 	$timeout{play}{time} = time;


### PR DESCRIPTION
There are two types of map changes in RO: teleport/portal change on the current map server, and map server changes. If we don't change map servers, the client is expected to keep the character's cart info (if any). If we do change map servers, the client is given new cart info, so we can discard the old one.

The code was set up opposite to the way it was supposed to be. We kept the cart when changing map servers (which is pretty harmless), and we threw away the cart when not changing map servers (which made the cart disappear after a teleport).

This pull request puts it back the way it's supposed to be.