### PR TITLE
bus: use json for data transport, new plugins

### DIFF
--- a/control/sys.txt
+++ b/control/sys.txt
@@ -49,7 +49,7 @@ loadPlugins 2
 # loadPlugins_list <list>
 #   if loadPlugins is set to 2, this comma-separated list of plugin names (filename without the extension)
 #   specifies which plugin files to load at startup or when the "plugin load all" command is used.
-loadPlugins_list macro,profiles,breakTime,raiseStat,raiseSkill,map,reconnect,eventMacro
+loadPlugins_list macro,profiles,breakTime,raiseStat,raiseSkill,map,reconnect,eventMacro,bus_hook,bus_party
 
 # skipPlugins_list <list>
 #   if loadPlugins is set to 3, this comma-separated list of plugin names (filename without the extension)

--- a/plugins/bus_hook/bus_hook.pl
+++ b/plugins/bus_hook/bus_hook.pl
@@ -1,0 +1,63 @@
+package OpenKore::Plugins::BusHook;
+###############################################################################
+# Plugin to connect to a Bus server and proxy Bus messages through hooks.
+
+use strict;
+
+use Bus::Client;
+use Log qw( &debug );
+
+our $name = 'bus_hook';
+our $bus;
+
+Plugins::register( $name, "$name plugin", \&Unload, \&Unload );
+
+my $hooks = Plugins::addHooks(    #
+	[ 'start3'       => \&onStart ],
+	[ 'mainLoop_pre' => \&onMainLoopPre ],
+	[ 'bus/send'     => \&onBusSend ],
+);
+
+sub Unload {
+	$bus = undef;
+	Plugins::delHooks( $hooks );
+}
+
+sub onStart {
+	return if $bus;
+
+	$bus = $Globals::bus || Bus::Client->new( userAgent => "$name plugin" );
+	$bus->onConnected->add( undef, \&onConnected );
+	$bus->onMessageReceived->add( undef, \&onMessageReceived );
+}
+
+sub onMainLoopPre {
+	onStart() if !$bus;
+	$bus->iterate;
+}
+
+sub onBusSend {
+	my ( undef, $msg ) = @_;
+	Plugins::callHook( 'bus/sent' => $msg );
+	debug "[$name] >> sent $msg->{messageID}\n", $name;
+	$bus->send( $msg->{messageID}, $msg->{args} );
+}
+
+# Ask for a list of other clients.
+sub onConnected {
+	debug "[$name] >> connected\n", $name;
+	onBusSend( undef, { messageID => 'LIST_CLIENTS2' } );
+	Plugins::callHook( 'bus/connect' );
+}
+
+sub onMessageReceived {
+	my ( undef, undef, $msg ) = @_;
+
+	my $mid  = $msg->{messageID};
+	my $args = $msg->{args};
+	debug "[$name] << received $mid\n", $name;
+	Plugins::callHook( 'bus/recv'      => $msg );
+	Plugins::callHook( "bus/recv/$mid" => $args );
+}
+
+1;

