### PR TITLE
Fix loop on buyAuto

### DIFF
--- a/src/InventoryList.pm
+++ b/src/InventoryList.pm
@@ -395,7 +395,7 @@ sub sumByName {
 	assert(defined $name) if DEBUG;
 	my $sum = 0;
 	for my $item (@$self) {
-		if ($item->{name} eq $name) {
+		if (lc($item->{name}) eq lc($name)) {
 			$sum = $sum + $item->{amount};
 		}
 	}


### PR DESCRIPTION
buyAuto is case insensitive, but if we try to buy, for instance, 'Yellow potion' and the store sells 'Yellow Potion' (mind the uppercase and lowercase 'P'), the item is bought -- but we enter a loop, because we still don't have enough of 'Yellow potion', even though we have enough of 'Yellow Potion'. This commit fixes that behaviour.

Also fixes #1587 


Expected behaviour (with this commit applied):
![2018-01-10_11h32_06](https://user-images.githubusercontent.com/17522256/34775523-9f908930-f5fa-11e7-9ca8-e1a8ed4e8409.png)

What happens without this commit. Notice we don't actually buy the stuff, but we keep trying.
![2018-01-10_11h40_01](https://user-images.githubusercontent.com/17522256/34775641-0712c168-f5fb-11e7-9e5b-c9ecc2842458.png)

