### PR TITLE
make raiseStat parse stats correctly even if is on inverse position

### DIFF
--- a/plugins/raiseStat/raiseStat.pl
+++ b/plugins/raiseStat/raiseStat.pl
@@ -192,6 +192,14 @@ sub validateSteps {
 				return 0;
 			}
 			push(@stats_to_add, {'value' => $value, 'stat' => $stat});
+		} elsif ($step =~ /^(str|vit|dex|int|luk|agi)\s+(\d+)$/) {
+			my $stat = $1;
+			my $value = $2;
+			if ($value > 99 && !$config{statsAdd_over_99}) {
+				error $translator->translatef("Stat '%s' is more then 99 and 'statsAdd_over_99' is disabled; disabling statsAddAuto\n", $step);
+				return 0;
+			}
+			push(@stats_to_add, {'value' => $value, 'stat' => $stat});
 		} else {
 			error $translator->translatef("Unknown stat '%s'; disabling statsAddAuto\n", $step);
 			return 0;


### PR DESCRIPTION
curretly, the plugin only parses the value if it is on this format
`10 str, 60 int`
(first the value, after the stat which will be leveled)

this PR proposes that user are free to use
`str 10, int 60` if he want (or if he didn't noticed he placed wrong)
this will not affect the function of plugin, will not make anything slower at all