### PR TITLE
[eventMacro][bugfix] whitespace support for hashes

### DIFF
--- a/plugins/eventMacro/eventMacro/Utilities.pm
+++ b/plugins/eventMacro/eventMacro/Utilities.pm
@@ -529,6 +529,8 @@ sub find_accessed_variable {
 		my $name = $1;
 		my $open_bracket = $2;
 		my $complement = $3;
+		$complement =~ s/^\s+//;
+		$complement =~ s/\s+$//;
 		return if (!defined $complement || $complement eq '');
 		my $close_bracket = $4;
 		
@@ -543,7 +545,7 @@ sub find_accessed_variable {
 			return if ($complement !~ /^\d+$/ && !find_variable($complement));
 			
 		} elsif ($type eq 'accessed_hash') {
-			return if ($complement !~ /^[a-zA-Z\d]+$/ && !find_variable($complement));
+			return if ($complement !~ /^[a-zA-Z\d ]+$/ && !find_variable($complement));
 		}
 		
 		my $original_name = ('$'.$name.$open_bracket.$complement.$close_bracket);


### PR DESCRIPTION
found a little bug while i was wrinting a new macro:
### the macro:
```perl
automacro defineHash {
	BaseLevel > 0
	run-once 1
	exclusive 1
	disabled 0
	call {
		log creating hashes values and keys
		$hash{noSpace} = 1
		log created noSpace
		$hash{ has Space } = 1
		log created has Space
		$hash{ noSpaceAgain } = 1
		log created noSpaceAgain
		$hash{has More Space} = 1
		log created has More Space
	}
}
```
### the bug:
![bug fix before](https://user-images.githubusercontent.com/11494727/32037292-6b5f1ab0-ba03-11e7-8c26-54be4d044f15.png)

with these new changes it works normally:
### working pic:
![bug fix after](https://user-images.githubusercontent.com/11494727/32037306-7b437548-ba03-11e7-8f84-14d09eb9bd0b.png)

