### PR TITLE
[Feature] Command Create (Potion/Weapon)

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -90,6 +90,7 @@ sub initHandlers {
 	closebuyshop		=> \&cmdCloseBuyShop,
 	conf				=> \&cmdConf,
 	connect				=> \&cmdConnect,
+	create				=> \&cmdCreate,
 	damage				=> \&cmdDamage,
 	dead				=> \&cmdDeadTime,
 	deal				=> \&cmdDeal,
@@ -6986,4 +6987,30 @@ sub cmdElemental {
 				list <index number> show informations about a specific elemental");
 	}
 }
+
+sub cmdCreate {
+	if (!$net || $net->getState() != Network::IN_GAME) {
+		error TF("You must be logged in the game to use this command '%s'\n", shift);
+		return;
+	}
+
+	my ($cmd, $args) = @_;
+	my @arg = parseArgs($args);
+
+	if ($arg[0] =~ /^\d+/ && defined $makableList->[$arg[0]]) { # viewID/nameID can be 0
+		$arg[1] = 0 if !defined $arg[1];
+		$arg[2] = 0 if !defined $arg[2];
+		$arg[3] = 0 if !defined $arg[3];
+		$messageSender->sendMakeItemRequest($makableList->[$arg[0]], $arg[1], $arg[2], $arg[3]);
+	} elsif($arg[0] =~ /^\d+/) {
+		message TF("Item with 'create' index: %s not found.\n", $arg[0]), "info";
+	} else {
+		error T("Error in function 'create'\n" .
+			"Usage: create <index number> <material 1 nameID> <material 2 nameID> <material 2 nameID>\n".
+			"material # nameID: can be 0 or undefined.\n");
+	}
+
+	undef $makableList;
+}
+
 1;

--- a/src/Globals.pm
+++ b/src/Globals.pm
@@ -31,7 +31,7 @@ our %EXPORT_TAGS = (
 	state   => [qw($accountID $cardMergeIndex @cardMergeItemsID $charID @chars @chars_old @friendsID %friends %incomingFriend $field %homunculus $itemsList @itemsID %items $monstersList @monstersID %monsters @npcsID %npcs $npcsList @playersID %players @portalsID @portalsID_old %portals %portals_old $portalsList $storeList $currentChatRoom @currentChatRoomUsers @chatRoomsID %createdChatRoom %chatRooms @skillsID $storageTitle @arrowCraftID %guild %incomingGuild @spellsID %spells @unknownPlayers @unknownNPCs $useArrowCraft %currentDeal %incomingDeal %outgoingDeal @identifyID @partyUsersID %incomingParty @petsID %pets $venderItemList $venderID $venderCID @venderListsID @buyerItemList @selfBuyerItemList $buyerID $buyingStoreID @buyerListsID @articles $articles %venderLists %buyerLists %monsters_old @monstersID_old %npcs_old %items_old %players_old @playersID_old @servers $sessionID $sessionID2 $accountSex $accountSex2 $map_ip $map_port $KoreStartTime $secureLoginKey $initSync $lastConfChangeTime $petsList $playersList $portalsList %elementals $elementalsList @elementalsID @playerNameCacheIDs %playerNameCache %pet $pvp @cashList $slavesList @slavesID %slaves %cashShop $skillExchangeItem $refineUI %clan)],
 	network => [qw($remote_socket $net $messageSender $charServer $conState $conState_tries $encryptVal $ipc $bus $masterServer $lastSwitch $packetParser $clientPacketHandler $bytesSent $incomingMessages $outgoingClientMessages $enc_val1 $enc_val2 $captcha_state)],
 	interface => [qw($interface)],
-	misc    => [qw($quit $reconnectCount @lastpm %lastpm @privMsgUsers %timeout_ex $shopstarted $dmgpsec $totalelasped $elasped $totaldmg %overallAuth %responseVars %talk $startTime_EXP $startingzeny @monsters_Killed $bExpSwitch $jExpSwitch $totalBaseExp $totalJobExp $shopEarned %itemChange $XKore_dontRedirect $monkilltime $monstarttime $startedattack $firstLoginMap $sentWelcomeMessage $versionSearch $monsterBaseExp $monsterJobExp %descriptions %flags %damageTaken $logAppend @sellList $userSeed $taskManager $repairList $mailList $rodexList $rodexWrite $auctionList $questList $achievementList $hotkeyList $devotionList $cookingList %charSvrSet @deadTime)],
+	misc    => [qw($quit $reconnectCount @lastpm %lastpm @privMsgUsers %timeout_ex $shopstarted $dmgpsec $totalelasped $elasped $totaldmg %overallAuth %responseVars %talk $startTime_EXP $startingzeny @monsters_Killed $bExpSwitch $jExpSwitch $totalBaseExp $totalJobExp $shopEarned %itemChange $XKore_dontRedirect $monkilltime $monstarttime $startedattack $firstLoginMap $sentWelcomeMessage $versionSearch $monsterBaseExp $monsterJobExp %descriptions %flags %damageTaken $logAppend @sellList $userSeed $taskManager $repairList $mailList $rodexList $rodexWrite $auctionList $questList $achievementList $hotkeyList $devotionList $cookingList $makableList %charSvrSet @deadTime)],
 	syncs => [qw($syncSync $syncMapSync)],
 	cmdqueue => [qw($cmdQueue @cmdQueueList $cmdQueueStartTime $cmdQueueTime @cmdQueuePriority)],
 );
