### PR TITLE
only trigger reconnect backoff for the login server

### DIFF
--- a/plugins/reconnect/reconnect.pl
+++ b/plugins/reconnect/reconnect.pl
@@ -8,7 +8,7 @@ package OpenKore::Plugins::reconnect;
 
 use strict;
 
-use Globals qw( %timeout );
+use Globals qw( %config %masterServers %timeout );
 use Log qw( &message );
 use Plugins;
 use Utils qw( &min );
@@ -29,7 +29,13 @@ sub unload {
 }
 
 sub trying_to_connect {
-	my $timeout = timeout();
+	my ( undef, $params ) = @_;
+
+	# Only trigger if we're connecting to the login server.
+	next if $masterServers{ $config{master} }->{ip} ne $params->{host};
+	next if $masterServers{ $config{master} }->{port} ne $params->{port};
+
+    my $timeout = timeout();
 
 	$timeout{reconnect} = { timeout => timeout() };
 	$counter++;


### PR DESCRIPTION
It turns out that `Network::connectTo` triggers for all server connect attempts, so a connection failure on the map server counts as three failures (login, character, and map server).

This pull request limits the backoff to only apply on login server connect attempts.