### PR TITLE
Beta change to make kore notice missing portals

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -204,6 +204,7 @@ route_teleport_minDistance 150
 route_teleport_maxTries 8
 route_teleport_notInMaps
 route_step 15
+route_tryToGuessMissingPortalByDistance 1
 
 runFromTarget 0
 runFromTarget_dist 6

--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -109,6 +109,12 @@ ai_teleport_safe_force 120
 ai_teleport_retry 0.5
 ai_teleport_delay 0.5
 
+ai_portal_wait 0.5
+
+# These timeouts are used in missing portals logic
+ai_portal_give_up 10
+ai_portal_re_add_missed 3600
+
 # You probably don't ever have to change the following timeouts
 ai_route_calcRoute 1
 ai_route_npcTalk 10

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -50,6 +50,7 @@ sub iterate {
 	processWipeOldActors();
 	processGetPlayerInfo();
 	processMisc();
+	processReAddMissingPortals();
 	processPortalRecording();
 	Benchmark::end("ai_prepare") if DEBUG;
 	
@@ -413,6 +414,16 @@ sub processDrop {
 		AI::args->{time} = time;
 		AI::dequeue if (@{AI::args->{'items'}} <= 0);
 	}
+}
+
+##### PORTALREADD #####
+# Automatically adds the last missing portals to portals_lut
+sub processReAddMissingPortals {
+	return unless (@portals_lut_missed);
+	return unless (timeOut($portals_lut_missed[0]{time}, $timeout{ai_portal_re_add_missed}{timeout}));
+	my $portal = shift(@portals_lut_missed);
+	$portals_lut{$portal->{name}} = $portal->{portal};
+	debug "Re adding portal '".$portal->{name}."' to portals list.\n", "portalReAdd";
 }
 
 ##### PORTALRECORD #####

