### PR TITLE
fix cart inventory; should clear when logging in

### DIFF
--- a/src/functions.pl
+++ b/src/functions.pl
@@ -619,6 +619,8 @@ sub initMapChangeVars {
 		delete $char->{casting};
 		delete $char->{homunculus}{appear_time} if $char->{homunculus};
 		$char->inventory->onMapChange();
+		# Clear the cart but do not close it.
+		$char->cart->clear;
 		$char->storage->close() if ($char->storage->isReady());
 	}
 	$timeout{play}{time} = time;


### PR DESCRIPTION
This pull request undoes more of the timing changes introduced by the InventoryList refactor. The cart inventory is supposed to be cleared when we log in (this pull request), and cart existence is supposed to be set when we get a `map_changed` packet (a different pull request, already merged).

Without this code, the cart can get into a bad state, with phantom items in the cart which can cause disconnects when the user tries to do something with them. And relogging won't fix it.