### PR TITLE
eventMacro - Add hash variables support for SimpleHookEvent

### DIFF
--- a/plugins/eventMacro/eventMacro/Condition/SimpleHookEvent.pm
+++ b/plugins/eventMacro/eventMacro/Condition/SimpleHookEvent.pm
@@ -41,8 +41,15 @@ sub get_new_variable_list {
 	
 	$new_variables->{".".$self->{name}."Last"} = $self->{last_hook};
 	while( my( $key, $value ) = each %{$self->{vars}} ){
-		$new_variables->{".".$self->{name}."Last".ucfirst($key)} = $value;
+		if(ref($value) eq "HASH"){
+			while ( my( $hash_key, $hash_value ) = each %{$value} ) {
+				$new_variables->{".".$self->{name}."Last".ucfirst($key).ucfirst($hash_key)} = $hash_value
+			}
+		}else{
+			$new_variables->{".".$self->{name}."Last".ucfirst($key)} = $value;
+		}
 	}
+
 	
 	return $new_variables;
 }


### PR DESCRIPTION
https://github.com/OpenKore/openkore/issues/1256
This patch add possibility to get hash args from SimpleHookEvent call.
```
$.SimpleHookEventLast<capitalized hash name><capitalized hash key>
```
Macro example (to get sold item name):
```
automacro vend {
	SimpleHookEvent vending_item_sold
	call {
		log $.SimpleHookEventLastVendArticleName
	}
}
```