### PR TITLE
[eventMacro] add $.statushandle

### DIFF
--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -777,6 +777,10 @@ sub get_scalar_var {
 			return '' if !$char;
 			return join ',', sort( ( $char->{muted} ? 'muted' : () ), ( $char->{dead} ? 'dead' : () ), map { $statusName{$_} || $_ } keys %{ $char->{statuses} } );
 		}
+		elsif ( $variable_name eq '.statushandle') {
+			return '' if !$char;
+			return join ',', keys %{ $char->{statuses} } ;
+		}
 
 		# Cart-related variables.
 		elsif ( $variable_name eq '.cartweight' )    { return $char && $char->cart->isReady ? $char->cart->{weight}     : 0; }


### PR DESCRIPTION
Similar to $.status, but with HANDLEs.
Does not support "dead" or "muted" statuses (after all, they aren't really statuses and therefore don't have handles)

Useful for cross-server eventMacros compatibility