### PR TITLE
add hook on processAutoAttack cleanMonsters

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2676,6 +2676,11 @@ sub processAutoAttack {
 				 && !$monster->{dmgFromYou}
 				 && ($control->{dist} eq '' || distance($monster->{pos}, calcPosition($char)) <= $control->{dist})
 				 && timeOut($monster->{attack_failed}, $timeout{ai_attack_unfail}{timeout})) {
+					my %hookArgs;
+					$hookArgs{monster} = $monster;
+					$hookArgs{return} = 1;
+					Plugins::callHook("checkMonsterAutoAttack", \%hookArgs);
+					next if (!$hookArgs{return});
 					push @cleanMonsters, $_;
 				}
 			}


### PR DESCRIPTION
This is useful because it is where 'new' monsters are chosen to be attacked when kore is not already attacking or being attacked. I am using it to avoid attacking monsters which can be assisted by others of its own nameID (namely Wolves), to do so I am using my plugin avoidAssisters (https://github.com/Henrybk/Plugins/blob/master/avoidAssisters/avoidAssisters.pl)