### PR TITLE
use the size of each stack for "deal 0-99"

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -1536,11 +1536,7 @@ sub cmdDeal {
 		while (@items && $n < $max_items) {
 			my $item = shift @items;
 			next if $item->{equipped};
-			my $amount = $item->{amount};
-			if (!$arg[2] || $arg[2] > $amount) {
-				$arg[2] = $amount;
-			}
-			dealAddItem($item, $arg[2]);
+			dealAddItem( $item, min( $item->{amount}, $arg[2] || $item->{amount} ) );
 			$n++;
 		}
 	} elsif ($arg[0] eq "add" && $arg[1] eq "z") {


### PR DESCRIPTION
- [ ] Code Review

When adding items to a deal in a batch, the number of items dealt would be the minimum of the stack size of the items so far, instead of the whole stack.

So if the following items were in inventory:
```
Jellopy x 7
Red Herb x 10
Green Herb x 5
Blue Herb x 15
```

... then the following item amounts would be dealt:
```
Jellopy x 7
Red Herb x 7
Green Herb x 5
Blue Herb x 5
```

This change causes the entire stack to be dealt instead.