### PR TITLE
[eventMacro] &split fix (support accessed array and hash)

### DIFF
--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1082,12 +1082,26 @@ sub next {
 						$eventMacro->set_full_hash($var->{real_name}, \%hash);
 					}
 					
-				} elsif ($var->{type} eq 'array' && $value =~ /^$macro_keywords_character(?:split)\(\s*(.*?)\s*\)$/) {
-					my ( $pattern, $var_str ) = parseArgs( "$1", undef, ',' );
-					$var_str =~ s/^\s+|\s+$//gos;
-					my $split_var = find_variable( $var_str );
-					$self->error( 'Variable not recognized' ), return if !$split_var;
-					$eventMacro->set_full_array( $var->{real_name}, [ split $pattern, $eventMacro->get_split_var( $split_var ) ] );
+				} elsif ($var->{type} eq 'array' && $value =~ /^$macro_keywords_character(?:split)\(([^\)]+)\)$/) {
+    				my ( $pattern, $var_str ) = parseArgs( "$1", undef, ',' );
+    				$var_str =~ s/^\s+|\s+$//gos;
+					my $split_var;
+    				if (my $var_hash = $self->find_and_define_key_index($var_str)) {
+						return if (defined $self->error);
+						$split_var = $var_hash->{var};
+						
+					} else {
+						return if (defined $self->error);
+						$split_var = find_variable($1);
+						if (defined $self->error) {
+							return;
+						} elsif (!defined $split_var) {
+							$self->error("Could not define variable type");
+							return;
+						}
+					}
+    				$eventMacro->set_full_array( $var->{real_name}, [ split $pattern, $eventMacro->get_split_var( $split_var ) ] );
+    
 				} elsif ($var->{type} eq 'array' && $value =~ /^$macro_keywords_character(keys|values)\(($hash_variable_qr)\)$/) {
 					my $type = $1;
 					my $var2 = find_variable($2);


### PR DESCRIPTION
this closes #1695 


## using accessed hash
```perl
[eventMacro] Conditions met for automacro 'test', calling macro 'tempMacro3'
[eventmacro log] $i is 0, then @group should be a:b:c
[eventmacro log] $group[0] is a
[eventmacro log] $group[1] is b
[eventmacro log] $group[2] is c
[eventmacro log] $i is 1, then @group should be 1:2:3
[eventmacro log] $group[0] is 1
[eventmacro log] $group[1] is 2
[eventmacro log] $group[2] is 3
[eventmacro log] $i is 2, then @group should be ma:me:mi:mo
[eventmacro log] $group[0] is ma
[eventmacro log] $group[1] is me
[eventmacro log] $group[2] is mi
[eventmacro log] $group[3] is mo
[eventmacro log] $i is 3, then @group should be sim:griim:fin
[eventmacro log] $group[0] is sim
[eventmacro log] $group[1] is griim
[eventmacro log] $group[2] is fin
[eventmacro log] done loop
eventMacro var_get
[eventMacro] Printing values off all variables
-------- Scalars --------
1 - '$.caller' = 'test'
2 - '$j' = '3'
3 - '$i' = '4'
4 - '$.BaseLevelLast' = '55'
-------- Arrays ---------
1 - '@group'
     '$group[0]' = 'sim'
     '$group[1]' = 'griim'
     '$group[2]' = 'fin'
-------- Hashes ---------
1 - '%hash'
     '$hash{1}' = '1:2:3'
     '$hash{0}' = 'a:b:c'
     '$hash{3}' = 'sim:griim:fin'
     '$hash{2}' = 'ma:me:mi:mo'
```

## using accessed array:

```perl
[eventMacro] Conditions met for automacro 'test', calling macro 'tempMacro4'
Speed changed.
[eventmacro log] $i is 0, then @group should be a:b:c
[eventmacro log] $group[0] is a
[eventmacro log] $group[1] is b
[eventmacro log] $group[2] is c
[eventmacro log] $i is 1, then @group should be 1:2:3
[eventmacro log] $group[0] is 1
[eventmacro log] $group[1] is 2
[eventmacro log] $group[2] is 3
[eventmacro log] $i is 2, then @group should be ma:me:mi:mo
[eventmacro log] $group[0] is ma
[eventmacro log] $group[1] is me
[eventmacro log] $group[2] is mi
[eventmacro log] $group[3] is mo
[eventmacro log] $i is 3, then @group should be sim:griim:fin
[eventmacro log] $group[0] is sim
[eventmacro log] $group[1] is griim
[eventmacro log] $group[2] is fin
[eventmacro log] done loop
eventMacro var_get
[eventMacro] Printing values off all variables
-------- Scalars --------
1 - '$.caller' = 'test'
2 - '$j' = '3'
3 - '$i' = '4'
4 - '$.BaseLevelLast' = '55'
-------- Arrays ---------
1 - '@array'
     '$array[0]' = 'a:b:c'
     '$array[1]' = '1:2:3'
     '$array[2]' = 'ma:me:mi:mo'
     '$array[3]' = 'sim:griim:fin'
2 - '@group'
     '$group[0]' = 'sim'
     '$group[1]' = 'griim'
     '$group[2]' = 'fin'
-------- Hashes ---------
```