### PR TITLE
[eventMacro] add one more hook to Zeny condition

### DIFF
--- a/plugins/eventMacro/eventMacro/Condition/Zeny.pm
+++ b/plugins/eventMacro/eventMacro/Condition/Zeny.pm
@@ -7,7 +7,7 @@ use base 'eventMacro::Conditiontypes::NumericConditionState';
 use Globals qw( $char );
 
 sub _hooks {
-	['zeny_change','packet/stat_info','packet/stats_info', 'complete_deal'];
+	['zeny_change','packet/stat_info','packet/stats_info','complete_deal'];
 }
 
 sub _get_val {

--- a/plugins/eventMacro/eventMacro/Condition/Zeny.pm
+++ b/plugins/eventMacro/eventMacro/Condition/Zeny.pm
@@ -7,7 +7,7 @@ use base 'eventMacro::Conditiontypes::NumericConditionState';
 use Globals qw( $char );
 
 sub _hooks {
-	['zeny_change','packet/stat_info','packet/stats_info'];
+	['zeny_change','packet/stat_info','packet/stats_info', 'complete_deal'];
 }
 
 sub _get_val {


### PR DESCRIPTION
i just made a deal right now, and when the deal was over, eventMacro didnt checked the zeny, and the automacro did not acttivated because of that