### PR TITLE
[eventMacro.pl] if parsing fix

### DIFF
--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -660,7 +660,7 @@ sub define_next_valid_command {
 		# Initial 'if'
 		######################################
 		} elsif ($self->{current_line} =~ /^if\s/) {
-			my ($condition_text, $post_if) = $self->{current_line} =~ /^if\s+\(\s*(.*)\s*\)\s+(goto\s+.*|call\s+.*|stop|{|)\s*/;
+			my ($condition_text, $post_if) = $self->{current_line} =~ /^if\s+\(\s*(.*)\s*\)\s*(goto\s+.*|call\s+.*|stop|{|)\s*/;
 
 			debug "[eventMacro] Script is a 'if' condition.\n", "eventMacro", 3;
 			


### PR DESCRIPTION
if (<condition>){ <- error
if (<condition>) { <- not error
if (<condition>)call <- error
if (<condition>) call <- not error
if (<condition>)goto <- error
if (<condition>) goto <- not error
but why?
....
fixed