### PR TITLE
fix assertion failed

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1260,7 +1260,7 @@ sub actor_display {
 				NPC_PET_TYPE, 'Actor::Pet',
 				NPC_HO_TYPE, 'Actor::Slave',
 				NPC_MERSOL_TYPE, 'Actor::Slave',
-				NPC_ELEMENTAL_TYPE, 'Actor::Elemental', # Sorcerer's Spirit
+				# NPC_ELEMENTAL_TYPE, 'Actor::Elemental', # Sorcerer's Spirit
 			}->{$args->{object_type}};
 		}
 


### PR DESCRIPTION
fix assertion fail caused by not implemented ELEMENTAL

reported here:
http://openkorebrasil.org/index.php?/topic/4812-erro-inesperado/

and here:
http://openkorebrasil.org/index.php?/topic/4816-erro-assertion-failed/

when NPC_ELEMENTAL is sended to openkore no one actor is generated, causing error in assertion