### PR TITLE
Add [NONE] to equipAuto

### DIFF
--- a/src/Actor/Item.pm
+++ b/src/Actor/Item.pm
@@ -184,14 +184,20 @@ sub bulkEquip {
 		my $skipIndex;
 		$skipIndex = $rightHand if ($_ eq 'leftHand');
 		$skipIndex = $rightAccessory if ($_ eq 'leftAccessory');
-		$item = Actor::Item::get($list->{$_}, $skipIndex, 1);
-
-		next unless ($item && $char->{equipment} && (!$char->{equipment}{$_} || $char->{equipment}{$_}{name} ne $item->{name}));
-
-		$item->equipInSlot($_);
 		
-		$rightHand = $item->{binID} if ($_ eq 'rightHand');
-		$rightAccessory = $item->{binID} if ($_ eq 'rightAccessory');
+		if ($list->{$_} eq "[NONE]") {
+			next unless $char->{equipment}{$_};
+			$char->{equipment}{$_}->unequip();
+		} else {
+			$item = Actor::Item::get($list->{$_}, $skipIndex, 1);
+
+			next unless ($item && $char->{equipment} && (!$char->{equipment}{$_} || $char->{equipment}{$_}{name} ne $item->{name}));
+
+			$item->equipInSlot($_);
+			
+			$rightHand = $item->{binID} if ($_ eq 'rightHand');
+			$rightAccessory = $item->{binID} if ($_ eq 'rightAccessory');
+		}
 	}
 }
 
@@ -234,8 +240,12 @@ sub scanConfigAndCheck {
 	my $count = 0;
 	foreach my $slot (values %equipSlot_lut) {
 		if (exists $config{"${prefix}_$slot"}){
-			my $item = Actor::Item::get($config{"${prefix}_$slot"}, undef, 1);
-			$count++ if ($item && $char->{equipment} && (!$char->{equipment}{$slot} || $char->{equipment}{$slot}{name} ne $item->{name}));
+			if ($config{"${prefix}_$slot"} eq "[NONE]") {
+				$count++ if ($char->{equipment} && $char->{equipment}{$slot});
+			} else {
+				my $item = Actor::Item::get($config{"${prefix}_$slot"}, undef, 1);
+				$count++ if ($item && $char->{equipment} && (!$char->{equipment}{$slot} || $char->{equipment}{$slot}{name} ne $item->{name}));
+			}
 		}
 	}
 	return $count;

--- a/src/Actor/Item.pm
+++ b/src/Actor/Item.pm
@@ -186,7 +186,7 @@ sub bulkEquip {
 		$skipIndex = $rightAccessory if ($_ eq 'leftAccessory');
 		
 		if ($list->{$_} eq "[NONE]") {
-			next unless $char->{equipment}{$_};
+			next unless ($char->{equipment} && $char->{equipment}{$_});
 			$char->{equipment}{$_}->unequip();
 		} else {
 			$item = Actor::Item::get($list->{$_}, $skipIndex, 1);


### PR DESCRIPTION
Using <slot> [NONE] in equipAuto now unequips that slot.

For example:
```
equipAuto {
	midHead [NONE]
	onAction sitAuto
}
```

Unequips whatever is equipped in midHead when sitAuto.