### PR TITLE
skill_used_no_damage null amount

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3523,7 +3523,7 @@ sub skillUseNoDamage_string {
 		$skillName,
 		T('on'),
 		$target->nameString($source),
-		($skillID == 28) ? ' ' . TF("(Gained: %s hp)", $amount) : ($amount) ? ' ' . TF("(Lv: %s)", $amount) : '');
+		($skillID == 28) ? ' ' . TF("(Gained: %s hp)", $amount) : ($amount && $amount != 65535 && $amount != 4294967295) ? ' ' . TF("(Lv: %s)", $amount) : '');
 }
 
 sub status_string {

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3490,7 +3490,7 @@ sub skillUse_string {
 		$source->nameString(),
 		$source->verb(T('use'), T('uses')),
 		$skillName,
-		($level != 65535) ? ' ' . TF("(Lv: %s)", $level) : '',
+		($level != 65535 && $level != 4294967295) ? ' ' . TF("(Lv: %s)", $level) : '',
 		T('on'),
 		$target->nameString($source),
 		($damage != -30000) ? ' ' . TF("(Dmg: %s)", $damage || T('Miss')) : '',
@@ -3505,7 +3505,7 @@ sub skillUseLocation_string {
 		$source->nameString(),
 		$source->verb(T('use'), T('uses')),
 		$skillName,
-		($args->{lv} != 65535) ? ' ' . TF("(Lv: %s)", $args->{lv}) : '',
+		($args->{lv} != 65535 && $args->{lv} != 4294967295) ? ' ' . TF("(Lv: %s)", $args->{lv}) : '',
 		T('on location'),
 		$args->{x},
 		$args->{y});

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -3640,7 +3640,7 @@ sub skill_used_no_damage {
 	if ($args->{skillID} == 28) {
 		$extra = ": $args->{amount} hp gained";
 		updateDamageTables($args->{sourceID}, $args->{targetID}, -$args->{amount});
-	} elsif ($args->{amount} != 65535) {
+	} elsif ($args->{amount} != 65535 && $args->{amount} != 4294967295) {
 		$extra = ": Lv $args->{amount}";
 	}
 

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -3125,7 +3125,7 @@ sub skill_used_no_damage {
 	if ($args->{skillID} == 28) {
 		$extra = ": $args->{amount} hp gained";
 		updateDamageTables($args->{sourceID}, $args->{targetID}, -$args->{amount});
-	} elsif ($args->{amount} != 65535) {
+	} elsif ($args->{amount} != 65535 && $args->{amount} != 4294967295) {
 		$extra = ": Lv $args->{amount}";
 	}
 


### PR DESCRIPTION
Support skill_used_no_damage long VAX null amount

Avoids showing "Lv: 4294967295" on skills (i.e. Hiding)
