### PR TITLE
Give RMS its own ServerType

### DIFF
--- a/src/Network/Receive/RMS.pm
+++ b/src/Network/Receive/RMS.pm
@@ -1,0 +1,27 @@
+#########################################################################
+#  OpenKore - Packet Receiveing
+#  This module contains functions for Receiveing packets to the server.
+#
+#  This software is open source, licensed under the GNU General Public
+#  License, version 2.
+#  Basically, this means that you're allowed to modify and distribute
+#  this software. However, if you distribute modified versions, you MUST
+#  also distribute the source code.
+#  See http://www.gnu.org/licenses/gpl.html for the full license.
+########################################################################
+# Korea (kRO)
+# The majority of private servers use eAthena, this is a clone of kRO
+
+package Network::Receive::RMS;
+
+use strict;
+use base qw(Network::Receive::kRO::RagexeRE_2014_10_22b);
+
+sub new {
+	my ($class) = @_;
+	my $self = $class->SUPER::new(@_);
+
+	return $self;
+}
+
+1;

--- a/src/Network/Send/RMS.pm
+++ b/src/Network/Send/RMS.pm
@@ -1,0 +1,26 @@
+#########################################################################
+#  OpenKore - Packet sending
+#  This module contains functions for sending packets to the server.
+#
+#  This software is open source, licensed under the GNU General Public
+#  License, version 2.
+#  Basically, this means that you're allowed to modify and distribute
+#  this software. However, if you distribute modified versions, you MUST
+#  also distribute the source code.
+#  See http://www.gnu.org/licenses/gpl.html for the full license.
+########################################################################
+package Network::Send::RMS;
+
+use strict;
+use base qw(Network::Send::kRO::RagexeRE_2014_10_22b);
+
+sub new {
+	my ($class) = @_;
+	my $self = $class->SUPER::new(@_);
+	
+	$self->cryptKeys(688214506, 761751195, 731196533);
+
+	return $self;
+}
+
+1;

--- a/tables/servers.txt
+++ b/tables/servers.txt
@@ -492,7 +492,7 @@ ip 69.197.167.236
 port 6900
 version 51
 master_version 2
-serverType kRO_RagexeRE_2014_10_22b
+serverType RMS
 serverEncoding Western
 charBlockSize 147
 addTableFolders kRO/RagexeRE_2014_10_22b;translated;translated/kRO_english;kRO
@@ -506,7 +506,7 @@ ip 69.197.167.236
 port 6901
 version 51
 master_version 2
-serverType kRO_RagexeRE_2014_10_22b
+serverType RMS
 serverEncoding Western
 charBlockSize 147
 addTableFolders kRO/RagexeRE_2014_10_22b;translated;translated/kRO_english;kRO


### PR DESCRIPTION
RMS now requires encryption to login (cryptKeys).

We could change it directly in kRO_RagexeRE_2014_10_22b, but that might break other servers using this ServerType