### PR TITLE
fix memory leak with shuffle.txt and sync.txt upon relog

### DIFF
--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -669,6 +669,7 @@ sub new {
 	my %sync_ex;
 	my $load_sync = Settings::addTableFile( 'sync.txt', loader => [ \&FileParsers::parseDataFile2, \%sync_ex ], mustExist => 0 );
 	Settings::loadByHandle( $load_sync );
+	Settings::removeFile( $load_sync );
 
 	foreach ( keys %sync_ex ) {
 		$self->{packet_list}{$_}   = ['sync_request_ex'];

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -178,6 +178,7 @@ sub shuffle {
 	my %shuffle;
 	my $load_shuffle = Settings::addTableFile( 'shuffle.txt', loader => [ \&FileParsers::parseDataFile2, \%shuffle ], mustExist => 0 );
 	Settings::loadByHandle( $load_shuffle );
+	Settings::removeFile( $load_shuffle );
 
 	# Build the list of changes. Be careful to handle swaps correctly.
 	my $new = {};


### PR DESCRIPTION
Symptom, after a few relogs:
```
> reload shuffle.txt
Loading tables/iRO/Restart/shuffle.txt...
Loading tables/iRO/Restart/shuffle.txt...
Loading tables/iRO/Restart/shuffle.txt...
Loading tables/iRO/Restart/shuffle.txt...
Loading tables/iRO/Restart/shuffle.txt...
[more of the same...]
```

Note that due to the way this is implemented, and how and when the network objects are instantiated:
* `reload shuffle.txt` and `reload sync.txt` didn't (and don't) do anything useful
* `shuffle.txt` and `sync.txt` get reloaded every time we relog, which can be dangerous for devs testing old feature branches on a server which requires these files
