### PR TITLE
eventMacro fix bug on sub statment in Runner.pm

### DIFF
--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1038,7 +1038,7 @@ sub next {
 			} elsif ($value =~ /^([+-]{2})$/i) {
 				my $change = (($1 eq '++') ? (1) : (-1));
 				
-				my $old_value = ($eventMacro->defined_var($var->{type}, $var->{real_name}, $complement) ? ($eventMacro->get_var($var->{type}, $var->{real_name})) : 0);
+				my $old_value = ($eventMacro->defined_var($var->{type}, $var->{real_name}, $complement) ? ($eventMacro->get_var($var->{type}, $var->{real_name}, $complement)) : 0);
 				$eventMacro->set_var(
 					$var->{type}, 
 					$var->{real_name}, 


### PR DESCRIPTION
before this PR, when you type something like:
`$hash{value}++` or `$hash{value}--`
`@array[0]++` or `@array[0]--`
the value was not corretly updated, but with scalar variables works fine.

this PR fix the bug.