### PR TITLE
allow "storage add" to store multiple items at once

### DIFF
--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -71,6 +71,9 @@ ai_items_gather_auto .3
 # Only gather items that have been more than x seconds on screen
 ai_items_gather_start .3
 
+# Delay between items when tranferring in batches.
+ai_transfer_items 0.15
+
 ai_follow_lost_end 10
 ai_getInfo 1
 ai_thanks_set 8

--- a/src/AI.pm
+++ b/src/AI.pm
@@ -232,7 +232,7 @@ sub ai_partyfollow {
 
 	my %master;
 	$master{id} = main::findPartyUserID($config{followTarget});
-	if ($master{id} ne "" && !AI::inQueue("storageAuto","storageGet","sellAuto","buyAuto")) {
+	if ($master{id} ne "" && !AI::inQueue("storageAuto","transferItems","sellAuto","buyAuto")) {
 
 		$master{x} = $char->{party}{users}{$master{id}}{pos}{x};
 		$master{y} = $char->{party}{users}{$master{id}}{pos}{y};

--- a/src/InventoryList.pm
+++ b/src/InventoryList.pm
@@ -211,6 +211,33 @@ sub getByNameList {
 }
 
 ##
+# Actor::Item $InventoryList->getMultiple(String searchPattern)
+# searchPattern: a search pattern.
+# Returns: an array of Actor::Item objects.
+#
+# Select one or more items by name and/or index.
+# $searchPattern has the following syntax:
+# <pre>index1,index2,...,indexN,name1,name2,...nameN</pre>
+# You can also use '-' to indicate a range (only for indexes), like:
+# <pre>1-5,7,9</pre>
+sub getMultiple {
+	my ( $self, $lists ) = @_;
+	assert( defined $lists ) if DEBUG;
+	my @indexes = split / *,+ */, lc( $lists );
+	my @items;
+	foreach my $index ( @indexes ) {
+		if ( $index =~ /^(\d+)-(\d+)$/o ) {
+			push @items, $self->get( $_ ) foreach $1 .. $2;
+		} elsif ( $index =~ /^(\d+)$/o ) {
+			push @items, $self->get( $index );
+		} else {
+			push @items, $self->getByName( $index );
+		}
+	}
+	grep {$_} @items;
+}
+
+##
 # boolean $InventoryList->remove(Actor::Item item)
 # Requires: defined($item) && defined($item->{name})
 #

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -2037,7 +2037,7 @@ sub transferItems {
 
 	AI::queue(
 		transferItems => {
-			timeout => $timeout{ai_transfer_items} || 0.15,
+			timeout => $timeout{ai_transfer_items}{timeout} || 0.15,
 			items => [ map { { item => $_, source => $source, target => $target, amount => $amount } } @$items ],
 		}
 	);

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -82,6 +82,7 @@ our @EXPORT = (
 	qw/inInventory
 	inventoryItemRemoved
 	storageGet
+	transferItems
 	cardName
 	itemName
 	itemNameSimple
@@ -1999,9 +2000,11 @@ sub itemNameToID {
 }
 
 ##
-# storageGet(items, max)
+# DEPRECATED: Use transferItems() instead.
+#
+# storageGet(items, amount)
 # items: reference to an array of storage item hashes.
-# max: the maximum amount to get, for each item, or 0 for unlimited.
+# amount: the maximum amount to get, for each item, or 0 for unlimited.
 #
 # Get one or more items from storage.
 #
@@ -2011,23 +2014,36 @@ sub itemNameToID {
 # # Get items $a and $b from storage, but at most 30 of each item.
 # storageGet([$a, $b], 30);
 sub storageGet {
-	my $indices = shift;
-	my $max = shift;
+	my ( $items, $amount ) = @_;
+	transferItems( $items, $amount, 'storage' => 'inventory' );
+}
 
-	if (@{$indices} == 1) {
-		my ($item) = @{$indices};
-		if (!defined($max) || $max > $item->{amount}) {
-			$max = $item->{amount};
+##
+# transferItems(items, amount, source, target)
+# items: reference to an array of Actor::Items.
+# amount: the maximum amount to get, for each item, or 0 for unlimited.
+# source: where the items come from; one of 'inventory', 'storage', 'cart'
+# target: where the items shoudl go; one of 'inventory', 'storage', 'cart'
+#
+# Transfer one or more items from their current location to another location.
+#
+# Example:
+# # Get items $a and $b from storage to inventory.
+# transferItems([$a, $b], 'storage' => 'inventory');
+# # Send items $a and $b from cart to storage, but at most 30 of each item.
+# transferItems([$a, $b], 30, 'cart' => 'storage');
+sub transferItems {
+	my ( $items, $amount, $source, $target ) = @_;
+
+	AI::queue(
+		transferItems => {
+			timeout => $timeout{ai_transfer_items} || 0.15,
+			items => [ map { { item => $_, source => $source, target => $target, amount => $amount } } @$items ],
 		}
-		$messageSender->sendStorageGet($item->{ID}, $max);
+	);
 
-	} else {
-		my %args;
-		$args{items} = $indices;
-		$args{max} = $max;
-		$args{timeout} = 0.15;
-		AI::queue("storageGet", \%args);
-	}
+	# Immediately run the AI sequence once. This will remove it from the queue if there's only one item to transfer.
+	AI::CoreLogic::processTransferItems();
 }
 
 ##


### PR DESCRIPTION
- [x] Code Review

Previously supported (and currently supported):
* `storage add Empty Bottle`
* `storage add 5`
* `storage add Empty Bottle 1`
* `storage add 5 1`

Newly supported:
* `storage add "Empty Bottle"`
* `storage add "Empty Bottle,Jellopy"`
* `storage add 1-5,9`
* `storage add "Empty Bottle" 1`
* `storage add "Empty Bottle,Jellopy" 1`
* `storage add 1-5,9 1`

The same treatment was given to `storage get`, `storage addfromcart`, `storage addtocart`, `cart get`, and `cart add`.

Multiple items are added via an AI sequence which only runs on auto AI (not manual), which I'm not sure I like. I believe it can only be triggered by a manual command on the console, which means it should run under manual AI. Thoughts?

A new `ai_transfer_items` timeout controls the delay between each item when transferring several in a batch.
