### PR TITLE
plugin: eventMacro: fix issue in getQuestStatus

### DIFF
--- a/plugins/eventMacro/eventMacro/Utilities.pm
+++ b/plugins/eventMacro/eventMacro/Utilities.pm
@@ -204,6 +204,8 @@ sub getQuestStatus {
 			$result->{$quest_id} = 'incomplete';
         } elsif ( grep { $_->{goal} && $_->{count} < $_->{goal} } values %{ $quest->{missions} } ) {
 			$result->{$quest_id} = 'incomplete';
+        } elsif ( grep { !$_->{goal} && $_->{count} == 0 } values %{ $quest->{missions} } ) {
+			$result->{$quest_id} = 'incomplete';
 		} else {
 			$result->{$quest_id} = 'complete';
 		}


### PR DESCRIPTION
getQuestStatus reported complete on newly added quests.
Since there's no goal property in a newly added quest, getQuestStatus subroutine always returns complete on such quests until relogging. This patch addresses this bug.