### PR TITLE
party share enhacement

### DIFF
--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -85,6 +85,8 @@ ai_dead_respawn 4
 ai_wipe_old 200
 ai_wipe_check 30
 
+# Every x seconds, check party share settings
+ai_partyShareCheck 60
 # Every x seconds, check pet hungry for feeding
 ai_petFeed 60
 # Every x seconds, check homun hungry for feeding

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -123,6 +123,7 @@ sub iterate {
 	processDeal();
 	processDealAuto();
 	processPartyAuto();
+	processPartyShareAuto();
 	processGuildAutoDeny();
 
 	Misc::checkValidity("AI part 1.1");
@@ -3195,6 +3196,23 @@ sub processFeed {
 		$messageSender->sendPetMenu(1);
 		$timeout{ai_petFeed}{time} = time;
 	}
+}
+
+sub processPartyShareAuto {
+	return if (!$char->{party}{users}{$accountID}{admin} || $char->{party}{shareForcedByCommand});	
+	
+	if (timeOut($timeout{ai_partyShareCheck})) {
+		if (!exists($char->{party}{shareTimes})) { $char->{party}{shareTimes} = 1; }
+		
+		if (($config{partyAutoShare} || $config{partyAutoShareItem} || $config{partyAutoShareItemDiv}) && $char->{party} && %{$char->{party}} && ($char->{party}{share} ne $config{partyAutoShare} || $char->{party}{itemPickup} ne $config{partyAutoShareItem} || $char->{party}{itemDivision} ne $config{partyAutoShareItemDiv})) {
+			$messageSender->sendPartyOption($config{partyAutoShare}, $config{partyAutoShareItem}, $config{partyAutoShareItemDiv});
+			$char->{party}{shareTimes}++;
+			if ($char->{party}{shareTimes} > 5) {
+				warning T("Party Share Settings have been sent many times, please check your party\n");
+			}			
+		}
+		$timeout{ai_partyShareCheck}{time} = time;
+	}	
 }
 
 1;

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -3549,7 +3549,7 @@ sub cmdParty {
 			$messageSender->sendPartyJoinRequestByName ($arg2);
 		}
 	# party leader specific commands
-	} elsif ($arg1 eq "share" || $arg1 eq "shareitem" || $arg1 eq "sharediv" || $arg1 eq "kick" || $arg1 eq "leader") {
+	} elsif ($arg1 eq "share" || $arg1 eq "shareitem" || $arg1 eq "shareauto" || $arg1 eq "sharediv" || $arg1 eq "kick" || $arg1 eq "leader") {
 		my $party_admin;
 		# check if we are the party leader before using leader specific commands.
 		for (my $i = 0; $i < @partyUsersID; $i++) {
@@ -3570,7 +3570,7 @@ sub cmdParty {
 				"Usage: party share <flag>\n");
 		} elsif ($arg1 eq "share") {
 			$messageSender->sendPartyOption($arg2, $config{partyAutoShareItem}, $config{partyAutoShareItemDiv});
-
+			$char->{party}{shareForcedByCommand} = 1;
 		} elsif ($arg1 eq "shareitem" && ( !$char->{'party'} || !%{$char->{'party'}} )) {
 			error T("Error in function 'party shareitem' (Set Party Share Item)\n" .
 				"Can't set share - you're not in a party.\n");
@@ -3579,7 +3579,7 @@ sub cmdParty {
 				"Usage: party shareitem <flag>\n");
 		} elsif ($arg1 eq "shareitem") {
 			$messageSender->sendPartyOption($config{partyAutoShare}, $arg2, $config{partyAutoShareItemDiv});
-
+			$char->{party}{shareForcedByCommand} = 1;
 		} elsif ($arg1 eq "sharediv" && ( !$char->{'party'} || !%{$char->{'party'}} )) {
 			error T("Error in function 'party share' (Set Party Share EXP)\n" .
 				"Can't set share - you're not in a party.\n");
@@ -3588,8 +3588,10 @@ sub cmdParty {
 				"Usage: party share <flag>\n");
 		} elsif ($arg1 eq "sharediv") {
 			$messageSender->sendPartyOption($config{partyAutoShare}, $config{partyAutoShareItem}, $arg2);
-
-
+			$char->{party}{shareForcedByCommand} = 1;
+		} elsif ($arg1 eq "shareauto") {
+			$messageSender->sendPartyOption($config{partyAutoShare}, $config{partyAutoShareItem}, $config{partyAutoShareItemDiv});
+			$char->{party}{shareForcedByCommand} = undef;
 		} elsif ($arg1 eq "kick" && ( !$char->{'party'} || !%{$char->{'party'}} )) {
 			error T("Error in function 'party kick' (Kick Party Member)\n" .
 				"Can't kick member - you're not in a party.\n");
@@ -3617,7 +3619,7 @@ sub cmdParty {
 		}
 	} else {
 		error T("Syntax Error in function 'party' (Party Management)\n" .
-			"Usage: party [<create|join|request|leave|share|shareitem|sharediv|kick|leader>]\n");
+			"Usage: party [<create|join|request|leave|share|shareitem|sharediv|shareauto|kick|leader>]\n");
 	}
 }
 

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -2295,10 +2295,9 @@ sub party_chat {
 	});
 }
 
