### PR TITLE
Morocc portals fix: 1 missing config

### DIFF
--- a/tables/iRO/Restart/official/portals.txt
+++ b/tables/iRO/Restart/official/portals.txt
@@ -1326,6 +1326,7 @@ moc_fild09 126 20 moc_fild15 158 363
 moc_fild09 267 371 moc_fild05 268 18
 moc_fild09 374 195 moc_fild08 16 207
 moc_fild10 19 207 morocc 302 207
+morocc 302 207 moc_fild10 19 207
 moc_fild10 189 23 moc_fild11 189 363
 moc_fild10 208 298 moc_fild06 207 18
 moc_fild11 189 363 moc_fild10 189 23


### PR DESCRIPTION
Accidentally omitted this config during the duplicate check.
Please add this as well.