### PR TITLE
CANNOT_CALCULATE_ROUTE message for single target

### DIFF
--- a/src/Task/CalcMapRoute.pm
+++ b/src/Task/CalcMapRoute.pm
@@ -183,10 +183,10 @@ sub iterate {
 			debug sprintf("%s\n", $self->getRouteString()), "route";
 
 		} elsif ($self->{done}) {
-			my $destpos = $self->{target}->{x} ? " ($self->{target}->{x},$self->{target}->{y})" : '';
+			my $destpos = $self->{targets}[0]->{x} ? " (".$self->{targets}[0]->{x}.",".$self->{targets}[0]->{y}.")" : undef;
 			$self->setError(CANNOT_CALCULATE_ROUTE, TF("Cannot calculate a route from %s (%d,%d) to %s%s",
 				$self->{source}{field}->baseName, $self->{source}{x}, $self->{source}{y},
-				$self->{target}->{map}, $destpos));
+				$self->{targets}[0]->{map} || T("unknown"), $destpos));
 			debug "CalcMapRoute failed.\n", "route";
 		}
 	}


### PR DESCRIPTION
Caused by #896
Behavior uknown for multiple targets, not fatal unless position zero is undef or not a hash, which shouldn't happen

Before:
![2018-01-13_10h41_19](https://user-images.githubusercontent.com/17522256/34906285-cb6f17d4-f851-11e7-9ce9-fcd608d8d808.png)

After:
1. Without coords
![2018-01-13_10h52_06](https://user-images.githubusercontent.com/17522256/34906286-cccef248-f851-11e7-90ce-009f10e1bd6b.png)
2. With coords
![2018-01-13_10h56_43](https://user-images.githubusercontent.com/17522256/34906287-ce31b044-f851-11e7-9074-5fc88305bafc.png)
