### PR TITLE
checking weight when get item via console commands

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -183,6 +183,7 @@ itemsMaxNum_sellOrStore 99
 cartMaxWeight 7900
 itemsTakeAuto_new 0
 itemsTakeGreed 0
+itemsCheckWeight 1
 
 lockMap
 lockMap_x

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1045,12 +1045,12 @@ sub processTransferItems {
 		#if you're sending to storage, doesn't need to check weight
 		#if there is no information about weight, there's no point in check
 		if ($row->{target} ne 'storage' && $item->weight()) {
-            my $freeWeight;
-            if ($row->{target} eq 'inventory') {
-                $freeWeight = int ($char->{weight_max} - $char->{weight});
-            } else { #if target not inventory, then is cart!
-                $freeWeight = $char->cart->{weight_max} - $char->cart->{weight};
-            }
+			my $freeWeight;
+			if ($row->{target} eq 'inventory') {
+				$freeWeight = int ($char->{weight_max} - $char->{weight});
+			} else { #if target not inventory, then is cart!
+				$freeWeight = $char->cart->{weight_max} - $char->cart->{weight};
+			}
 			my $weightNeeded = min( $item->{amount}, $row->{amount} || $item->{amount} ) * ($item->weight()/10);
 			
 			if ($weightNeeded > $freeWeight) {

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1056,7 +1056,7 @@ sub processTransferItems {
 			if ($weightNeeded > $freeWeight) {
 				#need to low down the amount
 				$row->{amount} = int ( $freeWeight / ( $item->weight()/10 ) );
-				warning TF("Amount of item %s is more that you can carry, getting the maximum possible (%d)\n", $row->{item}, $row->{amount});
+				warning TF("Amount of %s is more than you can carry, getting the maximum possible (%d)\n", $row->{item}, $row->{amount});
 			}		
 		}
 

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1044,7 +1044,7 @@ sub processTransferItems {
 		#verify if we can carry the amount of item
 		#if you're sending to storage, doesn't need to check weight
 		#if there is no information about weight, there's no point in check
-		if ($row->{target} ne 'storage' && $item->weight()) {
+		if ($row->{target} ne 'storage' && $item->weight() && $config{itemsCheckWeight}) {
 			my $freeWeight;
 			if ($row->{target} eq 'inventory') {
 				$freeWeight = int ($char->{weight_max} - $char->{weight});

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1049,13 +1049,13 @@ sub processTransferItems {
 			if ($row->{target} eq 'inventory') {
 				$freeWeight = int ($char->{weight_max} - $char->{weight});
 			} else { #if target not inventory, then is cart!
-				$freeWeight = $char->cart->{weight_max} - $char->cart->{weight};
+				$freeWeight = int ($char->cart->{weight_max} - $char->cart->{weight});
 			}
 			my $weightNeeded = min( $item->{amount}, $row->{amount} || $item->{amount} ) * ($item->weight()/10);
 			
 			if ($weightNeeded > $freeWeight) {
 				#need to low down the amount
-				$row->{amount} = int ( $freeWeight / ( $item->weight()/10 ) );
+				$row->{amount} = $freeWeight / ( $item->weight()/10 );
 				warning TF("Amount of %s is more than you can carry, getting the maximum possible (%d)\n", $row->{item}, $row->{amount});
 			}		
 		}

--- a/tables/bRO/control-br/config.txt
+++ b/tables/bRO/control-br/config.txt
@@ -1,4 +1,4 @@
-#############################################################################################
+﻿#############################################################################################
 # A Codificação do texto está correta?
 # Codificação:  ANSI -> UTF8 Without boom
 # Se você não está vendo a acentuação corretamente, seu arquivo está no formato incorreto.
@@ -196,6 +196,7 @@ itemsMaxNum_sellOrStore 99
 cartMaxWeight 7900
 itemsTakeAuto_new 0
 itemsTakeGreed 0
+itemsCheckWeight 1
 
 lockMap
 lockMap_x


### PR DESCRIPTION
This PR do:

* if the target is cart or inventory, will check weight of each item (and only if has information about weight)
* calc how much of the current item the bot can get, if the amount is bigger that he can carry, will get just enough to stay with 99% weight (or 100%)

```
-- Não utilizável --
13   Sangue de Lobo x 45
14   Gelo x 3507 #this is the item will get
16   Pedra x 1
17   Ombreira x 2

Capacidade: 27/600
--------------------------------------------------
storage get 14 #command to get the item
Amount of item Gelo (14) is more that you can carry, getting the maximum possible (2099)
Item adicionado ao inventário: Gelo (23) x 2099 - Event
Você está agora: Owg 90%
Item retirado do armazém: Gelo (14) x 2099
```