### PR TITLE
Add storageAuto_useItem

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -713,6 +713,8 @@ storageAuto_password
 storageEncryptKey
 storageAuto_keepOpen 0
 storageAuto_useChatCommand
+storageAuto_useItem 0
+storageAuto_useItem_item
 storageAuto_notAfterDeath
 relogAfterStorage 0
 minStorageZeny 50

--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -150,6 +150,7 @@ ai_sellAuto_wait_after_packet_giveup 15
 
 ai_storageAuto 2
 ai_storageAuto_giveup 15
+ai_storageAuto_useItem 2
 # delay between sending cart item add/get packets
 ai_cartAuto 0.15
 

--- a/tables/bRO/control-br/config.txt
+++ b/tables/bRO/control-br/config.txt
@@ -726,6 +726,8 @@ storageAuto_password
 storageEncryptKey
 storageAuto_keepOpen 0
 storageAuto_useChatCommand
+storageAuto_useItem 0
+storageAuto_useItem_item
 storageAuto_notAfterDeath
 relogAfterStorage 0
 minStorageZeny 50

--- a/tables/bRO/control-br/timeouts.txt
+++ b/tables/bRO/control-br/timeouts.txt
@@ -156,6 +156,7 @@ ai_sellAuto_wait_after_packet_giveup 15
 
 ai_storageAuto 2
 ai_storageAuto_giveup 15
+ai_storageAuto_useItem 2
 # atraso entre o envio dos pacotes "adicionar/pegar item do carrinho" (cart item add/get)
 ai_cartAuto 0.15
 


### PR DESCRIPTION
Allows opening storage with a consumable item, like [Kafra Card](http://ratemyserver.net/index.php?page=item_db&item_id=12211)

Usage:
```
storageAuto_useItem 1
storageAuto_useItem_item Kafra Card
```

* If you run out of Kafra Cards and storageAuto_npc is set, kore will do execute the normal storageAuto sequence. If storageAuto_npc is not set, storageAuto will be disabled.
* storageAuto_useChatCommand has priority over storageAuto_useItem.
  