### PR TITLE
[Pserver]Fix recv for client 201311+

### DIFF
--- a/src/Network/Receive/kRO/RagexeRE_2013_08_07a.pm
+++ b/src/Network/Receive/kRO/RagexeRE_2013_08_07a.pm
@@ -25,7 +25,7 @@ sub new {
 		'09CA' => ['area_spell_multiple3', 'v a*', [qw(len spellInfo)]], # -1
 		'09CB' => ['skill_used_no_damage', 'v2 v a4 a4 C', [qw(skillID lv amount targetID sourceID success)]], # 17
 		#'09CB' => ['skill_used_no_damage', 'v v x2 a4 a4 C', [qw(skillID amount targetID sourceID success)]],  #16
-
+		'08C8' => ['actor_action', 'a4 a4 a4 V3 x v C V', [qw(sourceID targetID tick src_speed dst_speed damage div type dual_wield_damage)]],
 	);
 
 	foreach my $switch (keys %packets) { $self->{packet_list}{$switch} = $packets{$switch}; }

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -371,7 +371,6 @@ sub new {
 		'0977' => ['monster_hp_info', 'a4 V V', [qw(ID hp hp_max)]],
 		'0983' => ['actor_status_active', 'v a4 C V5', [qw(type ID flag total tick unknown1 unknown2 unknown3)]],
 		'0984' => ['actor_status_active', 'a4 v V5', [qw(ID type total tick unknown1 unknown2 unknown3)]],
-		'08C8' => ['actor_action', 'a4 a4 a4 V3 x v C V', [qw(sourceID targetID tick src_speed dst_speed damage div type dual_wield_damage)]],
 		};
 
 	# Item RECORD Struct's

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -370,7 +370,8 @@ sub new {
 		'08C8' => ['actor_action', 'a4 a4 a4 V3 x v C V', [qw(sourceID targetID tick src_speed dst_speed damage div type dual_wield_damage)]],
 		'0977' => ['monster_hp_info', 'a4 V V', [qw(ID hp hp_max)]],
 		'0983' => ['actor_status_active', 'v a4 C V5', [qw(type ID flag total tick unknown1 unknown2 unknown3)]],
-		'0984' => ['actor_status_active', 'a4 v V5', [qw(ID type total tick unknown1 unknown2 unknown3)]],		
+		'0984' => ['actor_status_active', 'a4 v V5', [qw(ID type total tick unknown1 unknown2 unknown3)]],
+		'08C8' => ['actor_action', 'a4 a4 a4 V3 x v C V', [qw(sourceID targetID tick src_speed dst_speed damage div type dual_wield_damage)]],
 		};
 
 	# Item RECORD Struct's

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -364,6 +364,13 @@ sub new {
 		'0A00' => ['hotkeys'],	
 		'0AC4' => ['account_server_info', 'x2 a4 a4 a4 a4 a26 C x17 a*', [qw(sessionID accountID sessionID2 lastLoginIP lastLoginTime accountSex serverInfo)]],
 		'0A37' => ['inventory_item_added', 'a2 v2 C3 a8 V C2 a4 v a25', [qw(ID amount nameID identified broken upgrade cards type_equip type fail expire unknown options)]],
+		'09DB' => ['actor_moved', 'v C a4 a4 v3 V v5 a4 v6 a4 a2 v V C2 a6 C2 v2 a9 Z*', [qw(len object_type ID charID walk_speed opt1 opt2 option type hair_style weapon shield lowhead tick tophead midhead hair_color clothes_color head_dir costume guildID emblemID manner opt3 stance sex coords xSize ySize lv font opt4 name)]],
+		'09DC' => ['actor_connected', 'v C a4 a4 v3 V v11 a4 a2 v V C2 a3 C2 v2 a9 Z*', [qw(len object_type ID charID walk_speed opt1 opt2 option type hair_style weapon shield lowhead tophead midhead hair_color clothes_color head_dir costume guildID emblemID manner opt3 stance sex coords xSize ySize lv font opt4 name)]],
+		'09DD' => ['actor_exists', 'v C a4 a4 v3 V v11 a4 a2 v V C2 a3 C3 v2 a9 Z*', [qw(len object_type ID charID walk_speed opt1 opt2 option type hair_style weapon shield lowhead tophead midhead hair_color clothes_color head_dir costume guildID emblemID manner opt3 stance sex coords xSize ySize act lv font opt4 name)]],
+		'08C8' => ['actor_action', 'a4 a4 a4 V3 x v C V', [qw(sourceID targetID tick src_speed dst_speed damage div type dual_wield_damage)]],
+		'0977' => ['monster_hp_info', 'a4 V V', [qw(ID hp hp_max)]],
+		'0983' => ['actor_status_active', 'v a4 C V5', [qw(type ID flag total tick unknown1 unknown2 unknown3)]],
+		'0984' => ['actor_status_active', 'a4 v V5', [qw(ID type total tick unknown1 unknown2 unknown3)]],		
 		};
 
 	# Item RECORD Struct's

--- a/src/Network/Send/kRO/RagexeRE_2017_04_26d.pm
+++ b/src/Network/Send/kRO/RagexeRE_2017_04_26d.pm
@@ -10,7 +10,7 @@
 #  See http://www.gnu.org/licenses/gpl.html for the full license.
 ########################################################################
 
-package Network::Send::kRO::RagexeRE_2017_04_25d;
+package Network::Send::kRO::RagexeRE_2017_04_26d;
 
 use strict;
 use base qw(Network::Send::kRO::RagexeRE_2017_04_19b);

--- a/src/Network/Send/kRO/RagexeRE_2017_04_26d.pm
+++ b/src/Network/Send/kRO/RagexeRE_2017_04_26d.pm
@@ -13,7 +13,7 @@
 package Network::Send::kRO::RagexeRE_2017_04_25d;
 
 use strict;
-use base qw(Network::Send::kRO::RagexeRE_2017_04_19);
+use base qw(Network::Send::kRO::RagexeRE_2017_04_19b);
 
 sub new {
 	my ($class) = @_;


### PR DESCRIPTION
Client  Dec 23 2013
Issues #1394
You can use kRO_RagexeRE_2013_08_07a, but recvpacket must be Dec 23 2013.

```
[server?]
ip 45.77.45.251
port 6907
private 1
version 46
master_version 14
addTableFolders **you tables**
serverType kRO_RagexeRE_2013_08_07a
serverEncoding Western
charBlockSize 144
```

![image](https://user-images.githubusercontent.com/23263315/32850753-a5058502-ca65-11e7-80fb-0e0ba6f5cd88.png)
