### PR TITLE
[eventMacro] Fix crash on reload

### DIFF
--- a/plugins/eventMacro/eventMacro.pl
+++ b/plugins/eventMacro/eventMacro.pl
@@ -94,8 +94,13 @@ sub parseAndHook {
 	$eventMacro = new eventMacro::Core($file);
 	if ($eventMacro->{parse_failed}) {
 		debug "[eventMacro] Loading error\n", "eventMacro", 2;
+		return;
 	} else {
 		debug "[eventMacro] Loading success\n", "eventMacro", 2;
+	}
+	
+	if ($char && $net && $net->getState() == Network::IN_GAME) {
+		$eventMacro->check_all_conditions();
 	}
 }
 

--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -76,10 +76,6 @@ sub new {
 	$self->set_arrays_size_to_zero();
 	$self->set_hashes_size_to_zero();
 
-	if ($char && $net && $net->getState() == Network::IN_GAME) {
-		$self->check_all_conditions();
-	}
-
 	return $self;
 }
 


### PR DESCRIPTION
This fixes the crash that would occur when using condition BaseActorNearDist and reloading while it was on 'true' state.

Before:
[Error](https://i.gyazo.com/70d307fb7309f82061178e3861357058.png)

After:
[Working](https://i.gyazo.com/d40daa6284ddcbcbc3342005b56ca03b.png)

Tested using this macro:
`automacro dist {
    exclusive 1
    timeout 5
    NpcNearDist /kafra/i <= 4
    call {
        log Heeeey, it works, text
    }
}`

