### PR TITLE
[eventMacro] fix problem with else block of a switch case block

### DIFF
--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -696,7 +696,7 @@ sub define_next_valid_command {
 						}
 						
 						#Start of another if/switch/case/while block
-						if ( $self->{current_line} =~ /^(if|switch|case|while).*{$/ ) {
+						if ( $self->{current_line} =~ /^(if|switch|case|while|else).*{$/ ) {
 							$block_count++;
 							
 						#End of an if block or start of else block


### PR DESCRIPTION
when it has an else block of a switch case block, inside an else block, like this:

```perl
    if (&config(saveMap) = $mapa{saveMap}) {
        do conf lockMap $mapa{lockMap}
        call attackAgain
        do conf -f what_am_i_doing leveling
    } else {
        call stopAttacking
        do conf lockMap none
        
        if ($.map =~ /hugel|hu_fild/ && $mapa{saveMap} != hugel) {
            switch ($mapa{saveMap}) {
                case (~ rachel, veins) {
                    call airplane_hugelTo "rachel"
                }
                case (= einbroch) {
                    call airplane_hugelTo "einbroch"
                }
                else {
                    call airplane_hugelTo "juno"
                }
            }
            stop
        }
```

eventMacro was not reading this correctly, which ended in error
this PR fix it