### PR TITLE
fix for unmatched lastmatchs

### DIFF
--- a/plugins/macro/Macro/Utilities.pm
+++ b/plugins/macro/Macro/Utilities.pm
@@ -144,7 +144,7 @@ sub match {
 		if ($text =~ /$1/ || ($2 eq 'i' && $text =~ /$1/i)) {
 			if (!defined $cmpr) {
 				no strict;
-				foreach my $idx (1..$#-) {$varStack{".lastMatch$idx"} = ${$idx}}
+				foreach my $idx (1..$#+) {$varStack{".lastMatch$idx"} = ${$idx}}
 				use strict;
 			}
 			return 1


### PR DESCRIPTION
I have found a problem with the latest "lastMatch$idx" variable not being updated if a macro triggers with an empty match, really tricky!, here are repro steps:

1) create anautomacro:

```
automacro bug {
    party /^bug(\d+)?$/i
    call {
        $var = "foo"
        if ($.lastMatch1 != "") {
            $var = "bar"
        }
        log $var
    }
}
```

2) trigger the automacro

2.1) chat (by party in this case) "bug"
2.2) chat (by party in this case) "bug1"
2.3) chat (by party in this case) "bug"

3) check console

**RESULT:**

```
[Party] DummyPlayerName : bug
[macro] automacro bug triggered.
[macro log] "foo"
[Narty] DummyPlayername : bug1
[macro] automacro bug triggered.
[macro log] "bar"
[Narty] DummyPlayername : bug
[macro] automacro bug triggered.
[macro log] "bar"
```

**EXPECTED**

```
[Party] DummyPlayername : bug
[macro] automacro bug triggered.
[macro log] "foo"
[Narty] DummyPlayername : bug1
[macro] automacro bug triggered.
[macro log] "bar"
[Narty] DummyPlayername : bug
[macro] automacro bug triggered.
[macro log] "foo"
```

**detected problem:**
After step 2.2, `$.lastMatch1` is set to "1", but step 2.3, the match is empty, and not updated correctly, staying as "1" for next trigger, this is caused by the  `$#-` expression which find the last matched subgroup[1] causing the issue. Instead, if this is replaced with `$#+` it will consider all subgroups in the regular expression, not only matched, fixing the issue.

This pull request fixes the problem, updating the highest "lastMatch" index even if it was an empty match

**documentation:**
[1] https://perldoc.perl.org/perlvar.html

PD: I know this is a plugin, but could not find the repository, but since this code is in this repo, I expect this pull request to be accepted here, thanks