### PR TITLE
xconf plugin bugfix

### DIFF
--- a/plugins/needs-review/xconf/trunk/xconf.pl
+++ b/plugins/needs-review/xconf/trunk/xconf.pl
@@ -24,6 +24,8 @@ package xConf;
 use strict;
 use Plugins;
 use Globals;
+use utf8;
+
 use Log qw(message error debug warning);
 
 Plugins::register('xConf', 'commands for change items_control, mon_control, pickupitems, priority', \&Unload, \&Unload);
@@ -280,7 +282,6 @@ sub priconf {
 	open(my $file,"<:utf8",$controlfile);
 	my @lines;
 	while (my $tmp = <$file>) {
-		$tmp =~ s/\x{FEFF}//g;
 		push @lines, $tmp if $tmp =~ /^#/;
 	}
 	push @lines, "\n";


### PR DESCRIPTION
while it is decided if xconf will be merged to `Commands.pm` or not

fix this little bug, that when you use iconf or mconf  or pconf, and the `key` had utf8 characters, it crashes the openkore

by the way, this plugin needs update, it is not prepared to work with IDs on items_control.txt 
(in #1376 i've already updated)