### PR TITLE
fix izlude in iRO Restart

### DIFF
--- a/tables/iRO/Restart/resnametable.txt
+++ b/tables/iRO/Restart/resnametable.txt
@@ -1,0 +1,10 @@
+# Please don't modify this file. Make any changes in resnametable-custom.txt instead.
+
+# Include file from official client.
+!include ../official/resnametable.txt
+
+# OpenKore modifications to the official client file go here.
+
+# Include untracked local modifications.
+!include_create_if_missing resnametable-custom.txt
+


### PR DESCRIPTION
- [ ] Code Review

This uses the iRO official `resnametable.txt` file, for now, until iRO Restart gets its own version.