### PR TITLE
fix call bug, moved $.param to array

### DIFF
--- a/plugins/eventMacro/eventMacro/Automacro.pm
+++ b/plugins/eventMacro/eventMacro/Automacro.pm
@@ -90,6 +90,7 @@ sub set_call {
 	my ($self, $parameters, $macro_name) = @_;
 	$self->{parameters}{'call'} = $macro_name;
 }
+
 sub set_parameters {
 	my ($self, $parameters) = @_;
 	foreach (keys %{$parameters}) {

--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -1491,8 +1491,8 @@ sub call_macro {
 		#here the macro name and the params are together in get_parameter, time to split
 		my ($macro_name, @params) = parseArgs($automacro->get_parameter('call'));
 
-		# Update $.paramN with the values from the call.
-		$eventMacro->set_full_array( ".param", \@params );
+		# Update $.param[0] with the values from the call.
+		$eventMacro->set_full_array( ".param", \@params);
 
 		$automacro->set_call('call', $macro_name);
 	}

--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -1492,9 +1492,8 @@ sub call_macro {
 		my ($macro_name, @params) = parseArgs($automacro->get_parameter('call'));
 
 		# Update $.paramN with the values from the call.
-		$eventMacro->set_scalar_var( ".param$_", $params[ $_ - 1 ], 0 ) foreach 1 .. @params;
-		$eventMacro->set_scalar_var( ".param$_", undef,             0 ) foreach ( @params + 1 ) .. 100;
-		
+		$eventMacro->set_full_array( ".param", \@params );
+
 		$automacro->set_call('call', $macro_name);
 	}
 	

--- a/plugins/eventMacro/eventMacro/FileParser.pm
+++ b/plugins/eventMacro/eventMacro/FileParser.pm
@@ -113,7 +113,7 @@ sub parseMacroFile {
 				}
 				
 				
-			} elsif (/call [^{]/) {
+			} elsif (/call [^{]/ && !$macro{$block{loadmacro_name}}) {
 				my ($key, $value, $param) = $_ =~ /^(call)\s+(\S+)(?:\s*(.*))?/;
 				if (!defined $key || !defined $value) {
 					warning "$file: ignoring '$_' in line $. (munch, munch, not a pair)\n";

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1411,9 +1411,8 @@ sub parse_call {
 	    my @params;
 		( $macro_name, @params ) = parseArgs( $call_command );
 
-		# Update $.paramN with the values from the call.
-		$eventMacro->set_scalar_var( ".param$_", $params[ $_ - 1 ], 0 ) foreach 1 .. @params;
-		$eventMacro->set_scalar_var( ".param$_", undef,             0 ) foreach ( @params + 1 ) .. 100;
+		# Update $.param[n] with the values from the call.
+		$eventMacro->set_full_array( ".param", \@params );
 	}
 
 	my $parsed_macro_name = $self->parse_command($macro_name);

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1412,7 +1412,7 @@ sub parse_call {
 		( $macro_name, @params ) = parseArgs( $call_command );
 
 		# Update $.param[n] with the values from the call.
-		$eventMacro->set_full_array( ".param", \@params );
+		$eventMacro->set_full_array( ".param", \@params);
 	}
 
 	my $parsed_macro_name = $self->parse_command($macro_name);


### PR DESCRIPTION
when i've last implemented the parameters on an automacro call, a very serious bug appeared making every automacro that has a submacro that call another, to be ignored...

```
automacro test {
    BaseLevel > 0
    run-once 1
    exclusive 1
    call {
        call anotherMacro
    }
}
```

this automacro above do not run, it points out the error "parameter call duplicate"
this pull request fix this error 


move from $paramN to an array, which is much more natural
now instead of using:
`$.param1` or `$.param2`
you use `$.param[0]` or `$.param[1]`