@@ -569,6 +569,7 @@ our $auctionList;
 our $hotkeyList;
 our $devotionList;
 our $cookingList;
+our $makableList;
 our %charSvrSet;
 our $questList;
 our $achievementList;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -3391,21 +3391,28 @@ sub npc_chat {
 	# TODO hook
 }
 
-sub forge_list {
+# 018d <packet len>.W { <name id>.W { <material id>.W }*3 }*
+sub makable_item_list {
 	my ($self, $args) = @_;
-
-	message T("========Forge List========\n");
-	for (my $i = 4; $i < $args->{RAW_MSG_SIZE}; $i += 8) {
-		my $viewID = unpack("v1", substr($args->{RAW_MSG}, $i, 2));
-		message "$viewID $items_lut{$viewID}\n";
-		# always 0x0012
-		#my $unknown = unpack("v1", substr($args->{RAW_MSG}, $i+2, 2));
-		# ???
-		#my $charID = substr($args->{RAW_MSG}, $i+4, 4);
+	undef $makableList;
+	my $k = 0;
+	my $msg;
+	$msg .= center(" " . T("Create Item List") . " ", 79, '-') . "\n";
+	for (my $i = 0; $i < length($args->{item_list}); $i += 8) {
+		my $nameID = unpack("v", substr($args->{item_list}, $i, 2));
+		$makableList->[$k] = $nameID;
+		$msg .= swrite(sprintf("\@%s \@%s (\@%s)", ('>'x2), ('<'x50), ('<'x6)), [$k, itemNameSimple($nameID), $nameID]);
+		$k++;
 	}
-	message "=========================\n";
+	$msg .= sprintf("%s\n", ('-'x79));
+	message($msg, "list");
+	message T("You can now use the 'create' command.\n"), "info";
+
+	Plugins::callHook('makable_item_list', {
+		item_list => $makableList,
+	});
 }
- 
+
 sub storage_opened {
 	my ($self, $args) = @_;
 	$char->storage->open($args);

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -246,7 +246,7 @@ sub new {
 		'0189' => ['no_teleport', 'v', [qw(fail)]],
 		'018B' => ['quit_response', 'v', [qw(fail)]], # 4 # ported from kRO_Sakexe_0
 		'018C' => ['sense_result', 'v3 V v4 C9', [qw(nameID level size hp def race mdef element ice earth fire wind poison holy dark spirit undead)]],
-		'018D' => ['forge_list'],
+		'018D' => ['makable_item_list', 'v a*', [qw(len item_list)]],
 		'018F' => ['refine_result', 'v2', [qw(fail nameID)]],
 		'0191' => ['talkie_box', 'a4 Z80', [qw(ID message)]], # talkie box message
 		'0192' => ['map_change_cell', 'v3 Z16', [qw(x y type map_name)]], # ex. due to ice wall
@@ -2879,7 +2879,10 @@ sub skill_use_failed {
 		13 => T('Need this within the water'),
 		19 => T('Full Amulet'),
 		29 => TF('Must have at least %s of base XP', '1%'),
-		83 => T('Location not allowed to create chatroom/market')
+		71 => T('Missing Required Item'), # (item name) required x amount
+		78 => T('Required Equiped Weapon Class'),
+		83 => T('Location not allowed to create chatroom/market'),
+		84 => T('Need more bullet'),
 		);
 
 	my $errorMessage;

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -261,7 +261,7 @@ sub new {
 		'0189' => ['no_teleport', 'v', [qw(fail)]], # 4
 		'018B' => ['quit_response', 'v', [qw(fail)]], # 4
 		'018C' => ['sense_result', 'v3 V v4 C9', [qw(nameID level size hp def race mdef element ice earth fire wind poison holy dark spirit undead)]], # 29
-		'018D' => ['forge_list'], # -1
+		'018D' => ['makable_item_list', 'v a*', [qw(len item_list)]], # -1
 		'018F' => ['refine_result', 'v2', [qw(fail nameID)]], # 6
 		'0191' => ['talkie_box', 'a4 Z80', [qw(ID message)]], # 86 # talkie box message
 		'0192' => ['map_change_cell', 'v3 Z16', [qw(x y type map_name)]], # 24 # ex. due to ice wall

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -1568,5 +1568,15 @@ sub sendPetEvolution {
 	}));
 }
 
+sub sendMakeItemRequest {
+	my ($self, $nameID, $material_nameID1, $material_nameID2, $material_nameID3) = @_;
+	$self->sendToServer($self->reconstruct({
+		switch => 'make_item_request',
+		nameID => $nameID,
+		material_nameID1 => $material_nameID1,
+		material_nameID2 => $material_nameID2,
+		material_nameID3 => $material_nameID3,
+	}));
+}
 
 1;

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -86,6 +86,7 @@ sub new {
 		'017E' => ['guild_chat', 'x2 Z*', [qw(message)]],
 		'0187' => ['ban_check', 'a4', [qw(accountID)]],
 		'018A' => ['quit_request', 'v', [qw(type)]],
+		'018E' => ['make_item_request', 'v4', [qw(nameID material_nameID1 material_nameID2 material_nameID3)]], # Forge Item / Create Potion
 		'0193' => ['actor_name_request', 'a4', [qw(ID)]],
 		'019F' => ['pet_capture', 'a4', [qw(ID)]],
 		'01B2' => ['shop_open'], # TODO

--- a/src/Network/Send/kRO/Sakexe_0.pm
+++ b/src/Network/Send/kRO/Sakexe_0.pm
@@ -79,6 +79,7 @@ sub new {
 		'017E' => ['guild_chat', 'x2 Z*', [qw(message)]],
 		'0187' => ['ban_check', 'a4', [qw(accountID)]],
 		'018A' => ['quit_request', 'v', [qw(type)]],
+		'018E' => ['make_item_request', 'v4', [qw(nameID material_nameID1 material_nameID2 material_nameID3)]], # Forge Item / Create Potion
 		'0193' => ['actor_name_request', 'a4', [qw(ID)]],
 		'01B2' => ['shop_open'], # TODO
 		'012E' => ['shop_close'], # len 2

--- a/src/functions.pl
+++ b/src/functions.pl
@@ -666,6 +666,7 @@ sub initMapChangeVars {
 	undef $repairList;
 	undef $devotionList;
 	undef $cookingList;
+	undef $makableList;
 	undef $rodexList;
 	undef $rodexWrite;
 	undef $skillExchangeItem;


### PR DESCRIPTION
After use skill Pharmacy or use Iron|Golden|Oridecon Hammer enable command 'create' that send to server request to create Potion/Weapon.

Syntax:
```
create <index number> <material 1 nameID> <material 2 nameID> <material 2 nameID>
```

Tested in private server  kRO_RagexeRE_2017_06_14b and rAthena Emulator

Create Potion:
![image](https://user-images.githubusercontent.com/10372732/41823962-b50d279e-77de-11e8-8e47-3502e6e21108.png)

Create Weapon:
![image](https://user-images.githubusercontent.com/10372732/41823972-da8c2970-77de-11e8-86da-b214c3a8755f.png)
