### PR TITLE
Fix bug in support skill use

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -719,8 +719,8 @@ sub processSkillUse {
 				}
 				
 				if ($skillsArea{$handle} == 2) {
-					$target = $accountID;
-				} elsif ($args->{x} ne "") {
+					$target = Actor::get($accountID);
+				} elsif ($args->{x} && $args->{y}) {
 					$target = { x => $args->{x}, y => $args->{y} };					
 				} elsif(!$args->{target}) {
 						AI::dequeue;
@@ -728,11 +728,14 @@ sub processSkillUse {
 				} else {
 					$actorList = $monstersList;
 					$target = $monstersList->getByID($args->{target});
+					if (!$target) {
+						$target = Actor::get($accountID);
+					}
 				}
 				
 				undef $char->{permitSkill};
 				$args->{skill_use_last} = $char->{skills}{$handle}{time_used};				
-				$args->{maxCastTime}{time} = time;				
+				$args->{maxCastTime}{time} = time;
 				
 				my $skillTask = new Task::UseSkill(
 					actor => $skill->getOwner,


### PR DESCRIPTION
Introduced by #1154 

Before
```
Auto-skill on self: Envenenar Arma (lvl 6)
UseSkill - Created preparation subtask.
Skill Use on Location: 138, (, )  <<<<<<<<<<<<<<<-- Trying to use support skill on null location
UseSkill - Preparation subtask completed with success, waiting for cast to start...
Skill Use on Location: 138, (, ) <<<<<<<<<<<<<<<-- Trying to use support skill on null location
UseSkill - Timeout, recasting skill.
Skill Use on Location: 138, (, ) <<<<<<<<<<<<<<<-- Trying to use support skill on null location
UseSkill - Timeout, recasting skill.
UseSkill - Timeout, maximum tries reached.
Não foi possível usar a habilidade Envenenar Arma em 3 tentativas.
Received packet: 0110 Handler: skill_use_failed
Habilidade Envenenar Arma falhou: Pré-Requisito (erro 10)
Received packet: 0110 Handler: skill_use_failed
Habilidade Envenenar Arma falhou: Pré-Requisito (erro 10)
AI: skill_use attack route | 4
Received packet: 0110 Handler: skill_use_failed
```