### PR TITLE
[Default config] Stop using exploits to teleport

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -254,7 +254,7 @@ teleportAuto_onlyWhenSafe 0
 teleportAuto_maxDmg 500
 teleportAuto_maxDmgInLock 0
 teleportAuto_deadly 1
-teleportAuto_useSkill 3
+teleportAuto_useSkill 1
 teleportAuto_useChatCommand
 teleportAuto_allPlayers 0
 teleportAuto_notPlayers

--- a/tables/bRO/control-br/config.txt
+++ b/tables/bRO/control-br/config.txt
@@ -267,7 +267,7 @@ teleportAuto_onlyWhenSafe 0
 teleportAuto_maxDmg 500
 teleportAuto_maxDmgInLock 0
 teleportAuto_deadly 1
-teleportAuto_useSkill 3
+teleportAuto_useSkill 1
 teleportAuto_useChatCommand
 teleportAuto_allPlayers 0
 teleportAuto_notPlayers


### PR DESCRIPTION
Changes teleportAuto_useSkill default configuration to 1
teleportAuto_useSkill 3 (or 2, for that matter) is an exploit, mostly patched -- and detectable