--- a/plugins/bus_party/bus_party.pl
+++ b/plugins/bus_party/bus_party.pl
@@ -1,0 +1,145 @@
+package OpenKore::Plugins::BusParty;
+###############################################################################
+# Plugin to update party information via bus.
+
+use strict;
+
+use Globals qw( $accountID $char %config $field $net @partyUsersID );
+use Log qw( &debug &message );
+use Utils qw( &binAdd &binFind &binRemove &calcPosition &timeOut );
+use Time::HiRes qw( &time );
+
+our $name = 'bus_party';
+our $timeout = { time => 0, timeout => 0.2 };
+our $bus_party ||= {};
+
+Plugins::register( $name, "$name plugin", \&Unload, \&Unload );
+
+my $hooks = Plugins::addHooks(    #
+	[ 'mainLoop_pre'           => \&onMainLoopPre ],
+	[ 'bus/connect'            => \&onBusConnect ],
+	[ 'bus/recv/PARTY_REQUEST' => \&onBusRecvPartyRequest ],
+	[ 'bus/recv/PARTY_UPDATE'  => \&onBusRecvPartyUpdate ],
+	[ 'bus/recv/LEAVE'         => \&onBusRecvLeave ],
+);
+
+sub Unload {
+	Plugins::delHooks( $hooks );
+}
+
+sub onMainLoopPre {
+    return if !timeOut($timeout);
+    $timeout->{time} = time;
+
+	my $party_update = partial_party_update();
+	return if !%$party_update;
+	Plugins::callHook( 'bus/send', { messageID => 'PARTY_UPDATE', args => $party_update } );
+}
+
+sub onBusConnect{
+	Plugins::callHook( 'bus/send', { messageID => 'PARTY_REQUEST' } );
+	Plugins::callHook( 'bus/send', { messageID => 'PARTY_UPDATE', args => full_party_update() } );
+}
+
+sub onBusRecvPartyRequest {
+	my ( undef, $args ) = @_;
+	Plugins::callHook( 'bus/send', { messageID => 'PARTY_UPDATE', TO => $args->{FROM}, args => full_party_update() } );
+}
+
+sub onBusRecvPartyUpdate {
+	my ( undef, $args ) = @_;
+	my $actor = $bus_party->{ $args->{FROM} } ||= {};
+	$actor->{$_} = $args->{$_} foreach keys %$args;
+
+	# Update the party.
+	my $id = pack 'V', $actor->{id};
+	return if !$actor->{id} || $id eq $accountID;
+	return if !$actor->{name};
+	return if !$char;
+	return if !$char->{party};
+
+	my $party_user = $char->{party}{users}{$id};
+	if ( binFind( \@partyUsersID, $id ) eq '' ) {
+		binAdd( \@partyUsersID, $id );
+	}
+	if ( !$party_user ) {
+		$party_user = $char->{party}{users}{$id} = Actor::Party->new;
+		$party_user->{ID} = $id;
+		message "[bot_party] Party Member: $args->{name}\n";
+	}
+
+	foreach ( qw( name online hp hp_max ) ) {
+		$party_user->{$_} = $actor->{$_};
+	}
+	$party_user->{bus_party} = $actor->{party};
+	$party_user->{map}       = "$actor->{map}.gat";
+	$party_user->{pos}->{x}  = $actor->{x};
+	$party_user->{pos}->{y}  = $actor->{y};
+}
+
+sub onBusRecvLeave {
+	my ( undef, $args ) = @_;
+
+    my $actor = $bus_party->{ $args->{clientID} };
+    return if !$actor;
+
+	# Remove the character from $char->{party} if they're not in our actual party.
+	my $id = pack 'V', $actor->{id};
+	if ( $char && $char->{party} && ( !$char->{party}->{name} || $actor->{party} ne $char->{party}->{name} ) && binFind( \@partyUsersID, $id ) ne '' ) {
+		delete $char->{party}->{users}->{$id};
+		binRemove( \@partyUsersID, $id );
+	}
+
+	delete $bus_party->{ $args->{clientID} };
+}
+
+sub full_party_update {
+	my $update = {};
+	$update->{followTarget} = $config{follow} && $config{followTarget} || '';
+	if ( $char ) {
+		my $pos = calcPosition( $char );
+		$update->{id}         = unpack 'V', $accountID;
+		$update->{name}       = $char->{name};
+		$update->{hp}         = $char->{hp};
+		$update->{hp_max}     = $char->{hp_max};
+		$update->{sp}         = $char->{sp};
+		$update->{sp_max}     = $char->{sp_max};
+		$update->{lv}         = $char->{lv};
+		$update->{xp}         = $char->{exp};
+		$update->{xp_max}     = $char->{exp_max};
+		$update->{jl}         = $char->{lv_job};
+		$update->{jp}         = $char->{exp_job};
+		$update->{jp_max}     = $char->{exp_job_max};
+		$update->{zeny}       = $char->{zeny};
+		$update->{status}     = $char->{statuses} && %{ $char->{statuses} } ? join ', ', keys %{ $char->{statuses} } : '';
+		$update->{x}          = $pos->{x};
+		$update->{y}          = $pos->{y};
+		$update->{weight}     = $char->{weight};
+		$update->{weight_max} = $char->{weight_max};
+		if ( $char->{party} ) {
+			$update->{party} = $char->{party}->{name} || '';
+			$update->{admin} = $char->{party}->{users}->{$accountID}->{admin} ? 1 : 0;
+		}
+	}
+	if ( $field ) {
+		$update->{map} = $field->baseName;
+	}
+	if ( $net ) {
+		$update->{online} = $net->getState == Network::IN_GAME ? 1 : 0;
+	}
+	$update;
+}
+
+sub partial_party_update {
+	our $last_update ||= {};
+	my $update  = full_party_update();
+	my $partial = {};
+	foreach ( keys %$update ) {
+		next if $last_update->{$_} eq $update->{$_};
+		$partial->{$_} = $update->{$_};
+	}
+	$last_update = $update;
+	$partial;
+}
+
+1;

