### PR TITLE
[eventMacro] ConfigKeyNotExist label support

### DIFF
--- a/plugins/eventMacro/eventMacro/Condition/ConfigKeyNotExist.pm
+++ b/plugins/eventMacro/eventMacro/Condition/ConfigKeyNotExist.pm
@@ -5,7 +5,6 @@ use strict;
 use base 'eventMacro::Condition';
 
 use Globals qw( %config );
-use eventMacro::Data;
 use eventMacro::Utilities qw( find_variable );
 
 sub _hooks {


### PR DESCRIPTION
for now i have only managed to completly edit and test this condition.
`ConfigKey` and `ConfigKeyNot` is on test yet

now this condition support labels.

automacro used to test it:

```perl
automacro createNewBlock_buyAuto {
	ConfigKeyNotExist buyPot.block
	exclusive 1
	timeout 5
	call {
		createNewBlock_buyAuto()
	}
}

sub createNewBlock_buyAuto {
	open (my $fh, '>>:encoding(UTF-8)', Settings::getControlFilename('config.txt'));
	print $fh "\n";
	print $fh "buyAuto {\n";
	print $fh "	maxAmount\n";
	print $fh "	zeny\n";
	print $fh "	npc\n";
	print $fh "	disabled\n";
	print $fh "	label buyPot\n";
	print $fh "}\n";
	close($fh);
	Commands::run("reload config");
}
```

@Henrybk give your veredict