### PR TITLE
Changes to cmdParty

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -4626,4 +4626,11 @@ sub CharacterLogin {
 	}
 }
 
+sub getPartyLeaderName {
+	foreach (@partyUsersID) {
+		return $char->{'party'}{'users'}{$_}{'name'} if ($char->{'party'}{'users'}{$_}{'admin'});
+	}
+	
+}
+
 return 1;


### PR DESCRIPTION
* Add share|shareitem|sharediv info to cmd 'party'
* Check if we're in a party to use any party subcommand other than join|create
* `party leader` without $arg2 now shows the leader name
* `party share 0|1` now keeps the current setting for `shareitem `and `sharediv `instead of defaulting to config
* `party shareitem 0|1` now keeps the current setting for `share `and `sharediv `instead of defaulting to config
* `party sharediv 0|1` now keeps the current setting for `share `and `shareitem `instead of defaulting to config
* `party share|shareitem|sharediv` without $arg2 now shows the current setting
* Find party leader name algorithm to Misc as `getPartyLeaderName`