### PR TITLE
qw sakexe_0 to qw sT0

### DIFF
--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -18,8 +18,7 @@
 package Network::Receive::kRO::Sakexe_0;
 
 use strict;
-use Network::Receive::kRO ();
-use base qw(Network::Receive::kRO);
+use base qw(Network::Receive::ServerType0);
 ############# TEMPORARY?
 use Time::HiRes qw(time usleep);
 

--- a/src/Network/Send/kRO/Sakexe_0.pm
+++ b/src/Network/Send/kRO/Sakexe_0.pm
@@ -18,8 +18,7 @@
 package Network::Send::kRO::Sakexe_0;
 
 use strict;
-use base qw(Network::Send::kRO);
-use Network::Send::ServerType0();
+use base qw(Network::Send::ServerType0);
 
 use Log qw(message warning error debug);
 use I18N qw(stringToBytes);


### PR DESCRIPTION
```
In the future, there will be more sT.
I will solve the problem with qw servertybe0 instead.
Because you do not need to add the packet in sakexe_0, but add it to servertybe0 it works.
```

**Recv problem**
```
I solved with qw sT0 it would be better.
Because sakexe_0 is missing a lot of packets and sub .
```