### PR TITLE
Update RagexeRE_2012_04_10a.pm

### DIFF
--- a/src/Network/Receive/kRO/RagexeRE_2012_04_10a.pm
+++ b/src/Network/Receive/kRO/RagexeRE_2012_04_10a.pm
@@ -16,6 +16,33 @@ package Network::Receive::kRO::RagexeRE_2012_04_10a;
 
 use strict;
 use base qw(Network::Receive::kRO::RagexeRE_2012_03_07f);
+sub new {
+   my ($class) = @_;
+   my $self = $class->SUPER::new(@_);
+   my %packets = (
+	 '0915' => ['actor_exists', 'v C a4 v3 V v11 a4 a2 v V C2 a3 C3 v2 a9 Z*', [qw(len object_type ID walk_speed opt1 opt2 option type hair_style weapon shield lowhead tophead midhead hair_color clothes_color head_dir costume guildID emblemID manner opt3 stance sex coords xSize ySize act lv font opt4 name)]],
+	 '090F' => ['actor_connected', 'v C a4 v3 V v11 a4 a2 v V C2 a3 C2 v2 a9 Z*', [qw(len object_type ID walk_speed opt1 opt2 option type hair_style weapon shield lowhead tophead midhead hair_color clothes_color head_dir costume guildID emblemID manner opt3 stance sex coords xSize ySize lv font opt4 name)]],
+	 '0914' => ['actor_moved', 'v C a4 v3 V v5 a4 v6 a4 a2 v V C2 a6 C2 v2 a9 Z*', [qw(len object_type ID walk_speed opt1 opt2 option type hair_style weapon shield lowhead tick tophead midhead hair_color clothes_color head_dir costume guildID emblemID manner opt3 stance sex coords xSize ySize lv font opt4 name)]],
+	 '0086' => ['actor_display', 'a4 a6 V', [qw(ID coords tick)]],
+   );
+   
+   	foreach my $switch (keys %packets) {
+		$self->{packet_list}{$switch} = $packets{$switch};
+	}
+	
+	my %handlers = qw(
+		actor_connected 090F
+		actor_moved 0914
+		actor_exists 0915
+		actor_display 0086
+	);
+	
+   foreach my $switch (keys %packets) { $self->{packet_list}{$switch} = $packets{$switch}; }
+
+   return $self;
+}
+
+1;
 
 # TODO
 # 0x08E6,4


### PR DESCRIPTION
4ept provided this serverType.
Who posted, forgot to add these packets.

I'm using 2013 08 07a and i'm receiving this packet warning.


> actors [
> 	#elif PACKETVER < 20131223
> 		WBUFW(buf, 0) = 0x914;
> 	#elif PACKETVER < 20150513
> 		WBUFW(buf, 0) = 0x9db;
> 	#else
> 		WBUFW(buf, 0) = 0x9fd;
> 	#endif
> 
> 
> 	#elif PACKETVER < 20131223
> 		WBUFW(buf,0) = spawn ? 0x90f : 0x915;
> 	#elif PACKETVER < 20150513
> 			WBUFW(buf,0) = spawn ? 0x9dc : 0x9dd;
> 	#else
> 			WBUFW(buf,0) = spawn ? 0x9fe : 0x9ff;
> ]
> 

Can someone review, because according with 2014_10_22b : 

missingpackets : 
[
its using 0x9FE, instead of 0x9DC
its using 0x9FF instead of 0x9DD
its using 0x9FD instead of 0x9DB
]
When these packets should only used in sT above 2015.

I see this because : 

0x914. 0x915, 0x90F is already inside 2012_04_10a. 
Completely correct. According with hercules/rAthena emulators.



https://github.com/rathena/rathena/blob/master/src/map/clif.c
https://github.com/HerculesWS/Hercules/blob/master/src/map/packets_struct.h

0x9FE,0x9FF,0x9FD must be used above 20150513 servers.


TODO : 
Only in the future, about 6 weeks, i will provide a complete fix for this.
Here only to provide this patch!

My future fixes are listed in Modera's lounger in Forum ! Thx