### PR TITLE
[vendingLog] Fix date-format key meaning

### DIFF
--- a/plugins/vendingLog/vendingLog.pl
+++ b/plugins/vendingLog/vendingLog.pl
@@ -32,7 +32,7 @@ use constant {
 	
 	DATE_FORMAT_KEY => "vendingLog_dateFormat",
 	
-	DATE_FORMAT_VALUE_X_MEANING => [ "h:m:s", "y-m-d", "Mon d h:m:s y" ],
+	DATE_FORMAT_VALUE_X_MEANING => [ "y-m-d", "h:m:s", "Mon d h:m:s y" ],
 };
 
 my $translator = new Translation(PLUGIN_PODIR, $sys{locale});


### PR DESCRIPTION
vendingLog_dateFormat 0 -> `y-m-d`
vendingLog_dateFormat 1 -> `h:m:s`
vendingLog_dateFormat 2 -> `Mon d h:m:s y`

Functionality stays unchanged.