-# TODO: itemPickup itemDivision
 sub party_exp {
 	my ($self, $args) = @_;
-	$char->{party}{share} = $args->{type};
+	$char->{party}{share} = $args->{type}; # Always will be there, in 0101 also in 07D8
 	if ($args->{type} == 0) {
 		message T("Party EXP set to Individual Take\n"), "party", 1;
 	} elsif ($args->{type} == 1) {
@@ -2306,19 +2305,23 @@ sub party_exp {
 	} else {
 		error T("Error setting party option\n");
 	}
-	if ($args->{itemPickup} == 0) {
-		message T("Party item set to Individual Take\n"), "party", 1;
-	} elsif ($args->{itemPickup} == 1) {
-		message T("Party item set to Even Share\n"), "party", 1;
-	} else {
-		error T("Error setting party option\n");
-	}
-	if ($args->{itemDivision} == 0) {
-		message T("Party item division set to Individual Take\n"), "party", 1;
-	} elsif ($args->{itemDivision} == 1) {
-		message T("Party item division set to Even Share\n"), "party", 1;
-	} else {
-		error T("Error setting party option\n");
+	if(exists($args->{itemPickup}) || exists($args->{itemDivision})) {
+		$char->{party}{itemPickup} = $args->{itemPickup};
+		$char->{party}{itemDivision} = $args->{itemDivision};
+		if ($args->{itemPickup} == 0) {
+			message T("Party item set to Individual Take\n"), "party", 1;
+		} elsif ($args->{itemPickup} == 1) {
+			message T("Party item set to Even Share\n"), "party", 1;
+		} else {
+			error T("Error setting party option\n");
+		}
+		if ($args->{itemDivision} == 0) {
+			message T("Party item division set to Individual Take\n"), "party", 1;
+		} elsif ($args->{itemDivision} == 1) {
+			message T("Party item division set to Even Share\n"), "party", 1;
+		} else {
+			error T("Error setting party option\n");
+		}
 	}
 }
 
@@ -2489,30 +2492,7 @@ sub party_join {
 	$actor->{name} = $user;
 	$actor->{ID} = $ID;
 	$char->{party}{users}{$ID} = $actor;
-
-=pod
-	$char->{party}{users}{$ID} = new Actor::Party if ($char->{party}{users}{$ID}{name});
-	$char->{party}{users}{$ID}{admin} = !$role;
-	if ($type == 0) {
-		$char->{party}{users}{$ID}{online} = 1;
-	} elsif ($type == 1) {
-		$char->{party}{users}{$ID}{online} = 0;
-		delete $char->{party}{users}{$ID}{statuses};
-	}
-=cut
 	$char->{party}{name} = $name;
-=pod
-	$char->{party}{users}{$ID}{pos}{x} = $x;
-	$char->{party}{users}{$ID}{pos}{y} = $y;
-	$char->{party}{users}{$ID}{map} = $map;
-	$char->{party}{users}{$ID}{name} = $user;
-	$char->{party}{users}{$ID}->{ID} = $ID;
-=cut
-
-	if (($config{partyAutoShare} || $config{partyAutoShareItem} || $config{partyAutoShareItemDiv}) && $char->{party} && %{$char->{party}} && $char->{party}{users}{$accountID}{admin}) {
-		$messageSender->sendPartyOption($config{partyAutoShare}, $config{partyAutoShareItem}, $config{partyAutoShareItemDiv});
-
-	}
 }
 
 use constant {
@@ -2590,10 +2570,7 @@ sub party_users_info {
 		$char->{party}{users}{$ID}{online} = !(unpack("C1",substr($msg, $i + 45, 1)));
 		$char->{party}{users}{$ID}->{ID} = $ID;
 		debug TF("Party Member: %s (%s)\n", $char->{party}{users}{$ID}{name}, $char->{party}{users}{$ID}{map}), "party", 1;
-	}
-	if (($config{partyAutoShare} || $config{partyAutoShareItem} || $config{partyAutoShareItemDiv}) && $char->{party} && %{$char->{party}} && $char->{party}{users}{$accountID}{admin}) {
-		$messageSender->sendPartyOption($config{partyAutoShare}, $config{partyAutoShareItem}, $config{partyAutoShareItemDiv});
-	}
+	}	
 }
 
 sub pet_capture_result {


### PR DESCRIPTION
Fixed party setting spam.
**Reference**: #870 

- [ ] Code Review

**Currently:**
Kore don't have timeout or control to party share settings, he send party settings everytime when receive the following packets:
'00FB' => ['party_users_info']
'01E9' => ['party_join']


**After Changes:**
- Moved party share settings to AI
- Added `ai_partyShareCheck` in timeouts.txt to check every x seconds if party settings are right
- Openkore will not try to change back the settings if we send the command `party share 0|1`
- Added arg `shareauto` in party command. (this command allow AI check party settings again after we send  `party share 0|1`)
- Openkore warning us if we are spamming party share settings
![sem titulo](https://user-images.githubusercontent.com/10372732/29150584-f573ba9c-7d51-11e7-824f-92bec242186c.png)


