### PR TITLE
Fix free kafra ticked for teleportation

### DIFF
--- a/src/Task/CalcMapRoute.pm
+++ b/src/Task/CalcMapRoute.pm
@@ -93,6 +93,14 @@ sub new {
 	}
 	
 	$self->{maxTime} = $args{maxTime} || $timeout{ai_route_calcRoute}{timeout};
+	
+	my $tickets = $char->inventory->getByNameID(7060);
+	
+	if ($tickets) {
+		$self->{tickets_amount} = $tickets->{amount};
+	} else {
+		$self->{tickets_amount} = 0;
+	}
 
 	$self->{stage} = INITIALIZE;
 	$self->{openlist} = {};
@@ -141,6 +149,13 @@ sub iterate {
 					$openlist->{"$portal=$dest"}{walk} = $penalty + scalar @{$self->{solution}};
 					$openlist->{"$portal=$dest"}{zeny} = $entry->{dest}{$dest}{cost};
 					$openlist->{"$portal=$dest"}{allow_ticket} = $entry->{dest}{$dest}{allow_ticket};
+					if ($self->{tickets_amount} > 0 && $openlist->{"$portal=$dest"}{allow_ticket}) {
+						$openlist->{"$portal=$dest"}{zeny_covered_by_tickets} = $openlist->{"$portal=$dest"}{zeny};
+						$openlist->{"$portal=$dest"}{amount_of_tickets_used} = 1;
+					} else {
+						$openlist->{"$portal=$dest"}{zeny_covered_by_tickets} = 0;
+						$openlist->{"$portal=$dest"}{amount_of_tickets_used} = 0;
+					}
 				}
 			}
 		}
@@ -215,16 +230,19 @@ sub searchStep {
 	#foreach my $parent (keys %{$openlist})
 	{
 		my ($portal, $dest) = split /=/, $parent;
-		if ($self->{budget} ne '' && !($char->inventory->getByNameID(7060) && $openlist->{$parent}{allow_ticket}) && ($openlist->{$parent}{zeny} > $self->{budget})) {
+		
+		if ($self->{budget} ne '' && $self->{budget} < ($openlist->{$parent}{zeny} - $openlist->{$parent}{zeny_covered_by_tickets})) {
 			# This link is too expensive
-			# We should calculate the entire route cost
 			delete $openlist->{$parent};
 			next;
+
 		} else {
 			# MOVE this entry into the CLOSELIST
 			$closelist->{$parent}{walk}   = $openlist->{$parent}{walk};
 			$closelist->{$parent}{zeny}  = $openlist->{$parent}{zeny};
 			$closelist->{$parent}{allow_ticket}  = $openlist->{$parent}{allow_ticket};
+			$closelist->{$parent}{zeny_covered_by_tickets} = $openlist->{$parent}{zeny_covered_by_tickets};
+			$closelist->{$parent}{amount_of_tickets_used} = $openlist->{$parent}{amount_of_tickets_used};
 			$closelist->{$parent}{parent} = $openlist->{$parent}{parent};
 			# Then delete in from OPENLIST
 			delete $openlist->{$parent};
@@ -245,6 +263,8 @@ sub searchStep {
 					$arg{walk} = $closelist->{$this}{walk};
 					$arg{zeny} = $closelist->{$this}{zeny};
 					$arg{allow_ticket} = $closelist->{$this}{allow_ticket};
+					$arg{zeny_covered_by_tickets} = $closelist->{$this}{zeny_covered_by_tickets};
+					$arg{amount_of_tickets_used} = $closelist->{$this}{amount_of_tickets_used};
 					$arg{steps} = $portals_lut{$from}{dest}{$to}{steps};
 
 					unshift @{$self->{mapSolution}}, \%arg;
@@ -258,6 +278,8 @@ sub searchStep {
 				$closelist->{$walk}{parent} = $parent;
 				$closelist->{$walk}{zeny} = $closelist->{$parent}{zeny};
 				$closelist->{$walk}{allow_ticket} = $closelist->{$parent}{allow_ticket};
+				$closelist->{$walk}{zeny_covered_by_tickets} = $closelist->{$parent}{zeny_covered_by_tickets};
+				$closelist->{$walk}{amount_of_tickets_used} = $closelist->{$parent}{amount_of_tickets_used};
 				$self->{found} = $walk;
 				$self->{done} = 1;
 				$self->{mapSolution} = [];
@@ -270,6 +292,8 @@ sub searchStep {
 					$arg{walk} = $closelist->{$this}{walk};
 					$arg{zeny} = $closelist->{$this}{zeny};
 					$arg{allow_ticket} = $closelist->{$this}{allow_ticket};
+					$arg{zeny_covered_by_tickets} = $closelist->{$this}{zeny_covered_by_tickets};
+					$arg{amount_of_tickets_used} = $closelist->{$this}{amount_of_tickets_used};
 					$arg{steps} = $portals_lut{$from}{dest}{$to}{steps};
 
 					unshift @{$self->{mapSolution}}, \%arg;
@@ -295,6 +319,13 @@ sub searchStep {
 						$openlist->{"$child=$subchild"}{walk} = $thisWalk;
 						$openlist->{"$child=$subchild"}{zeny} = $closelist->{$parent}{zeny} + $portals_lut{$child}{dest}{$subchild}{cost};
 						$openlist->{"$child=$subchild"}{allow_ticket} = $portals_lut{$child}{dest}{$subchild}{allow_ticket};
+						if ($openlist->{"$child=$subchild"}{allow_ticket} && $self->{tickets_amount} > $openlist->{"$child=$subchild"}{amount_of_tickets_used}) {
+							$openlist->{"$child=$subchild"}{zeny_covered_by_tickets} = $closelist->{$parent}{zeny_covered_by_tickets} + $openlist->{"$child=$subchild"}{zeny};
+							$openlist->{"$child=$subchild"}{amount_of_tickets_used} = $closelist->{$parent}{amount_of_tickets_used} + 1;
+						} else {
+							$openlist->{"$child=$subchild"}{zeny_covered_by_tickets} = $closelist->{$parent}{zeny_covered_by_tickets};
+							$openlist->{"$child=$subchild"}{amount_of_tickets_used} = $closelist->{$parent}{amount_of_tickets_used};
+						}
 					}
 				}
 			}


### PR DESCRIPTION
While since my last change in CalcMapRoute made tele tickets work there was still a problem, openkore would not count the number of tickets used to a certain point nor the amount of zeny it saved by doing so, with this change both of these things are now fixed.

Example of situation that where kore found not work well before:
Number of tickets: 1
Zeny: 0
Route: 
Payon > Prontera (by Kafra)
Prontera > Al De Baran (by Kafra)

CalcMapRoute would think you could do this route because you had a ticked when actually you needed 2 tickets or 1 ticket + 3,000z.
