### PR TITLE
eventMacro MVP HOOK 

### DIFF
--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -2198,6 +2198,10 @@ sub mvp_item {
 	my $display = itemNameSimple($args->{itemID});
 	message TF("Get MVP item %s\n", $display);
 	chatLog("k", TF("Get MVP item %s\n", $display));
+	
+	Plugins::callHook('packet_mvp_item', {
+		display => $display
+	});	
 }
 
 sub mvp_other {
@@ -2205,6 +2209,10 @@ sub mvp_other {
 	my $display = Actor::get($args->{ID});
 	message TF("%s become MVP!\n", $display);
 	chatLog("k", TF("%s become MVP!\n", $display));
+	
+	Plugins::callHook('packet_mvp_other', {
+		display => $display
+	});	
 }
 
 sub mvp_you {
@@ -2212,6 +2220,9 @@ sub mvp_you {
 	my $msg = TF("Congratulations, you are the MVP! Your reward is %s exp!\n", $args->{expAmount});
 	message $msg;
 	chatLog("k", $msg);
+	
+	Plugins::callHook('packet_mvp_you', {
+		msg => $msg	
 }
 
 sub npc_sell_list {

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -1881,6 +1881,10 @@ sub mvp_item {
 	my $display = itemNameSimple($args->{itemID});
 	message TF("Get MVP item %s\n", $display);
 	chatLog("k", TF("Get MVP item %s\n", $display));
+	
+	Plugins::callHook('packet_mvp_item', {
+		display => $display
+	});		
 }
 
 sub mvp_other {
@@ -1888,6 +1892,10 @@ sub mvp_other {
 	my $display = Actor::get($args->{ID});
 	message TF("%s become MVP!\n", $display);
 	chatLog("k", TF("%s become MVP!\n", $display));
+	
+	Plugins::callHook('packet_mvp_other', {
+		display => $display
+	});	
 }
 
 sub mvp_you {
@@ -1895,6 +1903,10 @@ sub mvp_you {
 	my $msg = TF("Congratulations, you are the MVP! Your reward is %s exp!\n", $args->{expAmount});
 	message $msg;
 	chatLog("k", $msg);
+	
+	Plugins::callHook('packet_mvp_you', {
+		msg => $msg
+	});			
 }
 
 sub npc_sell_list {


### PR DESCRIPTION
```
automacro hookmvp1 {
    SimpleHookEvent packet_mvp_other
	timeout 1
    call {
		log packetmvpother work ! 
	}
}
[eventMacro] Event of type 'hook', and of name 'packet_mvp_other' activated automacro 'hookmvp1', calling macro 'tempMacro0'
[eventmacro log] packetmvpother work !
```
```
automacro hookmvp2 {
    SimpleHookEvent packet_mvp_item
	timeout 1
    call {
		log packet_mvp_item work ! 
	}
}
Get MVP item Yggdrasilberry
[eventMacro] Event of type 'hook', and of name 'packet_mvp_item' activated automacro 'hookmvp1', calling macro 'tempMacro1'
[eventmacro log] packet_mvp_item work !
```


Now packet_mvp_you not work . idk why ! 