### PR TITLE
add reconnect plugin

### DIFF
--- a/control/sys.txt
+++ b/control/sys.txt
@@ -49,7 +49,7 @@ loadPlugins 2
 # loadPlugins_list <list>
 #   if loadPlugins is set to 2, this comma-separated list of plugin names (filename without the extension)
 #   specifies which plugin files to load at startup or when the "plugin load all" command is used.
-loadPlugins_list macro,profiles,breakTime,raiseStat,raiseSkill,map
+loadPlugins_list macro,profiles,breakTime,raiseStat,raiseSkill,map,reconnect
 
 # skipPlugins_list <list>
 #   if loadPlugins is set to 3, this comma-separated list of plugin names (filename without the extension)

--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -12,6 +12,13 @@ play 40
 # When disconnected, wait x seconds before reconnecting again
 reconnect 30
 
+# After repeated disconnects, wait longer before reconnecting, to reduce load on the server.
+# The first value in this list overrides the "reconnect" timeout above.
+reconnect_backoff 30,60,120,180,300,600,600,900,900,1800
+
+# Add a random amount of seconds to reconnect time, up to a maximum of reconnect_random seconds.
+reconnect_random 20
+
 # Wait x seconds for a poseidon reply before disconnecting
 # Ignore this if you don't use Poseidon Server
 poseidon_wait_reply 15

--- a/plugins/reconnect/reconnect.pl
+++ b/plugins/reconnect/reconnect.pl
@@ -1,0 +1,54 @@
+# This package depends on two entries in control/timeouts.txt.
+#   * reconnect_backoff 30,60,180
+#   * reconnect_random 20
+# reconnect_backoff is a comma-separated list of timeouts which will be used in order when we get repeatedly disconnected from the server.
+# reconnect_random is the maximum random amount of time to be added to all reconnect times. This only applies if reconnect_backoff is defined. Default is zero.
+#
+package OpenKore::Plugins::reconnect;
+
+use strict;
+
+use Globals qw( %timeout );
+use Log qw( &message );
+use Plugins;
+use Utils qw( &min );
+use Translation qw( &TF );
+
+our $default;
+our $counter = 0;
+
+Plugins::register( 'reconnect', 'v1.0', \&unload );
+
+my $hooks = Plugins::addHooks(    #
+	[ 'Network::connectTo' => \&trying_to_connect ],
+	[ 'in_game'            => \&connected ],
+);
+
+sub unload {
+	Plugins::delHooks( $hooks );
+}
+
+sub trying_to_connect {
+	my $timeout = timeout();
+
+	$timeout{reconnect} = { timeout => timeout() };
+	$counter++;
+
+	if ( $counter > 1 ) {
+		message TF( "[reconnect] Login retry number %d, setting reconnect timeout to %d seconds.\n", $counter, $timeout{reconnect}->{timeout} ), 'success';
+	}
+}
+
+sub connected {
+	$counter = 0;
+	$timeout{reconnect} = { timeout => timeout() };
+}
+
+# Return the current timeout if there is one.
+sub timeout {
+	my @timeouts = split /\s*,\s*/, $timeout{reconnect_backoff}->{timeout} || '';
+	return $timeout{reconnect}->{timeout} if !@timeouts;
+	$timeouts[ min( $counter, $#timeouts ) ] + int rand( $timeout{reconnect_random}->{timeout} || 0 );
+}
+
+1;


### PR DESCRIPTION
- [x] Code Review
- [x] Finalize `reconnect_backoff` list

Progressively back off connect times, to reduce load on servers. Some servers have logic which blocks repeated reconnect attempts if they happen too fast. And the default 30 seconds is too fast, at least on iRO Restart.

The backoff list given here is `30,60,120,180,300,600,600,900,900,1800`, which equates to nine connection attempts in the first hour, followed by two connection attempts every hour.

Based on https://github.com/Henrybk/Plugins/blob/master/Reconnect/Reconnect.pl.

Here's an example of the plugin in action:
```
Connecting to Account Server...
Connecting (128.241.92.133:6800)... connected
Timeout on Account Server, reconnecting. Wait 45 seconds...
Disconnecting (128.241.92.133:6800)...disconnected
Connecting to Account Server...
[reconnect] Login retry number 2, setting reconnect timeout to 73 seconds.
Connecting (128.241.92.133:6800)... connected
Timeout on Account Server, reconnecting. Wait 73 seconds...
Disconnecting (128.241.92.133:6800)...disconnected
Connecting to Account Server...
[reconnect] Login retry number 3, setting reconnect timeout to 184 seconds.
Connecting (128.241.92.133:6800)... connected
Timeout on Account Server, reconnecting. Wait 184 seconds...
Disconnecting (128.241.92.133:6800)...disconnected
Connecting to Account Server...
[reconnect] Login retry number 4, setting reconnect timeout to 308 seconds.
Connecting (128.241.92.133:6800)... connected
Timeout on Account Server, reconnecting. Wait 308 seconds...
Disconnecting (128.241.92.133:6800)...disconnected
Connecting to Account Server...
[reconnect] Login retry number 5, setting reconnect timeout to 619 seconds.
Connecting (128.241.92.133:6800)... connected
Timeout on Account Server, reconnecting. Wait 919 seconds...
Disconnecting (128.241.92.133:6800)...disconnected
```