### PR TITLE
[pm command] All numbers character name fix.

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4135,7 +4135,7 @@ sub cmdPrivateMessage {
 			"Usage: pm (username) (message)\n       pm (<#>) (message)\n");
 		return;
 
-	} elsif ($user =~ /^\d+$/) {
+	} elsif ($user =~ /^[^"]{1}\d+[^"]{1}$/) {
 		if ($user - 1 >= @privMsgUsers) {
 			error TF("Error in function 'pm' (Private Message)\n" .
 				"Quick look-up %s does not exist\n", $user);

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4149,7 +4149,7 @@ sub cmdPrivateMessage {
 		}
 
 	} else {
-		$user =~ s/^\"(.*)\"$/\1/;
+		$user =~ s/^\"(.*)\"$/$1/;
 		if (!defined binFind(\@privMsgUsers, $user)) {
 			push @privMsgUsers, $user;
 		}

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4149,6 +4149,7 @@ sub cmdPrivateMessage {
 		}
 
 	} else {
+		$user = s/^\"(.*)\"$/\1/;
 		if (!defined binFind(\@privMsgUsers, $user)) {
 			push @privMsgUsers, $user;
 		}

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4149,7 +4149,7 @@ sub cmdPrivateMessage {
 		}
 
 	} else {
-		$user = s/^\"(.*)\"$/\1/;
+		$user =~ s/^\"(.*)\"$/\1/;
 		if (!defined binFind(\@privMsgUsers, $user)) {
 			push @privMsgUsers, $user;
 		}


### PR DESCRIPTION
If char name consists of only numbers. pm command would count it as list number.
So now we can "" the number so to send it to all numbers character name:
pm "12312" message