--- a/src/FileParsers.pm
+++ b/src/FileParsers.pm
@@ -570,7 +570,9 @@ sub parseMonControl {
 sub parsePortals {
 	my $file = shift;
 	my $r_hash = shift;
+	my $r_array = shift;
 	undef %{$r_hash};
+	undef @{$r_array};
 	my $reader = new Utils::TextReader($file);
 	while (!$reader->eof()) {
 		my $line = $reader->readLine();

--- a/src/Globals.pm
+++ b/src/Globals.pm
@@ -26,7 +26,7 @@ use Modules 'register';
 # Do not use any other Kore modules here. It will create circular dependancies.
 
 our %EXPORT_TAGS = (
-	config  => [qw(%arrowcraft_items %avoid @chatResponses %cities_lut %config %consoleColors %directions_lut %equipTypes_lut %equipSlot_rlut %equipSlot_lut %haircolors @headgears_lut @msgTable %items_control %items_lut %itemSlotCount_lut %itemsDesc_lut %itemTypes_lut %jobs_lut %maps_lut %masterServers %monsters_lut %npcs_lut %packetDescriptions %portals_lut %responses %sex_lut %shop %skillsDesc_lut %lookHandle %skillsArea %skillsEncore %spells_lut %emotions_lut %timeout $char %mon_control %priority %routeWeights %pickupitems %rpackets %itemSlots_lut %statusHandle %statusName %effectName %hatEffectHandle %hatEffectName %portals_los %stateHandle %ailmentHandle %mapTypeHandle %mapPropertyTypeHandle %mapPropertyInfoHandle %elements_lut %mapAlias_lut %quests_lut)],
+	config  => [qw(%arrowcraft_items %avoid @chatResponses %cities_lut %config %consoleColors %directions_lut %equipTypes_lut %equipSlot_rlut %equipSlot_lut %haircolors @headgears_lut @msgTable %items_control %items_lut %itemSlotCount_lut %itemsDesc_lut %itemTypes_lut %jobs_lut %maps_lut %masterServers %monsters_lut %npcs_lut %packetDescriptions %portals_lut @portals_lut_missed %responses %sex_lut %shop %skillsDesc_lut %lookHandle %skillsArea %skillsEncore %spells_lut %emotions_lut %timeout $char %mon_control %priority %routeWeights %pickupitems %rpackets %itemSlots_lut %statusHandle %statusName %effectName %hatEffectHandle %hatEffectName %portals_los %stateHandle %ailmentHandle %mapTypeHandle %mapPropertyTypeHandle %mapPropertyInfoHandle %elements_lut %mapAlias_lut %quests_lut)],
 	ai      => [qw(@ai_seq @ai_seq_args %ai_v $AI $AI_forcedOff %targetTimeout)],
 	state   => [qw($accountID $cardMergeIndex @cardMergeItemsID $charID @chars @chars_old @friendsID %friends %incomingFriend $field %homunculus $itemsList @itemsID %items $monstersList @monstersID %monsters @npcsID %npcs $npcsList @playersID %players @portalsID @portalsID_old %portals %portals_old $portalsList @storeList $currentChatRoom @currentChatRoomUsers @chatRoomsID %createdChatRoom %chatRooms @skillsID $storageTitle @arrowCraftID %guild %incomingGuild @spellsID %spells @unknownPlayers @unknownNPCs $useArrowCraft %currentDeal %incomingDeal %outgoingDeal @identifyID @partyUsersID %incomingParty @petsID %pets @venderItemList $venderID $venderCID @venderListsID @buyerItemList @selfBuyerItemList $buyerID $buyingStoreID @buyerListsID @articles $articles %venderLists %buyerLists %monsters_old @monstersID_old %npcs_old %items_old %players_old @playersID_old @servers $sessionID $sessionID2 $accountSex $accountSex2 $map_ip $map_port $KoreStartTime $secureLoginKey $initSync $lastConfChangeTime $petsList $playersList $portalsList @playerNameCacheIDs %playerNameCache %pet $pvp @cashList $slavesList @slavesID %slaves %cashShop)],
 	network => [qw($remote_socket $net $messageSender $charServer $conState $conState_tries $encryptVal $ipc $bus $masterServer $lastSwitch $packetParser $clientPacketHandler $bytesSent $incomingMessages $outgoingClientMessages $enc_val1 $enc_val2 $captcha_state)],
@@ -108,6 +108,7 @@ our %npcs_lut;
 our %packetDescriptions;
 our %portals_los;
 our %portals_lut;
+our @portals_lut_missed;
 our %priority;
 our %responses;
 our %routeWeights;

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -277,6 +277,11 @@ sub iterate {
 		if ($self->{missing_portal}) {
 		
 			if (!$config{route_tryToGuessMissingPortalByDistance}) {
+				my $missed = {};
+				$missed->{time} = time;
+				$missed->{name} = "$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}";
+				$missed->{portal} = $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
+				push(@portals_lut_missed, $missed);
 				delete $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
 				warning TF("Unable to use portal at %s (%s,%s).\n", $field->baseName, $self->{mapSolution}[0]{pos}{x}, $self->{mapSolution}[0]{pos}{y}), "route";
 				delete $self->{missing_portal};
@@ -298,6 +303,11 @@ sub iterate {
 						$self->{guess_portal} = $portalsList->get($closest_portal_binID);
 						warning TF("Guessing our desired portal to be  %s (%s,%s).\n", $field->baseName, $self->{guess_portal}{pos}{x}, $self->{guess_portal}{pos}{y}), "route";
 					} else {
+						my $missed = {};
+						$missed->{time} = time;
+						$missed->{name} = "$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}";
+						$missed->{portal} = $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
+						push(@portals_lut_missed, $missed);
 						delete $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
 						warning TF("Unable to use portal at %s (%s,%s).\n", $field->baseName, $self->{mapSolution}[0]{pos}{x}, $self->{mapSolution}[0]{pos}{y}), "route";
 						delete $self->{missing_portal};
@@ -326,8 +336,13 @@ sub iterate {
 			}
 			
 		} elsif ( distance($self->{actor}{pos_to}, $self->{mapSolution}[0]{pos}) == 0 ) {
-				$timeout{ai_portal_give_up}{timeout} = $timeout{ai_portal_give_up}{timeout} || 3;
-				return unless (timeOut($timeout{'ai_portal_wait'}{'time'}, $timeout{ai_portal_give_up}{timeout}));
+				if (!exists $timeout{ai_portal_give_up}{time}) {
+					$timeout{ai_portal_give_up}{time} = time;
+					$timeout{ai_portal_give_up}{timeout} = $timeout{ai_portal_give_up}{timeout} || 10;
+					return;
+				}
+				return unless (timeOut($timeout{ai_portal_give_up}));
+				delete $timeout{ai_portal_give_up}{time};
 				
 				my %plugin_args;
 				$plugin_args{object} = $self;

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -276,14 +276,14 @@ sub iterate {
 		
 		if ($self->{missing_portal}) {
 		
-			if (!$config{route_tryToGuessMissingPortalByDistance} || $portalsList->size == 0) {
+			if (!$config{route_tryToGuessMissingPortalByDistance}) {
 				delete $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
 				warning TF("Unable to use portal at %s (%s,%s).\n", $field->baseName, $self->{mapSolution}[0]{pos}{x}, $self->{mapSolution}[0]{pos}{y}), "route";
 				delete $self->{missing_portal};
 				delete $self->{guess_portal};
 				$self->initMapCalculator();	# redo MAP router
 				
-			} elsif ($config{route_tryToGuessMissingPortalByDistance}) {
+			} else {
 				if (!exists $self->{guess_portal}) {
 					my $closest_portal_binID;
 					my $closest_portal_dist;
@@ -328,6 +328,13 @@ sub iterate {
 		} elsif ( distance($self->{actor}{pos_to}, $self->{mapSolution}[0]{pos}) == 0 ) {
 				$timeout{ai_portal_give_up}{timeout} = $timeout{ai_portal_give_up}{timeout} || 3;
 				return unless (timeOut($timeout{'ai_portal_wait'}{'time'}, $timeout{ai_portal_give_up}{timeout}));
+				
+				my %plugin_args;
+				$plugin_args{object} = $self;
+				$plugin_args{solution} = \@solution;
+				$plugin_args{return} = 1;
+				Plugins::callHook('Task::MapRoute::iterate::missing_portal', \%plugin_args);
+				return if (!$plugin_args{return});
 				
 				$self->{missing_portal} = 1;
 

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -28,7 +28,7 @@ use Translation qw(T TF);
 use Log qw(message debug warning error);
 use Network;
 use Plugins;
-use Misc qw(useTeleport);
+use Misc qw(useTeleport portalExists);
 use Utils qw(timeOut distance existsInList);
 use Utils::PathFinding;
 use Utils::Exceptions;
@@ -296,6 +296,7 @@ sub iterate {
 						my $dist = distance($self->{actor}{pos_to}, $portal->{pos});
 						next if (exists $self->{guess_skip} && exists $self->{guess_skip}{$portal->{binID}});
 						next if (defined $closest_portal_dist && $closest_portal_dist < $dist);
+						next if (portalExists($portal->{pos})); # Only guess unknown portals
 						$closest_portal_binID = $portal->{binID};
 						$closest_portal_dist = $dist;
 					}

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -296,7 +296,7 @@ sub iterate {
 						my $dist = distance($self->{actor}{pos_to}, $portal->{pos});
 						next if (exists $self->{guess_skip} && exists $self->{guess_skip}{$portal->{binID}});
 						next if (defined $closest_portal_dist && $closest_portal_dist < $dist);
-						next if (portalExists($portal->{pos})); # Only guess unknown portals
+						next if (portalExists($field->baseName, $portal->{pos})); # Only guess unknown portals
 						$closest_portal_binID = $portal->{binID};
 						$closest_portal_dist = $dist;
 					}

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -271,8 +271,25 @@ sub iterate {
 
 	} elsif ( $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"}{source} ) {
 		# This is a portal solution
+		
+		
+		if ( distance($self->{actor}{pos_to}, $self->{mapSolution}[0]{pos}) == 0 ) {
+				return unless (timeOut($timeout{ai_portal_wait}));
+				if ($config{route_tryToGuessWrongPortalByDistance}) {
+					my $max_guess_distance = ($config{route_GuessWrongPortalMaxDistance} || 5);
+					for my $portal (@$portalsList) {
+						next unless (distance($self->{actor}{pos_to}, $portal->{pos}) <= $max_guess_distance);
+						$self->{actor}->sendMove(map int, @{$portal->{pos}}{qw(x y)});
+					}
+					
+				} else {
+					delete $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
+					warning TF("Unable to use portal at %s (%s,%s).\n", $field->baseName, $self->{mapSolution}[0]{pos}{x}, $self->{mapSolution}[0]{pos}{y}), "route";
+					$self->initMapCalculator();	# redo MAP router
+				}
 
-		if ( distance($self->{actor}{pos_to}, $self->{mapSolution}[0]{pos}) < 2 ) {
+		} elsif ( distance($self->{actor}{pos_to}, $self->{mapSolution}[0]{pos}) < 2 ) {
+			
 			# Portal is within 'Enter Distance'
 			$timeout{ai_portal_wait}{timeout} = $timeout{ai_portal_wait}{timeout} || 0.5;
 			if ( timeOut($timeout{ai_portal_wait}) ) {

--- a/src/functions.pl
+++ b/src/functions.pl
@@ -245,7 +245,7 @@ sub loadDataFiles {
 	Settings::addTableFile('packetdescriptions.txt',
 		loader => [\&parseSectionedFile, \%packetDescriptions], mustExist => 0);
 	Settings::addTableFile('portals.txt',
-		loader => [\&parsePortals, \%portals_lut]);
+		loader => [\&parsePortals, \%portals_lut, \@portals_lut_missed]);
 	Settings::addTableFile('portalsLOS.txt',
 		loader => [\&parsePortalsLOS, \%portals_los], createIfMissing => 1);
 	Settings::addTableFile('sex.txt',

--- a/tables/portals.txt
+++ b/tables/portals.txt
@@ -1,3 +1,11 @@
+
+
+
+payon 160 230 pay_dun04 150 150
+payon 160 225 pay_dun04 150 150
+
+
+
 #format: <source coordinate><destination coordinate>[zenny cost][conversation sequence]
 alberta 195 151 alb2trea 62 69 0 c c r0
 alb2trea 39 50 alberta 192 169 0 r0

--- a/tables/portals.txt
+++ b/tables/portals.txt
@@ -1,11 +1,3 @@
-
-
-
-payon 160 230 pay_dun04 150 150
-payon 160 225 pay_dun04 150 150
-
-
-
 #format: <source coordinate><destination coordinate>[zenny cost][conversation sequence]
 alberta 195 151 alb2trea 62 69 0 c c r0
 alb2trea 39 50 alberta 192 169 0 r0


### PR DESCRIPTION
This pull request is being made to create a discussion regarding the possible solutions for this old known problem.

Ilustration of the problem: https://i.gyazo.com/e157f69c4dda6146016db01d71c1eba6.jpg

Definition: Openkore now has no way of dealing with a missing portal and will just stay on top of the portal location in portals.txt sending loads of move packets to the server and never moving a muscle.

I showed 2 possible solutions for the problem in the files changed, first is to just delete the portal and re-route, as we do with missing npcs, and second is to try to search for near portals and route to them hoping they are the portal we actually want to reach.