### PR TITLE
fix 1397: ignore shuffles of packets which are not the version the cu…

### DIFF
--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -189,6 +189,9 @@ sub shuffle {
 	foreach ( sort keys %shuffle ) {
 		# We can only patch packets we know about.
 		next if !$self->{packet_list}->{$_};
+		# Ignore changes to packets which aren't used by this server.
+		my $handler = $self->{packet_list}->{$_}->[0];
+		next if $self->{packet_lut}->{$handler} && $self->{packet_lut}->{$handler} ne $_;
 		$new->{ $shuffle{$_} } = $self->{packet_list}->{$_};
 	}
 


### PR DESCRIPTION
…rrent server uses

- [ ] QA (does it work?)
