### PR TITLE
fix bug in party skill caused in #1884

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2632,7 +2632,8 @@ sub processPartySkillUse {
 					}
 					
 					# if that intended to distinguish between party members and other characters on the same accounts, then it didn't work
-					next if (($char->{party}{users}{$ID} ne $playersList->getByID($ID)) && !$config{"partySkill_$i"."_notPartyOnly"});
+					my $player = $playersList->getByID($ID);
+					next if (($char->{party}{users}{$ID}{name} ne $player->{name}) && !$config{"partySkill_$i"."_notPartyOnly"});
 				}
 				
 				my $player = Actor::get($ID);


### PR DESCRIPTION
I dont know why, but previouly openkore was comparing name get from actor :
code:
`next if (($char->{party}{users}{$ID} ne $playersList->getByID($ID)) && !$config{"partySkill_$i"."_notPartyOnly"});`

the following code:
```
$char->{party}{users}{$ID} :

```
Result:  Party sctnightcore 

and
```
$playersList->getByID($ID)):
```
Result:  Player sctnightcore (0)

this pull fix this:
![image](https://user-images.githubusercontent.com/10372732/38164815-7364ce46-34e0-11e8-8841-5841d7c43707.png)


thi fixes #1896 