### PR TITLE
enable eventMacro, fix &inventory and friends, pass params to called macros

### DIFF
--- a/control/sys.txt
+++ b/control/sys.txt
@@ -49,7 +49,7 @@ loadPlugins 2
 # loadPlugins_list <list>
 #   if loadPlugins is set to 2, this comma-separated list of plugin names (filename without the extension)
 #   specifies which plugin files to load at startup or when the "plugin load all" command is used.
-loadPlugins_list macro,profiles,breakTime,raiseStat,raiseSkill,map,reconnect
+loadPlugins_list macro,profiles,breakTime,raiseStat,raiseSkill,map,reconnect,eventMacro
 
 # skipPlugins_list <list>
 #   if loadPlugins is set to 3, this comma-separated list of plugin names (filename without the extension)

--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -682,6 +682,12 @@ sub check_all_conditions {
 	}
 }
 
+# Given the results of Utilities::find_variable(), return the variable data.
+sub get_split_var {
+	my ( $self, $var ) = @_;
+	$self->get_var( $var->{type}, $var->{real_name}, $var->{complement} );
+}
+
 # Generic variable functions
 sub get_var {
 	my ($self, $type, $variable_name, $complement) = @_;

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1081,10 +1081,10 @@ sub next {
 					}
 					
 				} elsif ($var->{type} eq 'array' && $value =~ /^$macro_keywords_character(?:split)\(\s*(.*?)\s*\)$/) {
-					my ( $pattern, $scalar ) = map {/^\s*(.*?)\s*$/} parseArgs( "$1", undef, ',' );
-					my $scalar_var = find_variable( $scalar );
-					$self->error( "Scalar variable not recognized" ), return if !$scalar_var;
-					$eventMacro->set_full_array( $var->{real_name}, [ split $pattern, $eventMacro->get_scalar_var( $scalar_var->{real_name} ) ] );
+					my ( $pattern, $var_str ) = map {/^\s*(.*?)\s*$/} parseArgs( "$1", undef, ',' );
+					my $split_var = find_variable( $var_str );
+					$self->error( 'Scalar variable not recognized' ), return if !$split_var;
+					$eventMacro->set_full_array( $var->{real_name}, [ split $pattern, $eventMacro->get_split_var( $split_var ) ] );
 				} elsif ($var->{type} eq 'array' && $value =~ /^$macro_keywords_character(keys|values)\(($hash_variable_qr)\)$/) {
 					my $type = $1;
 					my $var2 = find_variable($2);

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1081,9 +1081,10 @@ sub next {
 					}
 					
 				} elsif ($var->{type} eq 'array' && $value =~ /^$macro_keywords_character(?:split)\(\s*(.*?)\s*\)$/) {
-					my ( $pattern, $var_str ) = map {/^\s*(.*?)\s*$/} parseArgs( "$1", undef, ',' );
+					my ( $pattern, $var_str ) = parseArgs( "$1", undef, ',' );
+					$var_str =~ s/^\s+|\s+$//gos;
 					my $split_var = find_variable( $var_str );
-					$self->error( 'Scalar variable not recognized' ), return if !$split_var;
+					$self->error( 'Variable not recognized' ), return if !$split_var;
 					$eventMacro->set_full_array( $var->{real_name}, [ split $pattern, $eventMacro->get_split_var( $split_var ) ] );
 				} elsif ($var->{type} eq 'array' && $value =~ /^$macro_keywords_character(keys|values)\(($hash_variable_qr)\)$/) {
 					my $type = $1;
@@ -1795,11 +1796,10 @@ sub parse_command {
 			$result = join ',', getInventoryIDs($parsed);
 			
 		} elsif ($keyword eq 'store') {
-		    # TODO: Fix this to work with the new getItemIDs() implementation.
-			$result = getItemIDs($parsed, \@::storeList);
+			$result = (getItemIDs($parsed, $storeList))[0];
 			
 		} elsif ($keyword eq 'storage') {
-			($result) = (getStorageIDs($parsed))[0];
+			$result = (getStorageIDs($parsed))[0];
 			
 		} elsif ($keyword eq 'Storage') {
 			$result = join ',', getStorageIDs($parsed);
@@ -1814,16 +1814,16 @@ sub parse_command {
 			$result = getVenderID($parsed);
 			
 		} elsif ($keyword eq 'venderitem') {
-			($result) = (getItemIDs($parsed, \@::venderItemList))[0];
+			$result = (getItemIDs($parsed, $venderItemList))[0];
 			
 		} elsif ($keyword eq 'venderItem') {
-			$result = join ',', getItemIDs($parsed, \@::venderItemList);
+			$result = join ',', getItemIDs($parsed, $venderItemList);
 			
 		} elsif ($keyword eq 'venderprice') {
-			$result = getItemPrice($parsed, \@::venderItemList);
+			$result = getItemPrice($parsed, $venderItemList->getItems);
 			
 		} elsif ($keyword eq 'venderamount') {
-			$result = getVendAmount($parsed, \@::venderItemList);
+			$result = getVendAmount($parsed, $venderItemList->getItems);
 			
 		} elsif ($keyword eq 'random') {
 			$result = getRandom($parsed);

--- a/plugins/eventMacro/eventMacro/Utilities.pm
+++ b/plugins/eventMacro/eventMacro/Utilities.pm
@@ -252,13 +252,10 @@ sub getInventoryIDs {
 # get item array index
 sub getItemIDs {
 	my ($item, $pool) = (lc($_[0]), $_[1]);
-	my @ids;
-	for (my $id = 0; $id < @{$pool}; $id++) {
-		next unless $$pool[$id];
-		if (lc($$pool[$id]{name}) eq $item) {push @ids, $id}
-	}
-	unless (@ids) {push @ids, -1}
-	return @ids
+	return if !$pool->isReady;
+	my @ids = map { $_->{binID} } grep { $item eq lc $_->name } @$pool;
+	push @ids, -1 if !@ids;
+	@ids;
 }
 
 # get item price from its index

--- a/plugins/macro/Macro/Parser.pm
+++ b/plugins/macro/Macro/Parser.pm
@@ -306,16 +306,16 @@ sub parseCmd {
 		elsif ($kw eq 'Cart')       {$ret = join ',', getItemIDs($arg, $char->cart->getItems)}
 		elsif ($kw eq 'inventory')  {($ret) = getInventoryIDs($arg)}
 		elsif ($kw eq 'Inventory')  {$ret = join ',', getInventoryIDs($arg)}
-		elsif ($kw eq 'store')      {($ret) = getItemIDs($arg, \@::storeList)}
+		elsif ($kw eq 'store')      {($ret) = getItemIDs($arg, $storeList->getItems)}
 		elsif ($kw eq 'storage')    {($ret) = getStorageIDs($arg)}
 		elsif ($kw eq 'Storage')    {$ret = join ',', getStorageIDs($arg)}
 		elsif ($kw eq 'player')     {$ret = getPlayerID($arg)}
 		elsif ($kw eq 'monster')    {$ret = getMonsterID($arg)}
 		elsif ($kw eq 'vender')     {$ret = getVenderID($arg)}
-		elsif ($kw eq 'venderitem') {($ret) = getItemIDs($arg, \@::venderItemList)}
-		elsif ($kw eq 'venderItem') {$ret = join ',', getItemIDs($arg, \@::venderItemList)}
-		elsif ($kw eq 'venderprice'){$ret = getItemPrice($arg, \@::venderItemList)}
-		elsif ($kw eq 'venderamount'){$ret = getVendAmount($arg, \@::venderItemList)}
+		elsif ($kw eq 'venderitem') {($ret) = getItemIDs($arg, $venderItemList->getItems)}
+		elsif ($kw eq 'venderItem') {$ret = join ',', getItemIDs($arg, $venderItemList->getItems)}
+		elsif ($kw eq 'venderprice'){$ret = getItemPrice($arg, $venderItemList->getItems)}
+		elsif ($kw eq 'venderamount'){$ret = getVendAmount($arg, $venderItemList->getItems)}
 		elsif ($kw eq 'random')     {$ret = getRandom($arg); $randomized = 1}
 		elsif ($kw eq 'rand')       {$ret = getRandomRange($arg); $randomized = 1}
 		elsif ($kw eq 'invamount')  {$ret = getInventoryAmount($arg)}

--- a/plugins/needs-review/mercdb/tags/start/mercdb.pl
+++ b/plugins/needs-review/mercdb/tags/start/mercdb.pl
@@ -274,7 +274,7 @@ sub mercDbFill{
 
 	#print "Shop-Owner: " . $shopOwner . "(" . $shopOwnerID .")\n";
 	#print "Shop-Array: " . $::venderItemList . "\n";
-	if (!($::venderItemList[$::number]{'name'} eq "")) {
+	if (!($::venderItemList->get($::number)->{'name'} eq "")) {
 
 		#
 		# check if the offered items are already in the database
@@ -284,7 +284,7 @@ sub mercDbFill{
 		my $shopOwner = $::players{$::venderID}{'name'};
 		$shopOwner =~ s/\\/\\\\/g;
 		$shopOwner =~ s/'/\\'/g;
-		my $iid = $::venderItemList[$::number]{'nameID'};
+		my $iid = $::venderItemList->get($::number)->{'nameID'};
 		my $custom = unpack("C1", substr($::msg, $::i + 13, 1));
 		my $cardDB = substr($::msg, $::i + 14, 8);
 		my $suffix = "";
@@ -354,12 +354,12 @@ sub mercDbFill{
 		# if actual price is lower than average price minus standard deviation it's a HOT DEAL
 		
 		my $barrier_price = $avg_price - $std_price;
-		if ($::venderItemList[$::number]{'price'} < $barrier_price){
+		if ($::venderItemList->get($::number)->{'price'} < $barrier_price){
 			#
 			# HOT DEAL !!!!!!!!!!!!
 			#
 			print " HOT DEAL !!!!!!!!! \n";	
-#			print $avg_price . " - " . $std_price . " = " . $barrier_price . " // price: " . $::venderItemList[$::number]{'price'} ."\n";
+#			print $avg_price . " - " . $std_price . " = " . $barrier_price . " // price: " . $::venderItemList->get($::number)->{'price'} ."\n";
 #			print $avg_std_query . "\n";
 			
 			my @shoppinglist = split(/,/, $Settings::config{"merchantDB_shoppinglist"});
@@ -372,7 +372,7 @@ sub mercDbFill{
 #				print "bi: " . $buyitem . " / in: " . $itemNameLong . "\n";
 				if (($buyitem eq "all") || ($buyitem eq $itemNameLong)){					
 					# ok, its in our list ...
-					if ($chars[$config{'char'}]{'zenny'} >= $::venderItemList[$::number]{'price'}){
+					if ($chars[$config{'char'}]{'zenny'} >= $::venderItemList->get($::number)->{'price'}){
 						# ... and we have the money to buy it, let's go shopping
 						::sendBuyVender(\$::remote_socket, $::venderID, $::number, 1);
 					} else {
@@ -451,7 +451,7 @@ sub mercDbFill{
 			# this item wasn't offered by this dealer on this server
 			#
 			
-			$itemName = $::venderItemList[$::number]{'name'};
+			$itemName = $::venderItemList->get($::number)->{'name'};
 			$itemName = main::itemNameSimple($iid);
 			$itemName =~ s/\\/\\\\/g;
 			$itemName =~ s/'/\\'/g;
@@ -465,16 +465,16 @@ sub mercDbFill{
 			shopName = '" . $shopName . "', 
 			itemID = '" . $iid . "', 
 			name = '" . $itemName . "', 
-			amount = " . $::venderItemList[$::number]{'amount'} . ", 
-			typus = '" . $::itemTypes_lut{$::venderItemList[$::number]{'type'}} . "', 
-			identifiziert = '" . $::venderItemList[$::number]{'identified'} . "', \n"; 
+			amount = " . $::venderItemList->get($::number)->{'amount'} . ", 
+			typus = '" . $::itemTypes_lut{$::venderItemList->get($::number)->{'type'}} . "', 
+			identifiziert = '" . $::venderItemList->get($::number)->{'identified'} . "', \n"; 
 			
 			my $slots = 0;
 			$slots = $itemSlotCount_lut{$iid};
 			$insertQuery .= " slots = '$slots', \n";
 			
 			$insertQuery .= $insertQuery2 . $insertTemp;
-			$insertQuery .= " price = " . $::venderItemList[$::number]{'price'} . ", \n";
+			$insertQuery .= " price = " . $::venderItemList->get($::number)->{'price'} . ", \n";
 			$insertQuery .= " posx = '" . $::players{pack("L1",$shopOwnerID)}{'pos_to'}{'x'} . "', \n";
 			$insertQuery .= " posy = '" . $::players{pack("L1",$shopOwnerID)}{'pos_to'}{'y'} . "', \n";
 			$insertQuery .= " time = " . time . ", \n";
@@ -517,21 +517,21 @@ sub mercDbFill{
 			}
 			
 			# price has changed
-			if (@existingItem[19] != $::venderItemList[$::number]{'price'}){
+			if (@existingItem[19] != $::venderItemList->get($::number)->{'price'}){
 				if ($updateItem) {
 					$updateQuery .= ", ";
 				}
 				$updateItem = -1;
-				$updateQuery .= "price = '" . $::venderItemList[$::number]{'price'} . "'";
+				$updateQuery .= "price = '" . $::venderItemList->get($::number)->{'price'} . "'";
 			}
 			
 			# amount has changed
-                        if (@existingItem[6] != $::venderItemList[$::number]{'amount'}){
+                        if (@existingItem[6] != $::venderItemList->get($::number)->{'amount'}){
                                 if ($updateItem) {
                                         $updateQuery .= ", ";
                                 }
                                 $updateItem = -1;
-                                $updateQuery .= "amount = '" . $::venderItemList[$::number]{'amount'} . "'";
+                                $updateQuery .= "amount = '" . $::venderItemList->get($::number)->{'amount'} . "'";
                         }
 
 			# pos_x has changed

--- a/plugins/needs-review/mercdb/trunk/mercdb.pl
+++ b/plugins/needs-review/mercdb/trunk/mercdb.pl
@@ -265,7 +265,7 @@ sub mercDbFill{
 				# HOT DEAL !!!!!!!!!!!!
 				#
 				Log::message("HOT DEAL !!!!!!!!!");	
-	#			print $avg_price . " - " . $std_price . " * " . $myHotDeal . " = " . $barrier_price . " // price: " . $::venderItemList[$::number]{'price'} ."\n";
+	#			print $avg_price . " - " . $std_price . " * " . $myHotDeal . " = " . $barrier_price . " // price: " . $::venderItemList->get($::number)->{'price'} ."\n";
 	#			print $avg_std_query . "\n";
 				
 				my @shoppinglist = split(/,/, $Settings::config{"merchantDB_shoppinglist"});
@@ -371,7 +371,7 @@ sub mercDbFill{
 				# this item wasn't offered by this dealer on this server
 				#
 				
-				#$itemName = $::venderItemList[$::number]{'name'};
+				#$itemName = $::venderItemList->get($::number)->{'name'};
 				#$itemName = main::itemNameSimple($iid);
 				$itemName = $myItemList->{itemList}[$idx]{name};
 				$itemName =~ s/\\/\\\\/g;

--- a/src/Globals.pm
+++ b/src/Globals.pm
@@ -28,7 +28,7 @@ use Modules 'register';
 our %EXPORT_TAGS = (
 	config  => [qw(%arrowcraft_items %avoid @chatResponses %cities_lut %config %consoleColors %directions_lut %equipTypes_lut %equipSlot_rlut %equipSlot_lut %haircolors @headgears_lut @msgTable %items_control %items_lut %itemSlotCount_lut %itemsDesc_lut %itemTypes_lut %jobs_lut %maps_lut %masterServers %monsters_lut %npcs_lut %packetDescriptions %portals_lut %responses %sex_lut %shop %skillsDesc_lut %lookHandle %skillsArea %skillsEncore %spells_lut %emotions_lut %timeout $char %mon_control %priority %routeWeights %pickupitems %rpackets %itemSlots_lut %statusHandle %statusName %effectName %hatEffectHandle %hatEffectName %portals_los %stateHandle %ailmentHandle %mapTypeHandle %mapPropertyTypeHandle %mapPropertyInfoHandle %elements_lut %mapAlias_lut %quests_lut)],
 	ai      => [qw(@ai_seq @ai_seq_args %ai_v $AI $AI_forcedOff %targetTimeout)],
-	state   => [qw($accountID $cardMergeIndex @cardMergeItemsID $charID @chars @chars_old @friendsID %friends %incomingFriend $field %homunculus $itemsList @itemsID %items $monstersList @monstersID %monsters @npcsID %npcs $npcsList @playersID %players @portalsID @portalsID_old %portals %portals_old $portalsList @storeList $currentChatRoom @currentChatRoomUsers @chatRoomsID %createdChatRoom %chatRooms @skillsID $storageTitle @arrowCraftID %guild %incomingGuild @spellsID %spells @unknownPlayers @unknownNPCs $useArrowCraft %currentDeal %incomingDeal %outgoingDeal @identifyID @partyUsersID %incomingParty @petsID %pets @venderItemList $venderID $venderCID @venderListsID @buyerItemList @selfBuyerItemList $buyerID $buyingStoreID @buyerListsID @articles $articles %venderLists %buyerLists %monsters_old @monstersID_old %npcs_old %items_old %players_old @playersID_old @servers $sessionID $sessionID2 $accountSex $accountSex2 $map_ip $map_port $KoreStartTime $secureLoginKey $initSync $lastConfChangeTime $petsList $playersList $portalsList @playerNameCacheIDs %playerNameCache %pet $pvp @cashList $slavesList @slavesID %slaves %cashShop)],
+	state   => [qw($accountID $cardMergeIndex @cardMergeItemsID $charID @chars @chars_old @friendsID %friends %incomingFriend $field %homunculus $itemsList @itemsID %items $monstersList @monstersID %monsters @npcsID %npcs $npcsList @playersID %players @portalsID @portalsID_old %portals %portals_old $portalsList $storeList $currentChatRoom @currentChatRoomUsers @chatRoomsID %createdChatRoom %chatRooms @skillsID $storageTitle @arrowCraftID %guild %incomingGuild @spellsID %spells @unknownPlayers @unknownNPCs $useArrowCraft %currentDeal %incomingDeal %outgoingDeal @identifyID @partyUsersID %incomingParty @petsID %pets $venderItemList $venderID $venderCID @venderListsID @buyerItemList @selfBuyerItemList $buyerID $buyingStoreID @buyerListsID @articles $articles %venderLists %buyerLists %monsters_old @monstersID_old %npcs_old %items_old %players_old @playersID_old @servers $sessionID $sessionID2 $accountSex $accountSex2 $map_ip $map_port $KoreStartTime $secureLoginKey $initSync $lastConfChangeTime $petsList $playersList $portalsList @playerNameCacheIDs %playerNameCache %pet $pvp @cashList $slavesList @slavesID %slaves %cashShop)],
 	network => [qw($remote_socket $net $messageSender $charServer $conState $conState_tries $encryptVal $ipc $bus $masterServer $lastSwitch $packetParser $clientPacketHandler $bytesSent $incomingMessages $outgoingClientMessages $enc_val1 $enc_val2 $captcha_state)],
 	interface => [qw($interface)],
 	misc    => [qw($quit $reconnectCount @lastpm %lastpm @privMsgUsers %timeout_ex $shopstarted $dmgpsec $totalelasped $elasped $totaldmg %overallAuth %responseVars %talk $startTime_EXP $startingzeny @monsters_Killed $bExpSwitch $jExpSwitch $totalBaseExp $totalJobExp $shopEarned %itemChange $XKore_dontRedirect $monkilltime $monstarttime $startedattack $firstLoginMap $sentWelcomeMessage $versionSearch $monsterBaseExp $monsterJobExp %descriptions %flags %damageTaken $logAppend @sellList $userSeed $taskManager $repairList $mailList $rodexList $rodexWrite $auctionList $questList $achievementList $hotkeyList $devotionList $cookingList %charSvrSet @deadTime)],
@@ -410,7 +410,7 @@ our @portalsID;
 our @portalsID_old;
 our %portals;
 our %portals_old;
-our @storeList;
+our $storeList;
 our $currentChatRoom;
 our @currentChatRoomUsers;
 our @chatRoomsID;
@@ -441,7 +441,7 @@ our %cashShop;
 our @petsID;
 our %pets;
 our $pvp;
-our @venderItemList;
+our $venderItemList;
 our $venderID;
 our $venderCID;
 our @venderListsID;

--- a/src/InventoryList.pm
+++ b/src/InventoryList.pm
@@ -35,7 +35,7 @@ use base qw(ActorList);
 #
 # Creates a new InventoryList object.
 sub new {
-	my ($class) = @_;
+	my ($class, %args) = @_;
 	my $self = $class->SUPER::new('Actor::Item');
 
 	# Hash<String, Array<int>> nameIndex
@@ -70,6 +70,10 @@ sub new {
 	#     defined(nameChangeEvents)
 	#     scalar(keys nameChangeEvents) == size()
 	$self->{nameChangeEvents} = {};
+
+	if ( $args{items} ) {
+		$self->add( $_ ) foreach @{ $args{items} };
+	}
 
 	return $self;
 }
@@ -380,6 +384,11 @@ sub sumByName {
 	}
 
 	return $sum;
+}
+
+# isReady is true if this InventoryList has actionable data. Eg, storage is open, or we have a cart, etc.
+sub isReady {
+    1;
 }
 
 1;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -4053,33 +4053,24 @@ sub npc_store_begin {
 	$ai_v{'npc_talk'}{'talk'} = 'buy_or_sell';
 	$ai_v{'npc_talk'}{'time'} = time;
 
-	my $name = getNPCName($args->{ID});
+	$storeList->{npcName} = getNPCName($args->{ID}) || T('Unknown');
 }
 
 sub npc_store_info {
 	my ($self, $args) = @_;
 	my $msg = $args->{RAW_MSG};
-	undef @storeList;
-	my $storeList = 0;
+	my $pack = 'V V C v';
+	my $len = length pack $pack;
+	$storeList->clear;
 	undef %talk;
-	for (my $i = 4; $i < $args->{RAW_MSG_SIZE}; $i += 11) {
-		my $price = unpack("V1", substr($msg, $i, 4));
-		my $type = unpack("C1", substr($msg, $i + 8, 1));
-		my $ID = unpack("v1", substr($msg, $i + 9, 2));
+	for (my $i = 4; $i < $args->{RAW_MSG_SIZE}; $i += $len) {
+		my $item = Actor::Item->new;
+		@$item{qw( price _ type nameID )} = unpack $pack, substr $msg, $i, $len;
+		$item->{ID} = $item->{nameID};
+		$item->{name} = itemName($item);
+		$storeList->add($item);
 
-		my $store = $storeList[$storeList] = {};
-		# TODO: use itemName() or itemNameSimple()?
-		my $display = ($items_lut{$ID} ne "")
-			? $items_lut{$ID}
-			: T("Unknown ").$ID;
-		$store->{name} = $display;
-		$store->{nameID} = $ID;
-		$store->{type} = $type;
-		$store->{price} = $price;
-		# Real RO client can be receive this message without NPC Information. We should mimic this behavior.
-		$store->{npcName} = (defined $talk{ID}) ? getNPCName($talk{ID}) : T('Unknown') if ($storeList == 0);
-		debug "Item added to Store: $store->{name} - $price z\n", "parseMsg", 2;
-		$storeList++;
+		debug "Item added to Store: $item->{name} - $item->{price}z\n", "parseMsg", 2;
 	}
 
 	$ai_v{npc_talk}{talk} = 'store';

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -4446,6 +4446,8 @@ sub vender_items_list {
 	my $msg = $args->{RAW_MSG};
 	my $msg_size = $args->{RAW_MSG_SIZE};
 	my $headerlen;
+	my $item_pack = $self->{vender_items_list_item_pack} || 'V v2 C v C3 a8';
+	my $item_len = length pack $item_pack;
 
 	# a hack, but the best we can do now
 	if ($args->{switch} eq "0133") {
@@ -4454,57 +4456,36 @@ sub vender_items_list {
 		$headerlen = 12;
 	}
 
-	undef @venderItemList;
-	undef $venderID;
-	undef $venderCID;
 	$venderID = $args->{venderID};
-	$venderCID = $args->{venderCID} if exists $args->{venderCID};
+	$venderCID = $args->{venderCID};
 	my $player = Actor::get($venderID);
+	$venderItemList->clear;
 
 	message TF("%s\n" .
 		"#   Name                                      Type        Amount          Price\n",
-		center(' Vender: ' . $player->nameIdx . ' ', 79, '-')), ($config{showDomain_Shop}?$config{showDomain_Shop}:"list");
-	for (my $i = $headerlen; $i < $args->{RAW_MSG_SIZE}; $i+=22) {
-		my $item = {};
-		my $index;
+		center(' Vender: ' . $player->nameIdx . ' ', 79, '-')), $config{showDomain_Shop} || 'list';
+	for (my $i = $headerlen; $i < $args->{RAW_MSG_SIZE}; $i+=$item_len) {
+		my $item = Actor::Item->new;
 
-		($item->{price},
-		$item->{amount},
-		$index,
-		$item->{type},
-		$item->{nameID},
-		$item->{identified}, # should never happen
-		$item->{broken}, # should never happen
-		$item->{upgrade},
-		$item->{cards})	= unpack('V v2 C v C3 a8', substr($args->{RAW_MSG}, $i, 22));
+ 		@$item{qw( price amount ID type nameID identified broken upgrade cards options )} = unpack $item_pack, substr $args->{RAW_MSG}, $i, $item_len;
 
 		$item->{name} = itemName($item);
-		$venderItemList[$index] = $item;
+		$venderItemList->add($item);
 
 		debug("Item added to Vender Store: $item->{name} - $item->{price} z\n", "vending", 2);
 
-		Plugins::callHook('packet_vender_store', {
-			venderID => $venderID,
-			number => $index,
-			name => $item->{name},
-			amount => $item->{amount},
-			price => $item->{price},
-			upgrade => $item->{upgrade},
-			cards => $item->{cards},
-			type => $item->{type},
-			id => $item->{nameID}
-		});
+		Plugins::callHook('packet_vender_store', { item => $item });
 
 		message(swrite(
 			"@<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<<<<<< @>>>>> @>>>>>>>>>>>>z",
-			[$index, $item->{name}, $itemTypes_lut{$item->{type}}, formatNumber($item->{amount}), formatNumber($item->{price})]),
-			($config{showDomain_Shop}?$config{showDomain_Shop}:"list"));
+			[$item->{binID}, $item->{name}, $itemTypes_lut{$item->{type}}, formatNumber($item->{amount}), formatNumber($item->{price})]),
+			$config{showDomain_Shop} || 'list');
 	}
-	message("-------------------------------------------------------------------------------\n", ($config{showDomain_Shop}?$config{showDomain_Shop}:"list"));
+	message("-------------------------------------------------------------------------------\n", $config{showDomain_Shop} || 'list');
 
 	Plugins::callHook('packet_vender_store2', {
 		venderID => $venderID,
-		itemList => \@venderItemList
+		itemList => $venderItemList,
 	});
 }
 
@@ -4536,6 +4517,8 @@ sub vending_start {
 
 	my $msg = $args->{RAW_MSG};
 	my $msg_size = unpack("v1",substr($msg, 2, 2));
+	my $item_pack = $self->{vender_items_list_item_pack} || 'V v2 C v C3 a8';
+	my $item_len = length pack $item_pack;
 
 	#started a shop.
 	message TF("Shop '%s' opened!\n", $shop{title}), "success";
@@ -4547,18 +4530,11 @@ sub vending_start {
 	# the shop title instead of using $shop{title}.
 	my $display = center(" $shop{title} ", 79, '-') . "\n" .
 		T("#  Name                                       Type        Amount          Price\n");
-	for (my $i = 8; $i < $msg_size; $i += 22) {
-		my $number = unpack("v1", substr($msg, $i + 4, 2));
-		my $item = $articles[$number] = {};
-		$item->{nameID} = unpack("v1", substr($msg, $i + 9, 2));
-		$item->{quantity} = unpack("v1", substr($msg, $i + 6, 2));
-		$item->{type} = unpack("C1", substr($msg, $i + 8, 1));
-		$item->{identified} = unpack("C1", substr($msg, $i + 11, 1));
-		$item->{broken} = unpack("C1", substr($msg, $i + 12, 1));
-		$item->{upgrade} = unpack("C1", substr($msg, $i + 13, 1));
-		$item->{cards} = substr($msg, $i + 14, 8);
-		$item->{price} = unpack("V1", substr($msg, $i, 4));
+	for (my $i = 8; $i < $msg_size; $i += $item_len) {
+	    my $item = {};
+	    @$item{qw( price number quantity type nameID identified broken upgrade cards options )} = unpack $item_pack, substr $msg, $i, $item_len;
 		$item->{name} = itemName($item);
+	    $articles[delete $item->{number}] = $item;
 		$articles++;
 
 		debug ("Item added to Vender Store: $item->{name} - $item->{price} z\n", "vending", 2);

--- a/src/Network/Receive/iRO.pm
+++ b/src/Network/Receive/iRO.pm
@@ -16,7 +16,7 @@ package Network::Receive::iRO;
 use strict;
 use base qw(Network::Receive::ServerType0);
 
-use Globals qw($messageSender %timeout @articles $articles %shop %itemTypes_lut $shopEarned $venderID $venderCID %config @venderItemList);
+use Globals qw($messageSender %timeout %config);
 use Log qw(message debug);
 use Misc qw(center itemName);
 use Translation qw(T TF);
@@ -39,104 +39,10 @@ sub new {
 		$self->{packet_list}{$switch} = $packets{$switch};
 	}
 
+    # Version 2 of the 0800 vender items packet (with options).
+	$self->{vender_items_list_item_pack} = 'V v2 C v C3 a8 a25';
+
 	return $self;
-}
-
-# The packet number didn't change, but the length of the packet did, and
-# there's no good way to detect which version we're using based on the data
-# the server sends to us.
-sub vending_start {
-	my ($self, $args) = @_;
-
-	my $msg = $args->{RAW_MSG};
-	my $msg_size = unpack("v1",substr($msg, 2, 2));
-
-	#started a shop.
-	message TF("Shop '%s' opened!\n", $shop{title}), "success";
-	@articles = ();
-	# FIXME: why do we need a seperate variable to track how many items are left in the store?
-	$articles = 0;
-
-	my $display = center(" $shop{title} ", 79, '-') . "\n" .
-		T("#  Name                                       Type        Amount          Price\n");
-	for (my $i = 8; $i < $msg_size; $i += 47) {
-	    my $item = {};
-	    @$item{qw( price number quantity type nameID identified broken upgrade cards options )} = unpack 'V v v C v C C C a8 a25', substr $msg, $i, 47;
-		$item->{name} = itemName($item);
-	    $articles[delete $item->{number}] = $item;
-		$articles++;
-
-		debug ("Item added to Vender Store: $item->{name} - $item->{price} z\n", "vending", 2);
-
-		$display .= swrite(
-			"@< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<<<<<< @>>>>> @>>>>>>>>>>>>z",
-			[$articles, $item->{name}, $itemTypes_lut{$item->{type}}, formatNumber($item->{quantity}), formatNumber($item->{price})]);
-	}
-	$display .= ('-'x79) . "\n";
-	message $display, "list";
-	$shopEarned ||= 0;
-}
-
-sub vender_items_list {
-	my ($self, $args) = @_;
-
-	my $msg = $args->{RAW_MSG};
-	my $msg_size = $args->{RAW_MSG_SIZE};
-	my $headerlen = 12;
-
-	undef @venderItemList;
-	$venderID = $args->{venderID};
-	$venderCID = $args->{venderCID};
-	my $player = Actor::get($venderID);
-
-	message TF("%s\n" .
-		"#   Name                                      Type        Amount          Price\n",
-		center(' Vender: ' . $player->nameIdx . ' ', 79, '-')), $config{showDomain_Shop} || 'list';
-	for (my $i = $headerlen; $i < $args->{RAW_MSG_SIZE}; $i+=47) {
-		my $item = {};
-		my $index;
-
-		($item->{price},
-		$item->{amount},
-		$index,
-		$item->{type},
-		$item->{nameID},
-		$item->{identified}, # should never happen
-		$item->{broken}, # should never happen
-		$item->{upgrade},
-		$item->{cards},
-		$item->{options},
-		) = unpack('V v2 C v C3 a8 a25', substr($args->{RAW_MSG}, $i, 47));
-
-		$item->{name} = itemName($item);
-		$venderItemList[$index] = $item;
-
-		debug("Item added to Vender Store: $item->{name} - $item->{price} z\n", "vending", 2);
-
-		Plugins::callHook('packet_vender_store', {
-			venderID => $venderID,
-			number => $index,
-			name => $item->{name},
-			amount => $item->{amount},
-			price => $item->{price},
-			upgrade => $item->{upgrade},
-			cards => $item->{cards},
-			options => $item->{options},
-			type => $item->{type},
-			id => $item->{nameID}
-		});
-
-		message(swrite(
-			"@<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<<<<<< @>>>>> @>>>>>>>>>>>>z",
-			[$index, $item->{name}, $itemTypes_lut{$item->{type}}, formatNumber($item->{amount}), formatNumber($item->{price})]),
-			$config{showDomain_Shop} || 'list');
-	}
-	message("-------------------------------------------------------------------------------\n", $config{showDomain_Shop} || 'list');
-
-	Plugins::callHook('packet_vender_store2', {
-		venderID => $venderID,
-		itemList => \@venderItemList
-	});
 }
 
 sub received_characters_info {

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -3762,6 +3762,8 @@ sub vender_items_list {
 	my $msg = $args->{RAW_MSG};
 	my $msg_size = $args->{RAW_MSG_SIZE};
 	my $headerlen;
+	my $item_pack = $self->{vender_items_list_item_pack} || 'V v2 C v C3 a8';
+	my $item_len = length pack $item_pack;
 
 	# a hack, but the best we can do now
 	if ($args->{switch} eq "0133") {
@@ -3770,57 +3772,36 @@ sub vender_items_list {
 		$headerlen = 12;
 	}
 
-	undef @venderItemList;
-	undef $venderID;
-	undef $venderCID;
 	$venderID = $args->{venderID};
-	$venderCID = $args->{venderCID} if exists $args->{venderCID};
+	$venderCID = $args->{venderCID};
 	my $player = Actor::get($venderID);
+	$venderItemList->clear;
 
 	message TF("%s\n" .
-		"#  Name                                       Type           Amount       Price\n",
-		center(' Vender: ' . $player->nameIdx . ' ', 79, '-')), "list";
-	for (my $i = $headerlen; $i < $args->{RAW_MSG_SIZE}; $i+=22) {
-		my $item = {};
-		my $index;
+		"#   Name                                      Type        Amount          Price\n",
+		center(' Vender: ' . $player->nameIdx . ' ', 79, '-')), $config{showDomain_Shop} || 'list';
+	for (my $i = $headerlen; $i < $args->{RAW_MSG_SIZE}; $i+=$item_len) {
+		my $item = Actor::Item->new;
 
-		($item->{price},
-		$item->{amount},
-		$index,
-		$item->{type},
-		$item->{nameID},
-		$item->{identified}, # should never happen
-		$item->{broken}, # should never happen
-		$item->{upgrade},
-		$item->{cards})	= unpack('V v2 C v C3 a8', substr($args->{RAW_MSG}, $i, 22));
+ 		@$item{qw( price amount ID type nameID identified broken upgrade cards options )} = unpack $item_pack, substr $args->{RAW_MSG}, $i, $item_len;
 
 		$item->{name} = itemName($item);
-		$venderItemList[$index] = $item;
+		$venderItemList->add($item);
 
 		debug("Item added to Vender Store: $item->{name} - $item->{price} z\n", "vending", 2);
 
-		Plugins::callHook('packet_vender_store', {
-			venderID => $venderID,
-			number => $index,
-			name => $item->{name},
-			amount => $item->{amount},
-			price => $item->{price},
-			upgrade => $item->{upgrade},
-			cards => $item->{cards},
-			type => $item->{type},
-			id => $item->{nameID}
-		});
+		Plugins::callHook('packet_vender_store', { item => $item });
 
 		message(swrite(
-			"@<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<<<<<<<<< @>>>>> @>>>>>>>>>z",
-			[$index, $item->{name}, $itemTypes_lut{$item->{type}}, $item->{amount}, formatNumber($item->{price})]),
-			"list");
+			"@<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<<<<<< @>>>>> @>>>>>>>>>>>>z",
+			[$item->{ID}, $item->{name}, $itemTypes_lut{$item->{type}}, formatNumber($item->{amount}), formatNumber($item->{price})]),
+			$config{showDomain_Shop} || 'list');
 	}
-	message("-------------------------------------------------------------------------------\n", "list");
+	message("-------------------------------------------------------------------------------\n", $config{showDomain_Shop} || 'list');
 
 	Plugins::callHook('packet_vender_store2', {
 		venderID => $venderID,
-		itemList => \@venderItemList
+		itemList => $venderItemList,
 	});
 }
 

--- a/src/Task/TalkNPC.pm
+++ b/src/Task/TalkNPC.pm
@@ -21,7 +21,7 @@ use utf8;
 use Modules 'register';
 use Task;
 use base qw(Task);
-use Globals qw($char %timeout $npcsList $monstersList %ai_v $messageSender %config @storeList $net %talk);
+use Globals qw($char %timeout $npcsList $monstersList %ai_v $messageSender %config $storeList $net %talk);
 use Log qw(message debug error warning);
 use Utils;
 use Commands;
@@ -541,8 +541,8 @@ sub iterate {
 				while ($self->{steps}[0] =~ /^b(\d+),(\d+)/i){
 					my $index = $1;
 					my $amount = $2;
-					if ($storeList[$index]) {
-						my $itemID = $storeList[$index]{nameID};
+					if ($storeList->get($index)) {
+						my $itemID = $storeList->get($index)->{nameID};
 						push (@{$ai_v{npc_talk}{itemsIDlist}},$itemID);
 						push (@bulkitemlist,{itemID  => $itemID, amount => $amount});
 					} else {

--- a/src/functions.pl
+++ b/src/functions.pl
@@ -526,6 +526,8 @@ sub finalInitialization {
 	$npcsList = new ActorList('Actor::NPC');
 	$portalsList = new ActorList('Actor::Portal');
 	$slavesList = new ActorList('Actor::Slave');
+	$venderItemList = InventoryList->new;
+	$storeList = InventoryList->new;
 	foreach my $list ($itemsList, $monstersList, $playersList, $petsList, $npcsList, $portalsList, $slavesList) {
 		$list->onAdd()->add(undef, \&actorAdded);
 		$list->onRemove()->add(undef, \&actorRemoved);
@@ -644,7 +646,6 @@ sub initMapChangeVars {
 	undef %incomingParty;
 	undef %talk;
 	$ai_v{temp} = {};
-	undef @venderItemList;
 	undef $venderID;
 	undef $venderCID;
 	undef @venderListsID;
@@ -673,6 +674,8 @@ sub initMapChangeVars {
 	$portalsList->clear();
 	$npcsList->clear();
 	$slavesList->clear();
+	$venderItemList->clear;
+	$storeList->clear;
 
 	@unknownPlayers = ();
 	@unknownNPCs = ();


### PR DESCRIPTION
- [x] Handle TODOs
- Code Review

### General
* Enable eventMacro plugin.
* Fix `&cart()`, `&inventory()`, `&storage()`, `&venderitem()`.

### Add `@array = &split()` function.

One can do this (painfully) with `&eval()`, like so:
```
$list = a,b,c,d
@array = ()
&push(@array, &eval( (split(',', '$list'))[0] ))
&push(@array, &eval( (split(',', '$list'))[1] ))
&push(@array, &eval( (split(',', '$list'))[2] ))
&push(@array, &eval( (split(',', '$list'))[3] ))
```

This pull request adds the ability do this in a simpler way:
```
$list = a,b,c,d
@array = split(',', $list)
```

### Remove repeat option on `call macro_name`, replace with params.

Previously, there were two parameters to `call`: the macro name and a "repeat" parameter, which said how many times to call the macro. Most people probably didn't know the feature existed, and I don't think I've ever seen code using it.

This pull request changes the meaning of extra parameters to `call`, so that they now override the `$.param1`, `$.param2`, ..., `$.paramN` magic variables instead. This provides the ability to pass arbitrary parameters macros, like so:
```
call quest_talk prontera "140 100" "r0 e"
```

### Support calling macros by variable name.

It can (rarely) be useful to implement a dispatch table by passing a macro name around, and then calling the macro with the same name. This requires a sequence of `if` statements, something like this:
```
if ($macro = foo) call foo
if ($macro = bar) call bar
if ($macro = baz) call baz
```

As a side-effect of allowing variables in `call` params (see above), this pull request allows macros to be called by a variable name directly, like so:
```
call $macro
```
