### PR TITLE
Skip comments in args in items_control.txt

### DIFF
--- a/src/FileParsers.pm
+++ b/src/FileParsers.pm
@@ -504,6 +504,7 @@ sub parseItemsControl {
 		}
 		
 		next if $key =~ /^$/;
+		$args_text =~ s/\s*#.*//;
 		my @args = split /\s+/, $args_text;
 		# Cache similar entries to save memory.
 		$r_hash->{$key} = $cache{$args_text} ||= { map {$_ => shift @args} qw(keep storage sell cart_add cart_get) };


### PR DESCRIPTION
Avoids parsing " # Green Potion" in `506 0 1 0 # Green Potion`, for instance, as an argument

Might be related to #1371 and [pt-br] http://openkorebrasil.org/index.php?/topic/4288-config-da-kafra

Or it might not