### PR TITLE
Prevent party info loss

### DIFF
--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -2495,7 +2495,9 @@ sub party_join {
 		binAdd(\@partyUsersID, $ID) if (binFind(\@partyUsersID, $ID) eq "");
 		if ($ID eq $accountID) {
 			message TF("You joined party '%s'\n", $name), undef, 1;
-			$char->{party} = {};
+			# Some servers receive party_users_info before party_join when logging in
+			# This is to prevent clearing info already in $char->{party}
+			$char->{party} = {} unless ref($char->{party}) eq "HASH";
 			$char->{party}{joined} = 1;
 			Plugins::callHook('packet_partyJoin', { partyName => $name });
 		} else {

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -2073,7 +2073,9 @@ sub party_join {
 		binAdd(\@partyUsersID, $ID) if (binFind(\@partyUsersID, $ID) eq "");
 		if ($ID eq $accountID) {
 			message TF("You joined party '%s'\n", $name), undef, 1;
-			$char->{party} = {};
+			# Some servers receive party_users_info before party_join when logging in
+			# This is to prevent clearing info already in $char->{party}
+			$char->{party} = {} unless ref($char->{party}) eq "HASH";
 			$char->{party}{joined} = 1;
 		} else {
 			message TF("%s joined your party '%s'\n", $user, $name), undef, 1;


### PR DESCRIPTION
Sometimes we receive (or process?) party_users_info before party_join when logging in. This doesn't happen always, but when it does, it breaks Slave bots. This was noticed in bRO Thor

This is to prevent clearing info already in $char->{party}