### PR TITLE
change configKeys from 'disconnect' to 'quit'

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -144,21 +144,24 @@ cachePlayerNames_maxSize 100
 
 clientSight 20
 
-dcPause 1
-dcOnDeath 0
-dcOnDualLogin 0
-dcOnDisconnect 0
-dcOnEmptyArrow 0
-dcOnMaxReconnections 0
-dcOnMute 0
-dcOnPM 0
-dcOnZeny 0
-dcOnStorageFull 1
-dcOnPlayer 0
-dcOnServerShutDown 0
-dcOnServerClose 0
-dcOnJobLevel
-dcOnLevel
+noRespawnAfterDeath 0
+reconnectTimeAfterDualLogin 20
+
+pauseOnQuit 1
+quitOnDeath 0
+quitOnDualLogin 0
+quitOnDisconnect 0
+quitOnEmptyArrow 0
+quitOnMaxReconnections 0
+quitOnMute 0
+quitOnPM 0
+quitOnZenyLowerThan 0
+quitOnStorageFull 1
+quitOnPlayerNearby 0
+quitOnServerShutDown 0
+quitOnServerClose 0
+quitOnJobLevel
+quitOnBaseLevel
 
 follow 0
 followCheckLOS 0

--- a/openkore.pl
+++ b/openkore.pl
@@ -206,7 +206,7 @@ sub shutdown {
 		close F;
 		print "Benchmark results saved to benchmark-results.txt\n";
 	}
-		$interface->errorDialog(T("Bye!\n")) if $config{dcPause};
+		$interface->errorDialog(T("Bye!\n")) if $config{pauseOnQuit};
 }
 
 if (!defined($ENV{INTERPRETER}) && !$ENV{NO_AUTOSTART}) {

--- a/plugins/needs-review/autokach/trunk/control/config.txt
+++ b/plugins/needs-review/autokach/trunk/control/config.txt
@@ -136,18 +136,19 @@ cachePlayerNames_maxSize 100
 
 clientSight 20
 
-dcOnDeath 0
-dcOnDualLogin 0
-dcOnDisconnect 0
-dcOnEmptyArrow 0
-dcOnMaxReconnections 0
-dcOnMute 0
-dcOnPM 0
-dcOnZeny 0
-dcOnStorageFull 1
-dcOnPlayer 0
-dcOnServerShutDown 0
-dcOnServerClose 0
+quitOnDeath 0
+noRespawnAfterDeath 0
+quitOnDualLogin 0
+quitOnDisconnect 0
+quitOnEmptyArrow 0
+quitOnMaxReconnections 0
+quitOnMute 0
+quitOnPM 0
+quitOnZenyLowerThan 0
+quitOnStorageFull 1
+quitOnPlayerNearby 0
+quitOnServerShutDown 0
+quitOnServerClose 0
 
 follow 0
 followTarget

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -971,14 +971,14 @@ sub processDead {
 		}
 	}
 
