### PR TITLE
Fix eventmacro crash on reload with unclosed blocks

### DIFF
--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -111,7 +111,7 @@ sub unload {
 	$self->clear_queue();
 	$self->clean_hooks();
 	Plugins::delHook($self->{AI_start_Automacros_Check_Hook_Handle}) if ($self->{AI_start_Automacros_Check_Hook_Handle});
-	Plugins::delHook($self->{AI_state_change_Hook_Handle});
+	Plugins::delHook($self->{AI_state_change_Hook_Handle}) if ($self->{AI_state_change_Hook_Handle});
 }
 
 sub clean_hooks {


### PR DESCRIPTION
Reported by Kotsu

# How to reproduce:

```
automacro crash {
	BaseLevel > 0
	call {
		if ($var == 0) {
			log I won't close this if
	}
}
```

Run openkore and use command ```reload eventMacros.txt```

# Crash message

![image](https://user-images.githubusercontent.com/17522256/36746889-37b63ed8-1bd2-11e8-80e4-c4f3301c1810.png)


# After applying this patch:
![image](https://user-images.githubusercontent.com/17522256/36746949-5c946c70-1bd2-11e8-8320-81de130d97d8.png)
