### PR TITLE
eventMacro: add questStatus questInactiveCount questIncompleteCount, etc

### DIFF
--- a/plugins/eventMacro/eventMacro/Data.pm
+++ b/plugins/eventMacro/eventMacro/Data.pm
@@ -52,36 +52,26 @@ our %parameters = (
 	'CheckOnAI' => 1,    # option: on which AI state the automacro will be checked
 );
 
-our $macroKeywords =
-	"npc"          . "|" .
-	"store"        . "|" .
-	"player"       . "|" .
-	"monster"      . "|" .
-	"venderitem"   . "|" .
-	"venderprice"  . "|" .
-	"venderamount" . "|" .
-	"random"       . "|" .
-	"rand"         . "|" .
-	"invamount"    . "|" .
-	"cartamount"   . "|" .
-	"shopamount"   . "|" .
-	"storamount"   . "|" .
-	"[Ii]nventory" . "|" .
-	"[Ss]torage"   . "|" .
-	"[Cc]art"      . "|" .
-	"vender"       . "|" .
-	"config"       . "|" .
-	"eval"         . "|" .
-	"arg"          . "|" .
-	"listitem"     . "|" .
-   	"nick"         . "|" .
-	"push"         . "|" .
-	"pop"          . "|" .
-	"unshift"      . "|" .
-	"shift"        . "|" .
-	"exists"       . "|" .
-	"delete"       . "|" .
-	"defined"
-;
+our $macroKeywords = join '|', qw(
+	npc
+	store
+	player
+	monster
+	vender venderitem venderprice venderamount
+	random rand
+	invamount inventory Inventory
+	cartamount cart Cart
+	storamount storage Storage
+	shopamount
+	config
+	eval
+	arg
+	listitem
+	nick
+	push pop unshift shift
+	exists delete
+	defined
+	questStatus questInactiveCount questIncompleteCount questCompleteCount
+);
 
 1;

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -18,7 +18,7 @@ use eventMacro::Core;
 use eventMacro::FileParser qw(isNewCommandBlock);
 use eventMacro::Utilities qw(cmpr getnpcID getItemIDs getItemPrice getStorageIDs getInventoryIDs
 	getPlayerID getMonsterID getVenderID getRandom getRandomRange getInventoryAmount getCartAmount getShopAmount
-	getStorageAmount getVendAmount getConfig getWord q4rx q4rx2 getArgFromList getListLenght find_variable get_key_or_index);
+	getStorageAmount getVendAmount getConfig getWord q4rx q4rx2 getArgFromList getListLenght find_variable get_key_or_index getQuestStatus);
 use eventMacro::Automacro;
 
 # Creates the object
@@ -1878,6 +1878,19 @@ sub parse_command {
 			$result = $self->parse_defined($inside_brackets);
 			return if (defined $self->error);
 			$only_replace_once = 1;
+
+		} elsif ( $keyword eq 'questStatus' ) {
+			$result = getQuestStatus( $parsed )->{$parsed} || 'unknown';
+
+		} elsif ( $keyword eq 'questInactiveCount' ) {
+			$result = grep { $_ eq 'inactive' } values %{ getQuestStatus( split /\s*,\s*/, $parsed ) };
+
+		} elsif ( $keyword eq 'questIncompleteCount' ) {
+			$result = grep { $_ eq 'incomplete' } values %{ getQuestStatus( split /\s*,\s*/, $parsed ) };
+
+		} elsif ( $keyword eq 'questCompleteCount' ) {
+			$result = grep { $_ eq 'complete' } values %{ getQuestStatus( split /\s*,\s*/, $parsed ) };
+
 		}
 		
 		return unless defined $result;


### PR DESCRIPTION
Add some new eventMacro functions:
* `&questStatus(7123)` returns the status of quest 7123 as a string (see below for possible strings and meanings)
* `&questInactiveCount(7123,7124,7126,7127)` returns the number of given quests which have status "inactive"
* `&questIncompleteCount(7123,7124,7126,7127)` returns the number of given quests which have status "incomplete"
* `&questCompleteCount(7123,7124,7126,7127)` returns the number of given quests which have status "complete"

There are three possible quest statuses:
* `inactive` means that the quest doesn't exist or has been marked as inactive
* `incomplete` means that there is an incomplete timer or incomplete kill count
* `complete` means that the quest is complete and can be turned in

There are equivalent automacro conditions which are useful when triggering automacros, but sometimes one wants to batch turning in quests. For example, bounty boards. In these cases, it may be useful to know that all of a set of quests is complete, then turn in each one individually.

For example, the following macro turns in all of the "Guide" quests in the newbie castle, if they are complete, and only for the quests which are complete.
```
macro newbie_5 {
  if (&questCompleteCount(7123) == 1) {
    # Swordsman Guide
    call quest_talk new_1-3 '97 41' r3
    # <= quest 7123
    # => 200x Novice Potion
    # => 200/100 xp
  }

  if (&questCompleteCount(7124) == 1) {
    # Mage Guide
    call quest_talk new_1-3 '101 41' r3
    # <= quest 7124
    # => 30x Novice Butterfly Wing
    # => 200/100 xp
  }

  if (&questCompleteCount(7127) == 1) {
    # Thief Guide
    call quest_talk new_1-3 '105 41' r3
    # <= quest 7127
    # => 50x Novice Fly Wing
    # => 200/100 xp
  }

  if (&questCompleteCount(7126) == 1) {
    # Merchant Guide
    call quest_talk new_1-3 '109 41' r3
    # <= quest 7126
    # => 7x Phracon
    # => 200/100 xp
  }
}
```