### PR TITLE
[eventMacro.pl] SimpleHookEvent get Hook Variables

### DIFF
--- a/plugins/eventMacro/eventMacro/Condition/SimpleHookEvent.pm
+++ b/plugins/eventMacro/eventMacro/Condition/SimpleHookEvent.pm
@@ -30,6 +30,7 @@ sub validate_condition {
 	
 	#always true
 	$self->{last_hook} = $callback_name;
+	$self->{vars} = \%$args;
 	
 	return $self->SUPER::validate_condition( 1 );
 }
@@ -39,6 +40,9 @@ sub get_new_variable_list {
 	my $new_variables;
 	
 	$new_variables->{".".$self->{name}."Last"} = $self->{last_hook};
+	while( my( $key, $value ) = each %{$self->{vars}} ){
+		$new_variables->{".".$self->{name}."Last".ucfirst($key)} = $value;
+	}
 	
 	return $new_variables;
 }


### PR DESCRIPTION
Now we get all variables from hook in SimpleEventHook which basically supports all non implemented hooks in one go.
Tested like:

```
automacro test{
SimpleHookEvent zeny_change
call test
}

macro test{
[
	log $.SimpleHookEventLast
	log $.SimpleHookEventLastChange
	log $.SimpleHookEventLastZeny
]
}
```

got 

> [Sep 12 10:04:45 2017.86] You lost 50 zeny.
> [Sep 12 10:04:45 2017.86] [eventMacro] Event of type 'hook', and of name 'zeny_change' activated automacro 'test', calling macro 'test '
> [Sep 12 10:04:45 2017.86] Item added to inventory: Rod [3] (20) x 1 - Weapon
> [Sep 12 10:04:45 2017.86] Buy completed.
> [Sep 12 10:04:45 2017.86] [eventmacro log] SimpleHookEvent
> [Sep 12 10:04:46 2017.87] [eventmacro log] -50
> [Sep 12 10:04:47 2017.88] [eventmacro log] 59235