### PR TITLE
make call on an automacro accept params

### DIFF
--- a/plugins/eventMacro/eventMacro/Automacro.pm
+++ b/plugins/eventMacro/eventMacro/Automacro.pm
@@ -86,6 +86,10 @@ sub get_parameter {
 	return $self->{parameters}{$parameter};
 }
 
+sub set_call {
+	my ($self, $parameters, $macro_name) = @_;
+	$self->{parameters}{'call'} = $macro_name;
+}
 sub set_parameters {
 	my ($self, $parameters) = @_;
 	foreach (keys %{$parameters}) {

--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -202,15 +202,14 @@ sub create_automacro_list {
 			}
 			###Parameter: call with or without param
 			if ($parameter->{'key'} eq "call" && $parameter->{'value'} =~ /(\S+)\s+(.*)?/) {
-				if (!$self->{Macro_List}->getByName($1) ) {
-					warning "[eventMacro] Ignoring automacro '$name' (call '".$1."' is not a valid macro name)\n";
+				my ($macro_name, $params) = ($1 , $2); 
+				
+				if (!$self->{Macro_List}->getByName($macro_name) ) {
+					warning "[eventMacro] Ignoring automacro '$name' (call '".$macro_name."' is not a valid macro name)\n";
 					next AUTOMACRO;
 				} else {
-					if (defined $2) {
-						#put both values together in call name, split later in sub call_macro
-						$parameter->{'value'} = join (" ",$1,$2);
-					} else {
-						$parameter->{'value'} = $1;
+					unless (defined $params) {
+					$parameter->{'value'} = $macro_name;
 					}
 					$currentParameters{$parameter->{'key'}} = $parameter->{'value'};
 				}
@@ -1494,6 +1493,7 @@ sub call_macro {
 
 		# Update $.paramN with the values from the call.
 		$eventMacro->set_scalar_var( ".param$_", $params[ $_ - 1 ], 0 ) foreach 1 .. @params;
+		$eventMacro->set_scalar_var( ".param$_", undef,             0 ) foreach ( @params + 1 ) .. 100;
 		
 		$automacro->set_call('call', $macro_name);
 	}

--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -1485,6 +1485,8 @@ sub call_macro {
 	my ($self, $automacro) = @_;
 	if (defined $self->{Macro_Runner}) {
 		$self->clear_queue();
+	}
+	
 	if ($automacro->get_parameter('call') =~ /\s+/) {
 		
 		#here the macro name and the params are together in get_parameter, time to split

--- a/plugins/eventMacro/eventMacro/FileParser.pm
+++ b/plugins/eventMacro/eventMacro/FileParser.pm
@@ -113,7 +113,7 @@ sub parseMacroFile {
 				}
 				
 				
-			} elsif ($_ =~ /call [^{]/) {
+			} elsif (/call [^{]/) {
 				my ($key, $value, $param) = $_ =~ /^(call)\s+(\S+)(?:\s*(.*))?/;
 				if (!defined $key || !defined $value) {
 					warning "$file: ignoring '$_' in line $. (munch, munch, not a pair)\n";

--- a/plugins/eventMacro/eventMacro/FileParser.pm
+++ b/plugins/eventMacro/eventMacro/FileParser.pm
@@ -32,7 +32,6 @@ my %automacro;
 
 sub parseMacroFile {
 	my ($file, $recursive) = @_;
-	
 	unless ($recursive) {
 		undef %macro;
 		undef %automacro;
@@ -49,7 +48,6 @@ sub parseMacroFile {
 		s/^\s+|\s+$//gos;   # trim leading and trailing whitespace
 		s/  +/ /g;          # trim down spaces - very cool for user's string data?
 		next unless ($_);
-
 		if (!%block && /{$/) {
 			my ($key, $value) = $_ =~ /^(.*?)\s+(.*?)\s*{$/;
 			if ($key eq 'macro') {
@@ -113,6 +111,19 @@ sub parseMacroFile {
 				} else {
 					undef %block
 				}
+				
+				
+			} elsif ($_ =~ /call [^{]/) {
+				my ($key, $value, $param) = $_ =~ /^(call)\s+(\S+)(?:\s*(.*))?/;
+				if (!defined $key || !defined $value) {
+					warning "$file: ignoring '$_' in line $. (munch, munch, not a pair)\n";
+					next;
+				}
+				#check if macro is being called with params or not
+				if (defined $param) {
+					$value = join (' ', $value,$param);
+				} 
+				push(@{$automacro{$block{name}}{parameters}}, {key => 'call', value => $value});
 			} elsif ($_ eq "call {") {
 				$block{loadmacro} = 1;
 				$block{loadmacro_name} = "tempMacro".$tempmacro++;

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1407,13 +1407,12 @@ sub parse_call {
 
 	my $macro_name   = $call_command;
 	my $repeat_times = 1;
-	if ( $call_command =~ /\s/ ) {
+	if ( $call_command =~ /\s+/ ) {
 	    my @params;
 		( $macro_name, @params ) = parseArgs( $call_command );
 
 		# Update $.paramN with the values from the call.
 		$eventMacro->set_scalar_var( ".param$_", $params[ $_ - 1 ], 0 ) foreach 1 .. @params;
-		$eventMacro->set_scalar_var( ".param$_", undef,             0 ) foreach ( @params + 1 ) .. 100;
 	}
 
 	my $parsed_macro_name = $self->parse_command($macro_name);

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1413,6 +1413,7 @@ sub parse_call {
 
 		# Update $.paramN with the values from the call.
 		$eventMacro->set_scalar_var( ".param$_", $params[ $_ - 1 ], 0 ) foreach 1 .. @params;
+		$eventMacro->set_scalar_var( ".param$_", undef,             0 ) foreach ( @params + 1 ) .. 100;
 	}
 
 	my $parsed_macro_name = $self->parse_command($macro_name);


### PR DESCRIPTION
Before, the only way to make call accept params is the call from inside a macro.
So you had to do something like this to get what you want:
```
automacro goSave {
    ConfigKeyNot saveMap prontera 
    call {
        call saveIn "prontera" "100 100"
    }
}
```
but with this update, the call of an automacro accepts directly the params, like this:
```
automacro goSave {
    ConfigKeyNot saveMap prontera 
    call saveIn "prontera" "100 100"
}
```

Obs: **macros cannot have spaces in name!!!!**
there shouldn't be even possible to add space in name, but its a feature not implemented yet.

i would like to thank **@Henrybk** for giving me tips to do this  and **@allanon** for made the call on macros to accept params in the first place, that piece of code was very useful to me.

Tested with this macro and working great:
```
automacro test_with_params {
	BaseLevel > 0
	exclusive 1
	run-once 1
	priority 1
	call test_macro "aldebaran" "170 155"
}

automacro test_without_params {
	BaseLevel > 0
	exclusive 1
	run-once 1
	priority -5
	call test_macro
}

macro test_macro {
	log param1 is : $.param1
	log param2 is : $.param2
	log $.caller running the macro without erros
}
```