### PR TITLE
add npc checks in autobuy and autosell sequence

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -699,7 +699,7 @@ sellAuto 0
 sellAuto_npc
 sellAuto_standpoint
 sellAuto_distance 5
-sellAuto_npc_steps s e
+sellAuto_npc_steps s
 
 storageAuto 0
 storageAuto_npc

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1532,13 +1532,15 @@ sub processAutoSell {
 				my $realpos = {};
 				getNPCInfo($config{"sellAuto_npc"}, $realpos);
 
-				ai_talkNPC($realpos->{pos}{x}, $realpos->{pos}{y}, $config{sellAuto_npc_steps} || 's e');
+				ai_talkNPC($realpos->{pos}{x}, $realpos->{pos}{y}, $config{sellAuto_npc_steps} || 's');
 
 				return;
 			}
 			$args->{'done'} = 1;			
 			
 			Plugins::callHook("AI_sell_auto");
+			
+			return unless ($ai_v{'npc_talk'}{'talk'} eq 'sell');
 			
 			# Form list of items to sell
 			my @sellItems;
@@ -1750,10 +1752,12 @@ sub processAutoBuy {
 				my $realpos = {};
 				getNPCInfo($config{"buyAuto_$args->{index}"."_npc"}, $realpos);
 
-				ai_talkNPC($realpos->{pos}{x}, $realpos->{pos}{y}, $config{"buyAuto_$args->{index}"."_npc_steps"} || 'b e');
+				ai_talkNPC($realpos->{pos}{x}, $realpos->{pos}{y}, $config{"buyAuto_$args->{index}"."_npc_steps"} || 'b');
 				return;
 			}
 
+			return unless ($ai_v{'npc_talk'}{'talk'} eq 'store');
+			
 			my $maxbuy = ($config{"buyAuto_$args->{index}"."_price"}) ? int($char->{zeny}/$config{"buyAuto_$args->{index}"."_price"}) : 30000; # we assume we can buy 30000, when price of the item is set to 0 or undef
 			my $needbuy = $config{"buyAuto_$args->{index}"."_maxAmount"};
 			$needbuy -= $char->inventory->get($args->{invIndex})->{amount} if ($args->{invIndex} ne ""); # we don't need maxAmount if we already have a certain amount of the item in our inventory

--- a/src/Task/TalkNPC.pm
+++ b/src/Task/TalkNPC.pm
@@ -290,10 +290,9 @@ sub iterate {
 				undef $ai_v{'npc_talk'}{'time'};
 				undef $ai_v{'npc_talk'}{'talk'};
 			}
-			
-			return unless $self->addSteps($self->{sequence});
 
 			if ($target || %talk) {
+				return unless ($self->addSteps($self->{sequence}));
 				$self->{stage} = TALKING_TO_NPC;
 				$self->{time} = time;
 			}

--- a/tables/bRO/control-br/config.txt
+++ b/tables/bRO/control-br/config.txt
@@ -712,7 +712,7 @@ sellAuto 0
 sellAuto_npc
 sellAuto_standpoint
 sellAuto_distance 5
-sellAuto_npc_steps s e
+sellAuto_npc_steps s
 
 storageAuto 0
 storageAuto_npc


### PR DESCRIPTION
With these changes openkore won't send unecessary packets to the server during autobuy ( #671  ) if it cannot talk to the npc and also won't check for a sell list if it isn't already talking to a npc.

Also `e` at the end of sellauto and buyauto are not necessary since Task::TalkNPC will clear itself if no more steps are given after a buy or sell interaction.