### PR TITLE
 Remove encoding pragma in plugins loaded by default

### DIFF
--- a/plugins/eventMacro/eventMacro/FileParser.pm
+++ b/plugins/eventMacro/eventMacro/FileParser.pm
@@ -1,7 +1,6 @@
 package eventMacro::FileParser;
 
 use strict;
-use encoding 'utf8';
 
 require Exporter;
 our @ISA = qw(Exporter);

--- a/plugins/macro/Macro/Automacro.pm
+++ b/plugins/macro/Macro/Automacro.pm
@@ -137,7 +137,7 @@ sub checkPersonGuild {
 
 	if ($guild eq 'guild.txt') {
 		my @gld;
-		if (open(FILE, "<", Settings::getControlFilename("guild.txt"))) {
+		if (open(FILE, "<:utf8", Settings::getControlFilename("guild.txt"))) {
 			while (<FILE>) {
 				$_ =~ s/\x{FEFF}//g;
 				chomp($_);

--- a/plugins/macro/Macro/Parser.pm
+++ b/plugins/macro/Macro/Parser.pm
@@ -2,7 +2,6 @@
 package Macro::Parser;
 
 use strict;
-use encoding 'utf8';
 
 require Exporter;
 our @ISA = qw(Exporter);


### PR DESCRIPTION
The encoding pragma was deprecated in perl 5.18 and is no longer allowed in perl 5.26

Fixes #1388 and #855
Won't cause the same problem as #856, described in #863 -- this is implemented with perlIO layer, instead of the open pragma