--- a/src/Bus/MessageParser.pm
+++ b/src/Bus/MessageParser.pm
@@ -20,7 +20,7 @@ sub readNext {
 	my ($self, $ID) = @_;
 	my $processed;
 	my $args = unserialize($self->{buffer}, $ID, \$processed);
-	if ($args) {
+	if ($$ID) {
 		substr($self->{buffer}, 0, $processed, '');
 	}
 	return $args;

--- a/src/Bus/Messages.pm
+++ b/src/Bus/Messages.pm
@@ -90,9 +90,10 @@ use Exporter;
 use base qw(Exporter);
 use Encode;
 use Utils::Exceptions;
+use JSON;
 
 our @EXPORT_OK = qw(serialize unserialize);
-
+our $json = JSON->new->utf8->allow_nonref;
 
 ##
 # Bytes Bus::Messages::serialize(String ID, arguments)
@@ -104,50 +105,10 @@ our @EXPORT_OK = qw(serialize unserialize);
 #
 # This symbol is exportable.
 sub serialize {
-	my ($ID, $arguments) = @_;
-
-	# Header
-	my $options = (!$arguments || ref($arguments) eq 'HASH') ? 0 : 1;
-	my $ID_bytes = toBytes(\$ID);
-	my $data = pack("N C C a*",
-		0,			# Message length
-		$options,		# Options
-		length($$ID_bytes),	# ID length
-		$$ID_bytes);		# ID
-
-	if ($options == 0 && $arguments) {
-		# Key-value map arguments.
-		my ($key, $value);
-		while (($key, $value) = each %{$arguments}) {
-			my $key_bytes = toBytes(\$key);
-			my ($type, $value_bytes);
-			$value_bytes = valueToData(\$type, \$value);
-
-			$data .= pack("C a* C a3 a*",
-				length($$key_bytes),
-				$$key_bytes,
-
-				$type,
-				toInt24(length($$value_bytes)),
-				$$value_bytes
-			);
-		}
-
-	} elsif ($options == 1) {
-		# Array arguments.
-		foreach my $entry (@{$arguments}) {
-			my ($type, $value_bytes);
-			$value_bytes = valueToData(\$type, \$entry);
-			$data .= pack("C a3 a*",
-				$type,
-				toInt24(length($$value_bytes)),
-				$$value_bytes
-			);
-		}
-	}
-
-	substr($data, 0, 4, pack("N", length($data)));
-	return $data;
+	my ( $ID, $arguments ) = @_;
+	my $data = eval { $json->encode( { ID => $ID, args => $arguments } ) };
+	$data = 'null' if !defined $data;
+	pack( 'V', 4 + length $data ) . $data;
 }
 
 ##
@@ -167,144 +128,18 @@ sub serialize {
 # This symbol is exportable.
 sub unserialize {
 	my ($data, $r_ID, $processed) = @_;
-	my $dataLen = length($data);
-	return undef if ($dataLen < 4);
+	my $dataLen = length $data;
+	return if $dataLen < 4;
 
 	# Header
-	my $messageLen = unpack("N", $data);
-	return undef if ($dataLen < $messageLen);
-	my ($options, $ID) = unpack("x[N] C C/a", $data);
-	Encode::_utf8_on($ID);
-	if (!Encode::is_utf8($ID, 1)) {
-		UTF8MalformedException->throw("Malformed UTF-8 data in message ID.");
-	}
+	my $messageLen = unpack 'V', $data;
+	return if $dataLen < $messageLen;
 
-	my $offset = 6 + length($ID);
+	my $msg = $json->decode( substr $data, 4, $messageLen - 4 );
 
-	my $args;
-	if ($options == 0) {
-		# Key-value map arguments.
-		$args = {};
-		while ($offset < $messageLen) {
-			# Key and type.
-			my ($key, $type) = unpack("x[$offset] C/a C", $data);
-			Encode::_utf8_on($key);
-			if (!Encode::_utf8_on($key)) {
-				UTF8MalformedException->throw("Malformed UTF-8 data in key.");
-			}
-			$offset += 2 + length($key);
-
-			# Value length.
-			my ($valueLen) = substr($data, $offset, 3);
-			$valueLen = fromInt24($valueLen);
-			$offset += 3;
-
-			# Value.
-			my ($value) = substr($data, $offset, $valueLen);
-			dataToValue($type, \$value);
-
-			$args->{$key} = $value;
-			$offset += $valueLen;
-		}
-
-	} else {
-		# Array arguments.
-		$args = [];
-		while ($offset < $messageLen) {
-			# Type and length.
-			my ($type, $len) = unpack("x[$offset] C a3", $data);
-			$len = fromInt24($len);
-			$offset += 4;
-
-			# Value.
-			my ($value) = substr($data, $offset, $len);
-			dataToValue($type, \$value);
-
-			push @{$args}, $value;
-			$offset += $len;
-		}
-	}
-
-	$$r_ID = $ID;
-	$$processed = $messageLen if ($processed);
-	return $args;
-}
-
-# Converts a String to Bytes, with as little copying as possible.
-#
-# r_string: A reference to a String.
-# Returns: A reference to the UTF-8 data as Bytes.
-sub toBytes {
-	my ($r_string) = @_;
-	if (Encode::is_utf8($$r_string)) {
-		my $data = Encode::encode_utf8($$r_string);
-		return \$data;
-	} else {
-		return $r_string;
-	}
-}
-
-# Bytes toInt24(int i)
-# Ensures: length(result) == 3
-#
-# Converts a Perl scalar to a 24-bit unsigned big-endian integer.
-sub toInt24 {
-	my ($i) = @_;
-	return substr(pack("N", $i), 1, 3);
-}
-
-# int fromInt24(Bytes data)
-# Requires: length($data) == 3
-#
-# Convert a 24-bit unsigned big-endian integer to a Perl scalar.
-sub fromInt24 {
-	my ($data) = @_;
-	return unpack("N", "\0" . $data);
-}
-
-# Bytes* valueToData(int* type, Scalar* value)
-#
-# Autodetect the format of $data, and return a reference to a byte
-# string, to be used in serializing a message. The data type is
-# returned in $type.
-sub valueToData {
-	my ($type, $value) = @_;
-	if (!defined $$value) {
-		my $data = '';
-		$$type = 0;
-		return \$data;
-	} elsif ($$value =~ /^\d+$/) {
-		# Integer.
-		$$type = 2;
-		my $data = pack("N", $$value);
-		return \$data;
-	} elsif (Encode::is_utf8($$value)) {
-		# UTF-8 string.
-		$$type = 1;
-		my $data = Encode::encode_utf8($$value);
-		return \$data;
-	} else {
-		# Binary string.
-		$$type = 0;
-		return $value;
-	}
-}
-
-sub dataToValue {
-	my ($type, $r_value) = @_;
-	if ($type == 1) {
-		Encode::_utf8_on($$r_value);
-		if (!Encode::_utf8_on($$r_value)) {
-			UTF8MalformedException->throw("Malformed UTF-8 data in value.");
-		}
-	} elsif ($type == 2) {
-		if (length($$r_value) == 4) {
-			$$r_value = unpack("N", $$r_value);
-		} else {
-			DataFormatException->throw("Integer value with invalid length (" .
-				length($$r_value) . ") found.");
-		}
-	}
+	$$r_ID = $msg->{ID};
+	$$processed = $messageLen;
+	$msg->{args};
 }
 
 # sub testPerformance {

--- a/src/Bus/Server/AbstractServer.pm
+++ b/src/Bus/Server/AbstractServer.pm
@@ -123,8 +123,10 @@ sub onClientData {
 	my $parser = $client->{BAS_parser};
 	$parser->add($data);
 
-	my $ID;
-	while (my $args = $parser->readNext(\$ID)) {
+	while () {
+		my $ID;
+		my $args = $parser->readNext(\$ID);
+		last if !$ID;
 		$self->messageReceived($client, $ID, $args);
 	}
 }


### PR DESCRIPTION
* Change the `bus` transport mechanism from packed binary data to JSON.
* Add a `verbose` option to `Bus::Client`.
* Add a new built-in `CLIENT_LIST2` packet type, which returns data as an array of hashes instead of a flat hash.
* Add a new `bus_hook` plugin which converts bus messages into hook calls, and vice versa.
** Hook `bus/send` - allow plugins other than `bus_hook` to send bus messages.
** Hook `bus/sent` - called whenever `bus_hook` sends a bus message.
** Hook `bus/recv` - called whenever `bus_hook` receives a bus message.
** Hook `bus/recv/$MID` - where `$MID` is the actual message ID (eg, `JOIN` or `LEAVE`) - called whenever `bus_hook` receives a bus message with message ID equal to `$MID`
* Add a new `bus_party` plugin which sends party update packets every 0.2 seconds, and updates the party with data from the bus.
