### PR TITLE
Add whenPartyMembersNear and whenPartyMembersNearDist

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -4243,8 +4243,36 @@ sub checkSelfCondition {
 		return 0 if ($field->getBlock($pos->{x}, $pos->{y}) != Field::WALKABLE_WATER);
 	}
 	
-	if (defined $config{$prefix.'_devotees'}) {
+	if ($config{$prefix.'_devotees'}) {
 		return 0 unless inRange(scalar keys %{$devotionList->{$accountID}{targetIDs}}, $config{$prefix.'_devotees'});
+	}
+	
+	if ($config{$prefix."_whenPartyMembersNear"}) {
+		# Short circuit if there's not enough players nearby, party members or not
+		# +1 account for self
+		return 0 unless inRange(scalar @{$playersList} + 1, $config{$prefix."_whenPartyMembersNear"});
+
+		# Short circuit if there's not enough players in our party
+		return 0 unless inRange(scalar @partyUsersID, $config{$prefix."_whenPartyMembersNear"});
+
+		my $dist;
+		my $amountInRange = 1; # account for self
+		
+		if ($config{$prefix."_whenPartyMembersNearDist"}) {
+			$dist = $config{$prefix."_whenPartyMembersNearDist"};
+		} else {
+			$dist = "< ";
+			$dist .= ($config{removeActorWithDistance} || $config{clientSight} || 15);
+		}
+
+		foreach my $player (@{$playersList}) {
+			next unless (exists $char->{party}{users}{$player->{ID}} && $char->{party}{users}{$player->{ID}});
+			next unless inRange(distance(calcPosition($char), calcPosition($player)), $dist);
+			 
+			++$amountInRange;
+		}
+
+		return 0 unless inRange($amountInRange, $config{$prefix."_whenPartyMembersNear"});
 	}
 
 	my %hookArgs;


### PR DESCRIPTION
whenPartyMembersNear : range of party members nearby necessary to trigger this block
whenPartyMembersNearDist : range of distance those party members have to be to trigger this block. If unset, defaults to less than removeActorWithDistance or clientSight or 15 (in this order)

Both are self coditions, therefore can be used in partySkill, useSelfSkill, useSelf_item, buyAuto, etc.

Allows users to do things like this:

Use Clementia if there's more than two party members nearby
Use Blessing otherwise

```
partySkill Clementia {
    target_whenStatusInactive Blessing
    whenPartyMembersNear > 2
    whenPartyMembersNearDist <= 7
}

partySkill Blessing {
    target_whenStatusInactive Blessing
    whenPartyMembersNear 2
}
```