### PR TITLE
Entity save type

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1782,6 +1782,7 @@ sub revolving_entity {
 	if ($sourceID eq $accountID && $entityNum != $char->{spirits}) {
 		$char->{spirits} = $entityNum;
 		$char->{amuletType} = $entityElement;
+		$char->{spiritsType} = $entityType;
 		$entityElement ?
 			# Translation Comment: Message displays following: quantity, the name of the entity and its element
 			message TF("You have %s %s(s) of %s now\n", $entityNum, $entityType, $entityElement), "parseMsg_statuslook", 1 :
@@ -1790,6 +1791,7 @@ sub revolving_entity {
 	} elsif ($entityNum != $actor->{spirits}) {
 		$actor->{spirits} = $entityNum;
 		$actor->{amuletType} = $entityElement;
+		$actor->{spiritsType} = $entityType;
 		$entityElement ?
 			# Translation Comment: Message displays following: actor, quantity, the name of the entity and its element
 			message TF("%s has %s %s(s) of %s now\n", $actor, $entityNum, $entityType, $entityElement), "parseMsg_statuslook", 1 :


### PR DESCRIPTION
Entity save type to check when send to client in xkore 2

```
# Send spirit sphere information. packets 01D0 01E1 08CF
	# 01D0 (spirits), 01E1 (coins), 08CF (amulets)
	if ($char->{spirits}) {
		my $switch = "01D0";
		if($char->{spiritsType} eq "coin") { $switch = "01E1"; }
		if($char->{spiritsType} eq "amulet") { $switch = "08CF"; }
		
		my $type = 0;
		if(exists $char->{amuletType}) { $type = $char->{amuletType}; }

		$data = $self->{recvPacketParser}->reconstruct({
					switch => $switch,
					sourceID => $char->{ID},
					entity => $char->{spirits},
					type => $type,
				}) ;
		$client->send($data);
	}
```