-	if (AI::action eq "dead" && $config{dcOnDeath} != -1 && time - $char->{dead_time} >= $timeout{ai_dead_respawn}{timeout}) {
+	if (AI::action eq "dead" && !$config{noRespawnAfterDeath} && time - $char->{dead_time} >= $timeout{ai_dead_respawn}{timeout}) {
 		$messageSender->sendRestart(0);
 		$char->{'dead_time'} = time;
 	}
 
-	if (AI::action eq "dead" && $config{dcOnDeath} && $config{dcOnDeath} != -1) {
-		error T("Auto disconnecting on death!\n");
-		chatLog("k", T("*** You died, auto disconnect! ***\n"));
+	if (AI::action eq "dead" && $config{quitOnDeath}) {
+		error T("Auto quiting on death!\n");
+		chatLog("k", T("*** You died, auto quiting! ***\n"));
 		$messageSender->sendQuit();
 		quit();
 	}
@@ -1378,10 +1378,10 @@ sub processAutoStorage {
 				$args->{done} = 1;
 				
 				# if storage is full disconnect if it says so in conf
-				if($char->storage->wasOpenedThisSession() && $char->storage->isFull() && $config{'dcOnStorageFull'}) {
+				if($char->storage->wasOpenedThisSession() && $char->storage->isFull() && $config{'quitOnStorageFull'}) {
 					$messageSender->sendQuit();
-					error T("Auto disconnecting on StorageFull!\n");
-					chatLog("k", T("*** Your storage is full , disconnect! ***\n"));
+					error T("Auto quiting on StorageFull!\n");
+					chatLog("k", T("*** Your storage is full , quit! ***\n"));
 					quit();
 				}
 
@@ -1547,10 +1547,10 @@ sub processAutoStorage {
 			$messageSender->sendStorageClose() unless $config{storageAuto_keepOpen};
 			if (percent_weight($char) >= $config{'itemsMaxWeight_sellOrStore'} && ai_storageAutoCheck()) {
 				error T("Character is still overweight after storageAuto (storage is full?)\n");
-				if ($config{dcOnStorageFull}) {
+				if ($config{quitOnStorageFull}) {
 					$messageSender->sendQuit();
-					error T("Auto disconnecting on StorageFull!\n");
-					chatLog("k", T("*** Your storage is full , disconnect! ***\n"));
+					error T("Auto quiting on StorageFull!\n");
+					chatLog("k", T("*** Your storage is full , quit! ***\n"));
 					quit();
 				}
 			}
@@ -3352,12 +3352,12 @@ sub processAutoBuyerShopOpen {
 
 sub processDcOnPlayer {
 	# Disconnect when a player is detected
-	if (!$field->isCity && !AI::inQueue("storageAuto", "buyAuto") && $config{dcOnPlayer}
+	if (!$field->isCity && !AI::inQueue("storageAuto", "buyAuto") && $config{quitOnPlayerNearby}
 		&& ($config{'lockMap'} eq "" || $field->baseName eq $config{'lockMap'})
 		&& !isSafe() && timeOut($AI::Temp::Teleport_allPlayers, 0.75)) {
 			$messageSender->sendQuit();
-			error T("Auto disconnecting on Player!\n");
-			chatLog("k", T("*** Nearby is another player, auto disconnect! ***\n"));
+			error T("Auto quiting, Player detected!\n");
+			chatLog("k", T("*** there is a player nearby, auto quit! ***\n"));
 			quit();
 	}
 }

--- a/src/Interface/Wx.pm
+++ b/src/Interface/Wx.pm
@@ -1134,7 +1134,7 @@ sub onAdvancedConfig {
 	$cfg->addCategory('items', 'Grid', ['itemsTakeAuto', 'itemsTakeAuto_party', 'itemsGatherAuto', 'itemsMaxWeight', 'itemsMaxWeight_sellOrStore', 'itemsMaxNum_sellOrStore', 'cartMaxWeight']);
 	$cfg->addCategory('sellAuto', 'Grid', ['sellAuto', 'sellAuto_npc', 'sellAuto_standpoint', 'sellAuto_distance']);
 	$cfg->addCategory('storageAuto', 'Grid', ['storageAuto', 'storageAuto_npc', 'storageAuto_distance', 'storageAuto_npc_type', 'storageAuto_npc_steps', 'storageAuto_password', 'storageAuto_keepOpen', 'storageAuto_useChatCommand', 'relogAfterStorage']);
-	$cfg->addCategory('disconnect', 'Grid', ['dcOnDeath', 'dcOnDualLogin', 'dcOnDisconnect', 'dcOnEmptyArrow', 'dcOnMute', 'dcOnPM', 'dcOnZeny', 'dcOnStorageFull', 'dcOnPlayer']);
+	$cfg->addCategory('quiting', 'Grid', ['quitOnDeath', 'quitOnDualLogin', 'quitOnDisconnect', 'quitOnEmptyArrow', 'quitOnMute', 'quitOnPM', 'quitOnZenyLowerThan', 'quitOnStorageFull', 'quitOnPlayerNearby']);
 
 	$cfg->onChange(sub {
 		my ($key, $value) = @_;

--- a/src/Network/DirectConnection.pm
+++ b/src/Network/DirectConnection.pm
@@ -468,8 +468,8 @@ sub checkConnection {
 
 		} elsif (timeOut($timeout{'master'}) && timeOut($timeout_ex{'master'})) {
 			if ($config{quitOnMaxReconnections} && $config{quitOnMaxReconnections} <= $reconnectCount) {
-				error T("Auto disconnecting on MaxReconnections!\n");
-				chatLog("k", T("*** Exceeded the maximum number attempts to reconnect, auto disconnect! ***\n"));
+				error T("Auto quiting on MaxReconnections!\n");
+				chatLog("k", T("*** Exceeded the maximum number attempts to reconnect, auto quit! ***\n"));
 				$quit = 1;
 				return;
 			}
@@ -620,8 +620,8 @@ sub checkConnection {
 		if(!$self->serverAlive()) {
 			Plugins::callHook('disconnected');
 			if ($config{quitOnDisconnect}) {
-				error T("Auto disconnecting on Disconnect!\n");
-				chatLog("k", T("*** You disconnected, auto disconnect! ***\n"));
+				error T("Auto quiting on Disconnect!\n");
+				chatLog("k", T("*** You disconnected, auto quit! ***\n"));
 				$quit = 1;
 			} else {
 				message TF("Disconnected from Map Server, connecting to Account Server in %s seconds...\n", $timeout{reconnect}{timeout}), "connection";
@@ -635,7 +635,7 @@ sub checkConnection {
 			error T("Timeout on Map Server, "), "connection";
 			Plugins::callHook('disconnected');
 			if ($config{quitOnDisconnect}) {
-				error T("Auto disconnecting on Disconnect!\n");
+				error T("Auto quiting on Disconnect!\n");
 				chatLog("k", T("*** You disconnected, auto disconnect! ***\n"));
 				$quit = 1;
 			} else {

--- a/src/Network/DirectConnection.pm
+++ b/src/Network/DirectConnection.pm
@@ -467,7 +467,7 @@ sub checkConnection {
 			undef $secureLoginKey;
 
 		} elsif (timeOut($timeout{'master'}) && timeOut($timeout_ex{'master'})) {
-			if ($config{dcOnMaxReconnections} && $config{dcOnMaxReconnections} <= $reconnectCount) {
+			if ($config{quitOnMaxReconnections} && $config{quitOnMaxReconnections} <= $reconnectCount) {
 				error T("Auto disconnecting on MaxReconnections!\n");
 				chatLog("k", T("*** Exceeded the maximum number attempts to reconnect, auto disconnect! ***\n"));
 				$quit = 1;
@@ -619,7 +619,7 @@ sub checkConnection {
 	} elsif ($self->getState() == Network::IN_GAME) {
 		if(!$self->serverAlive()) {
 			Plugins::callHook('disconnected');
-			if ($config{dcOnDisconnect}) {
+			if ($config{quitOnDisconnect}) {
 				error T("Auto disconnecting on Disconnect!\n");
 				chatLog("k", T("*** You disconnected, auto disconnect! ***\n"));
 				$quit = 1;
@@ -634,7 +634,7 @@ sub checkConnection {
 		} elsif (timeOut($timeout{play})) {
 			error T("Timeout on Map Server, "), "connection";
 			Plugins::callHook('disconnected');
-			if ($config{dcOnDisconnect}) {
+			if ($config{quitOnDisconnect}) {
 				error T("Auto disconnecting on Disconnect!\n");
 				chatLog("k", T("*** You disconnected, auto disconnect! ***\n"));
 				$quit = 1;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -4130,7 +4130,10 @@ sub errors {
 
 	Plugins::callHook('disconnected') if ($net->getState() == Network::IN_GAME);
 	if ($net->getState() == Network::IN_GAME &&
-		($config{quitOnDisconnect} > 1 || ($config{quitOnDisconnect} && $args->{type} != 3 && $args->{type} != 10))) {
+		($config{quitOnDisconnect} > 1 ||
+		($config{quitOnDisconnect} &&
+		$args->{type} != 3 &&
+		$args->{type} != 10))) {
 		error T("Auto quiting on Disconnect!\n");
 		chatLog("k", T("*** You disconnected, auto quit! ***\n"));
 		$quit = 1;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -858,9 +858,9 @@ our %stat_info_handlers = (
 
 		return unless $actor->isa('Actor::You');
 
-		if ($config{dcOnMute} && $actor->{muted}) {
-			error TF("Auto disconnecting, %s have been muted for %s minutes!\n", $actor, $actor->{mute_period}/60);
-			chatLog("k", TF("*** %s have been muted for %d minutes, auto disconnect! ***\n", $actor, $actor->{mute_period}/60));
+		if ($config{quitOnMute} && $actor->{muted}) {
+			error TF("Auto quiting, %s have been muted for %s minutes!\n", $actor, $actor->{mute_period}/60);
+			chatLog("k", TF("*** %s have been muted for %d minutes, auto quit! ***\n", $actor, $actor->{mute_period}/60));
 			$messageSender->sendQuit();
 			quit();
 		}
@@ -889,12 +889,12 @@ our %stat_info_handlers = (
 		return unless $actor->isa('Actor::You');
 
 		Plugins::callHook('base_level_changed', {
-			level	=> $actor->{lv}
+			level => $actor->{lv}
 		});
 
-		if ($config{dcOnLevel} && $actor->{lv} >= $config{dcOnLevel}) {
-			message TF("Disconnecting on level %s!\n", $config{dcOnLevel});
-			chatLog("k", TF("Disconnecting on level %s!\n", $config{dcOnLevel}));
+		if ($config{quitOnBaseLevel} && $actor->{lv} >= $config{quitOnBaseLevel}) {
+			message TF("quiting on base level %s!\n", $config{quitOnBaseLevel});
+			chatLog("k", TF("quiting on base level %s!\n", $config{quitOnBaseLevel}));
 			quit();
 		}
 	},
@@ -927,10 +927,10 @@ our %stat_info_handlers = (
 		});
 
 
-		if ($config{dcOnZeny} && $actor->{zeny} <= $config{dcOnZeny}) {
+		if ($config{quitOnZenyLowerThan} && $actor->{zeny} <= $config{quitOnZenyLowerThan}) {
 			$messageSender->sendQuit();
-			error (TF("Auto disconnecting due to zeny lower than %s!\n", $config{dcOnZeny}));
-			chatLog("k", T("*** You have no money, auto disconnect! ***\n"));
+			error (TF("Auto quiting due to zeny lower than %s!\n", $config{quitOnZenyLowerThan}));
+			chatLog("k", TF("*** You have less than %s zenys, auto quit! ***\n", $config{quitOnZenyLowerThan}));
 			quit();
 		}
 	},
@@ -997,9 +997,9 @@ our %stat_info_handlers = (
 			level	=> $actor->{lv_job}
 		});
 
-		if ($config{dcOnJobLevel} && $actor->{lv_job} >= $config{dcOnJobLevel}) {
-			message TF("Disconnecting on job level %d!\n", $config{dcOnJobLevel});
-			chatLog("k", TF("Disconnecting on job level %d!\n", $config{dcOnJobLevel}));
+		if ($config{quitOnJobLevel} && $actor->{lv_job} >= $config{quitOnJobLevel}) {
+			message TF("quiting on job level %d!\n", $config{quitOnJobLevel});
+			chatLog("k", TF("quiting on job level %d!\n", $config{quitOnJobLevel}));
 			quit();
 		}
 	},
@@ -1702,7 +1702,7 @@ sub actor_died_or_disappeared {
 	if ($ID eq $accountID) {
 		message T("You have died\n") if (!$char->{dead});
 		Plugins::callHook('self_died');
-		closeShop() unless !$shopstarted || $config{'dcOnDeath'} == -1 || AI::state == AI::OFF;
+		closeShop() unless !$shopstarted || $config{'noRespawnAfterDeath'} || AI::state == AI::OFF;
 		$char->{deathCount}++;
 		$char->{dead} = 1;
 		$char->{dead_time} = time;
@@ -4130,12 +4130,9 @@ sub errors {
 
 	Plugins::callHook('disconnected') if ($net->getState() == Network::IN_GAME);
 	if ($net->getState() == Network::IN_GAME &&
-		($config{dcOnDisconnect} > 1 ||
-		($config{dcOnDisconnect} &&
-		$args->{type} != 3 &&
-		$args->{type} != 10))) {
-		error T("Auto disconnecting on Disconnect!\n");
-		chatLog("k", T("*** You disconnected, auto disconnect! ***\n"));
+		($config{quitOnDisconnect} > 1 || ($config{quitOnDisconnect} && $args->{type} != 3 && $args->{type} != 10))) {
+		error T("Auto quiting on Disconnect!\n");
+		chatLog("k", T("*** You disconnected, auto quit! ***\n"));
 		$quit = 1;
 	}
 
@@ -4149,31 +4146,31 @@ sub errors {
 	}
 	if ($args->{type} == 0) {
 		# FIXME BAN_SERVER_SHUTDOWN is 0x1, 0x0 is BAN_UNFAIR
-		if ($config{'dcOnServerShutDown'} == 1) {
-			error T("Auto disconnecting on ServerShutDown!\n");
-			chatLog("k", T("*** Server shutting down , auto disconnect! ***\n"));
+		if ($config{'quitOnServerShutDown'} == 1) {
+			error T("Auto quiting on ServerShutDown!\n");
+			chatLog("k", T("*** Server shutting down , auto quit! ***\n"));
 			$quit = 1;
 		} else {
 			error T("Server shutting down\n"), "connection";
 		}
 	} elsif ($args->{type} == 1) {
-		if($config{'dcOnServerClose'} == 1) {
-			error T("Auto disconnecting on ServerClose!\n");
-			chatLog("k", T("*** Server is closed , auto disconnect! ***\n"));
+		if($config{'quitOnServerClose'} == 1) {
+			error T("Auto quiting on ServerClose!\n");
+			chatLog("k", T("*** Server is closed , auto quit! ***\n"));
 			$quit = 1;
 		} else {
 			error T("Error: Server is closed\n"), "connection";
 		}
 	} elsif ($args->{type} == 2) {
-		if ($config{'dcOnDualLogin'} == 1) {
+		if ($config{'quitOnDualLogin'}) {
 			error (TF("Critical Error: Dual login prohibited - Someone trying to login!\n\n" .
-				"%s will now immediately 	disconnect.\n", $Settings::NAME));
-			chatLog("k", T("*** DualLogin, auto disconnect! ***\n"));
+				"%s will now immediately quit.\n", $Settings::NAME));
+			chatLog("k", T("*** DualLogin, auto quit! ***\n"));
 			quit();
-		} elsif ($config{'dcOnDualLogin'} >= 2) {
+		} elsif ($config{'reconnectTimeAfterDualLogin'} >= 1) {
 			error T("Critical Error: Dual login prohibited - Someone trying to login!\n");
-			message TF("Reconnecting, wait %s seconds...\n", $config{'dcOnDualLogin'}), "connection";
-			$timeout_ex{'master'}{'timeout'} = $config{'dcOnDualLogin'};
+			message TF("Reconnecting, wait %s seconds...\n", $config{'reconnectTimeAfterDualLogin'}), "connection";
+			$timeout_ex{'master'}{'timeout'} = $config{'reconnectTimeAfterDualLogin'};
 		} else {
 			error T("Critical Error: Dual login prohibited - Someone trying to login!\n"), "connection";
 		}

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -1025,9 +1025,9 @@ sub arrow_none {
 	my $type = $args->{type};
 	if ($type == 0) {
 		delete $char->{'arrow'};
-		if ($config{'dcOnEmptyArrow'}) {
-			error T("Auto disconnecting on EmptyArrow!\n");
-			chatLog("k", T("*** Your Arrows is ended, auto disconnect! ***\n"));
+		if ($config{'quitOnEmptyArrow'}) {
+			error T("Auto quiting on EmptyArrow!\n");
+			chatLog("k", T("*** Your Arrows is ended, auto quiting! ***\n"));
 			$messageSender->sendQuit();
 			quit();
 		} else {
@@ -2195,9 +2195,9 @@ sub private_message {
 		Msg => $privMsg
 	});
 
-	if ($config{dcOnPM} && AI::state == AI::AUTO) {
-		message T("Auto disconnecting on PM!\n");
-		chatLog("k", T("*** You were PM'd, auto disconnect! ***\n"));
+	if ($config{quitOnPM} && AI::state == AI::AUTO) {
+		message T("Auto quiting on PM!\n");
+		chatLog("k", T("*** You were PM'd, auto quit! ***\n"));
 		$messageSender->sendQuit();
 		quit();
 	}

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -917,7 +917,7 @@ sub arrow_none {
 	my $type = $args->{type};
 	if ($type == 0) {
 		delete $char->{'arrow'};
-		if ($config{'dcOnEmptyArrow'}) {
+		if ($config{'quitOnEmptyArrow'}) {
 			error T("Auto disconnecting on EmptyArrow!\n");
 			chatLog("k", T("*** Your Arrows is ended, auto disconnect! ***\n"));
 			$messageSender->sendQuit();
@@ -2127,9 +2127,9 @@ sub private_message {
 		Msg => $privMsg
 	});
 
-	if ($config{dcOnPM} && AI::state == AI::AUTO) {
-		message T("Auto disconnecting on PM!\n");
-		chatLog("k", T("*** You were PM'd, auto disconnect! ***\n"));
+	if ($config{quitOnPM} && AI::state == AI::AUTO) {
+		message T("Auto quiting on PM!\n");
+		chatLog("k", T("*** You were PM'd, auto quit! ***\n"));
 		$messageSender->sendQuit();
 		quit();
 	}

--- a/src/Network/XKore.pm
+++ b/src/Network/XKore.pm
@@ -244,7 +244,7 @@ sub checkConnection {
 		$self->setState(Network::NOT_CONNECTED);
 		error T("Timeout on Map Server, "), "connection";
 		Plugins::callHook('disconnected');
-		if ($config{dcOnDisconnect}) {
+		if ($config{quitOnDisconnect}) {
 			error T("Auto disconnecting on Disconnect!\n");
 			chatLog("k", T("*** You disconnected, auto disconnect! ***\n"));
 			$quit = 1;

--- a/src/Network/XKore.pm
+++ b/src/Network/XKore.pm
@@ -245,8 +245,8 @@ sub checkConnection {
 		error T("Timeout on Map Server, "), "connection";
 		Plugins::callHook('disconnected');
 		if ($config{quitOnDisconnect}) {
-			error T("Auto disconnecting on Disconnect!\n");
-			chatLog("k", T("*** You disconnected, auto disconnect! ***\n"));
+			error T("Auto quiting on Disconnect!\n");
+			chatLog("k", T("*** You disconnected, auto quit! ***\n"));
 			$quit = 1;
 		} else {
 			error "waiting actions for the Ragnarok Online client\n";

--- a/tables/bRO/control-br/config.txt
+++ b/tables/bRO/control-br/config.txt
@@ -157,21 +157,23 @@ cachePlayerNames_maxSize 100
 
 clientSight 20
 
-dcPause 1
-dcOnDeath 0
-dcOnDualLogin 0
-dcOnDisconnect 0
-dcOnEmptyArrow 0
-dcOnMaxReconnections 0
-dcOnMute 0
-dcOnPM 0
-dcOnZeny 0
-dcOnStorageFull 1
-dcOnPlayer 0
-dcOnServerShutDown 0
-dcOnServerClose 0
-dcOnJobLevel
-dcOnLevel
+pauseOnQuit 1
+quitOnDeath 0
+noRespawnAfterDeath 0
+quitOnDualLogin 0
+reconnectTimeAfterDualLogin 20
+quitOnDisconnect 0
+quitOnEmptyArrow 0
+quitOnMaxReconnections 0
+quitOnMute 0
+quitOnPM 0
+quitOnZenyLowerThan 0
+quitOnStorageFull 1
+quitOnPlayerNearby 0
+quitOnServerShutDown 0
+quitOnServerClose 0
+quitOnJobLevel
+quitOnBaseLevel
 
 follow 0
 followCheckLOS 0

--- a/tables/twRO/chinese/control/config.txt
+++ b/tables/twRO/chinese/control/config.txt
@@ -1863,49 +1863,51 @@ removeActorWithDistance
 #║ 特殊情況 AI 處理 設定 ║
 #║                       ║
 #═════════════════════════
-dcOnDeath 0
+quitOnDeath 0
+noRespawnAfterDeath 0
 # 當角色死亡時，-1 = 不做任何事、0 = 過一段時間後回城、 2 = 直接斷線［結束自動練功］
 
-dcOnDualLogin 0
+quitOnDualLogin 0
+reconnectTimeAfterDualLogin 20
 # 遇到相同帳號登入時的反應。0 = 立刻重連、 1 = 立刻斷線結束、 >1以上 = 斷線幾秒後重連
 
-dcOnDisconnect 0
+quitOnDisconnect 0
 # 網路不通時的反應。0 = 不反應，持續連線。
 
-dcOnEmptyArrow 0
+quitOnEmptyArrow 0
 # 箭矢用光時是否斷線結束 如沒設定自動取箭矢  人物只會走到魔物面前不做任何事情重複再重複的走
 # 很容易就被識為外掛
 
-dcOnMaxReconnections 0
+quitOnMaxReconnections 0
 # 連線失敗最多幾次後就放棄結束。0 = 永不放棄、>1以上 = 次數
 
-dcOnMute 0
+quitOnMute 0
 # 被禁言時是否斷線結束 ［魔物沉默術，綠水可解，或系統禁言］
 # 註：關係到法師系角色的施法，還有無限瞬移。
 
-dcOnPM 0
+quitOnPM 0
 # 被密語時是否斷線結束
 
-dcOnZeny 0
+quitOnZenyLowerThan 0
 # 身上 zeny 少於多少錢時自動斷線結束。0 = 忽略、>1以上 = zeny 數目
 # 註：有時候自動買物來練功，可能會買到沒錢，而 kore 又一直買而陷入迴圈。
 
-dcOnStorageFull 0
+quitOnStorageFull 0
 # 自動存倉完成後若身上負重仍高於設定值時［表示倉庫可能滿了］是否自動斷線結束
 # 註：倉庫最大只能存 300 樣物品，每樣物品最高數量 3萬個
 
-dcOnPlayer 0
+quitOnPlayerNearby 0
 # 有任何玩家出現在視線範圍內時是否要斷線結束
 # 註：假如是掛見不得人的地圖的話，例如：未開放地圖，PVP 夢靨模式。
 
-dcOnLevel 0
+quitOnBaseLevel 0
 # 基本等級升級時是否要斷線結速
 
-dcOnJobLevel 0
+quitOnJobLevel 0
 # 技能等級升級時是否要斷線結速
 
-dcOnServerShutDown 0
-dcOnServerClose 0
+quitOnServerShutDown 0
+quitOnServerClose 0
 #════════════════════════════
 #║                          ║
 #║ 人工生命體 傭兵 寵物設定 ║


### PR DESCRIPTION
## Things changed:
all configs that start with 'disconnect' were changed to `quit`, since the config is in fact quiting

#### dcOnDeath
this has additional changes, it was splitted into two different configs: `quitOnDeath` and `noRespawnAfterDeath`
the `noRespawnAfterDeath` config are meant for people who don't want to get back to city when the char dies.

#### dcOnDualLogin
this has also additional changes, it was splitted into two different configs too: `quitOnDualLogin`and `reconnectTimeAfterDualLogin`
the `reconnectTimeAfterDualLogin` defines how many seconds it will wait before recconect after a dual login detected


#### Others have no changes, only their names
