### PR TITLE
Network use reconstruct

### DIFF
--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -1737,4 +1737,17 @@ sub sendAdoptRequest {
 	debug "Sent Adoption Request.\n", "sendPacket", 2;
 }
 
+sub sendAdoptReply {
+	my ($self, $parentID1, $parentID2, $result) = @_;
+	
+	$self->sendToServer($self->reconstruct({
+		switch => 'adopt_reply_request',
+		parentID1 => $parentID1,
+		parentID2 => $parentID2,
+		result => $result
+	}));
+	
+	debug "Sent Adoption Reply.\n", "sendPacket", 2;
+}
+
 1;

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -1711,4 +1711,19 @@ sub sendFriendRemove {
 	debug "Sent Remove a friend\n", "sendPacket";
 }
 
+sub sendRepairItem {
+	my ($self, $args) = @_;
+	
+	$self->sendToServer($self->reconstruct({
+		switch => 'repair_item',
+		index => $args->{ID},
+		nameID => $args->{nameID},
+		status => $args->{status},
+		status2 => $args->{status2},
+		listID => $args->{listID},
+	}));
+	
+	debug ("Sent repair item: ".$args->{ID}."\n", "sendPacket", 2);
+}
+
 1;

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -1698,4 +1698,17 @@ sub sendChangeDress {
 	
 	debug "Sent Change Dress\n", "sendPacket", 2;
 }
+
+sub sendFriendRemove {
+	my ($self, $accountID, $charID) = @_;
+	
+	$self->sendToServer($self->reconstruct({
+		switch => 'friend_remove',
+		accountID => $accountID,
+		charID => $charID,
+	}));
+	
+	debug "Sent Remove a friend\n", "sendPacket";
+}
+
 1;

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -1726,4 +1726,15 @@ sub sendRepairItem {
 	debug ("Sent repair item: ".$args->{ID}."\n", "sendPacket", 2);
 }
 
+sub sendAdoptRequest {
+	my ($self, $ID) = @_;
+	
+	$self->sendToServer($self->reconstruct({
+		switch => 'adopt_request',
+		ID => $ID,
+	}));
+	
+	debug "Sent Adoption Request.\n", "sendPacket", 2;
+}
+
 1;

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -98,6 +98,7 @@ sub new {
 		'01E7' => ['novice_dori_dori'],
 		'01FA' => ['master_login', 'V Z24 a16 C C', [qw(version username password_salted_md5 master_version clientInfo)]],
 		'0202' => ['friend_request', 'a*', [qw(username)]],# len 26
+		'0203' => ['friend_remove', 'a4 a4', [qw(accountID charID)]],
 		'0204' => ['client_hash', 'a16', [qw(hash)]],
 		'0208' => ['friend_response', 'a4 a4 V', [qw(friendAccountID friendCharID type)]],
 		'021D' => ['less_effect'], # TODO
@@ -489,16 +490,6 @@ sub sendEmotion {
 	my $msg = pack("C*", 0xBF, 0x00).pack("C1",$ID);
 	$self->sendToServer($msg);
 	debug "Sent Emotion\n", "sendPacket", 2;
-}
-
-# 0x0208,11,friendslistreply,2:6:10
-# Reject:0/Accept:1
-
-sub sendFriendRemove {
-	my ($self, $accountID, $charID) = @_;
-	my $msg = pack("C*", 0x03, 0x02) . $accountID . $charID;
-	$self->sendToServer($msg);
-	debug "Sent Remove a friend\n", "sendPacket";
 }
 
 =pod

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -96,6 +96,7 @@ sub new {
 		'01DB' => ['secure_login_key_request'], # len 2
 		'01DD' => ['master_login', 'V Z24 a16 C', [qw(version username password_salted_md5 master_version)]],
 		'01E7' => ['novice_dori_dori'],
+		'01F7' => ['adopt_reply_request', 'V3', [qw(parentID1 parentID2 result)]],
 		'01F9' => ['adopt_request', 'V', [qw(ID)]],
 		'01FA' => ['master_login', 'V Z24 a16 C C', [qw(version username password_salted_md5 master_version clientInfo)]],
 		'01FD' => ['repair_item', 'a2 v V2 C', [qw(index nameID status status2 listID)]],
@@ -1034,13 +1035,6 @@ sub sendWho {
 	my $msg = pack("v", 0x00C1);
 	$self->sendToServer($msg);
 	debug "Sent Who\n", "sendPacket", 2;
-}
-
-sub SendAdoptReply {
-	my ($self, $parentID1, $parentID2, $result) = @_;
-	my $msg = pack("v V3", 0x01F7, $parentID1, $parentID2, $result);
-	$self->sendToServer($msg);
-	debug "Sent Adoption Reply.\n", "sendPacket", 2;
 }
 
 # 0x0213 has no info on eA

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -97,6 +97,7 @@ sub new {
 		'01DD' => ['master_login', 'V Z24 a16 C', [qw(version username password_salted_md5 master_version)]],
 		'01E7' => ['novice_dori_dori'],
 		'01FA' => ['master_login', 'V Z24 a16 C C', [qw(version username password_salted_md5 master_version clientInfo)]],
+		'01FD' => ['repair_item', 'a2 v V2 C', [qw(index nameID status status2 listID)]],
 		'0202' => ['friend_request', 'a*', [qw(username)]],# len 26
 		'0203' => ['friend_remove', 'a4 a4', [qw(accountID charID)]],
 		'0204' => ['client_hash', 'a16', [qw(hash)]],
@@ -907,13 +908,6 @@ sub sendRemoveAttachments {
 	my $msg = pack("C*", 0x2A, 0x01);
 	$_[0]->sendToServer($msg);
 	debug "Sent remove attachments\n", "sendPacket", 2;
-}
-
-sub sendRepairItem {
-	my ($self, $args) = @_;
-	my $msg = pack("C2 a2 v V2 C1", 0xFD, 0x01, $args->{ID}, $args->{nameID}, $args->{status}, $args->{status2}, $args->{listID});
-	$self->sendToServer($msg);
-	debug ("Sent repair item: ".$args->{ID}."\n", "sendPacket", 2);
 }
 
 sub sendSellBulk {

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -96,6 +96,7 @@ sub new {
 		'01DB' => ['secure_login_key_request'], # len 2
 		'01DD' => ['master_login', 'V Z24 a16 C', [qw(version username password_salted_md5 master_version)]],
 		'01E7' => ['novice_dori_dori'],
+		'01F9' => ['adopt_request', 'V', [qw(ID)]],
 		'01FA' => ['master_login', 'V Z24 a16 C C', [qw(version username password_salted_md5 master_version clientInfo)]],
 		'01FD' => ['repair_item', 'a2 v V2 C', [qw(index nameID status status2 listID)]],
 		'0202' => ['friend_request', 'a*', [qw(username)]],# len 26
@@ -1040,13 +1041,6 @@ sub SendAdoptReply {
 	my $msg = pack("v V3", 0x01F7, $parentID1, $parentID2, $result);
 	$self->sendToServer($msg);
 	debug "Sent Adoption Reply.\n", "sendPacket", 2;
-}
-
-sub SendAdoptRequest {
-	my ($self, $ID) = @_;
-	my $msg = pack("v V", 0x01F9, $ID);
-	$self->sendToServer($msg);
-	debug "Sent Adoption Request.\n", "sendPacket", 2;
 }
 
 # 0x0213 has no info on eA

--- a/src/Network/Send/kRO/Sakexe_0.pm
+++ b/src/Network/Send/kRO/Sakexe_0.pm
@@ -1323,14 +1323,6 @@ sub SendAdoptReply {
 
 # 0x01f8,2
 
-# 0x01f9,6,adoptrequest,0
-sub SendAdoptRequest {
-	my ($self, $ID) = @_;
-	my $msg = pack('v V', 0x01F9, $ID);
-	$self->sendToServer($msg);
-	debug "Sent Adoption Request.\n", "sendPacket", 2;
-}
-
 # 0x01fa,48
 # TODO
 

--- a/src/Network/Send/kRO/Sakexe_0.pm
+++ b/src/Network/Send/kRO/Sakexe_0.pm
@@ -86,6 +86,8 @@ sub new {
 		'01D5' => ['npc_talk_text', 'v a4 Z*', [qw(len ID text)]],
 		'01DB' => ['secure_login_key_request'], # len 2
 		'01E7' => ['novice_dori_dori'],
+		'01F7' => ['adopt_reply_request', 'V3', [qw(parentID1 parentID2 result)]],
+		'01F9' => ['adopt_request', 'V', [qw(ID)]],
 		'01FD' => ['repair_item', 'a2 v V2 C', [qw(index nameID status status2 listID)]],
 		'0202' => ['friend_request', 'a*', [qw(username)]],# len 26
 		'0203' => ['friend_remove', 'a4 a4', [qw(accountID charID)]],
@@ -1312,14 +1314,6 @@ sub sendSuperNoviceExplosion {
 # 0x01f4,32
 # 0x01f5,9
 # 0x01f6,34
-
-# 0x01f7,14,adoptreply,0
-sub SendAdoptReply {
-	my ($self, $parentID1, $parentID2, $result) = @_;
-	my $msg = pack('v V3', 0x01F7, $parentID1, $parentID2, $result);
-	$self->sendToServer($msg);
-	debug "Sent Adoption Reply.\n", "sendPacket", 2;
-}
 
 # 0x01f8,2
 

--- a/src/Network/Send/kRO/Sakexe_0.pm
+++ b/src/Network/Send/kRO/Sakexe_0.pm
@@ -86,6 +86,7 @@ sub new {
 		'01D5' => ['npc_talk_text', 'v a4 Z*', [qw(len ID text)]],
 		'01DB' => ['secure_login_key_request'], # len 2
 		'01E7' => ['novice_dori_dori'],
+		'01FD' => ['repair_item', 'a2 v V2 C', [qw(index nameID status status2 listID)]],
 		'0202' => ['friend_request', 'a*', [qw(username)]],# len 26
 		'0203' => ['friend_remove', 'a4 a4', [qw(accountID charID)]],
 		'0204' => ['client_hash', 'a16', [qw(hash)]],
@@ -1338,14 +1339,6 @@ sub SendAdoptRequest {
 
 # 0x01fc,-1
 
-# 0x01fd,4,repairitem,2
-sub sendRepairItem {
-	my ($self, $args) = @_;
-	my $msg = pack('C2 a2 v V2 C', 0x01FD, $args->{ID}, $args->{nameID}, $args->{status}, $args->{status2}, $args->{listID});
-	$self->sendToServer($msg);
-	debug ("Sent repair item: ".$args->{ID}."\n", "sendPacket", 2);
-}
-
 # 0x01fe,5
 # 0x01ff,10
 
@@ -1359,9 +1352,6 @@ sub sendRepairItem {
 # 0x0205,26
 # 0x0206,11
 # 0x0207,34
-
-# 0x0208,11,friendslistreply,2:6:10
-# sendFriendReject:0/sendFriendAccept:1
 
 sub SendPrivateairShiprequest {
 	my ($self, $args,$mapname,$ItemID) = @_;

--- a/src/Network/Send/kRO/Sakexe_0.pm
+++ b/src/Network/Send/kRO/Sakexe_0.pm
@@ -87,6 +87,7 @@ sub new {
 		'01DB' => ['secure_login_key_request'], # len 2
 		'01E7' => ['novice_dori_dori'],
 		'0202' => ['friend_request', 'a*', [qw(username)]],# len 26
+		'0203' => ['friend_remove', 'a4 a4', [qw(accountID charID)]],
 		'0204' => ['client_hash', 'a16', [qw(hash)]],
 		'0208' => ['friend_response', 'a4 a4 C', [qw(friendAccountID friendCharID type)]],
 		'0222' => ['refine_item', 'V', [qw(ID)]],
@@ -1352,14 +1353,6 @@ sub sendRepairItem {
 # TODO
 
 # 0x0201,-1
-
-# 0x0203,10,friendslistremove,2:6
-sub sendFriendRemove {
-	my ($self, $accountID, $charID) = @_;
-	my $msg = pack('v a4 a4', 0x0203, $accountID, $charID);
-	$self->sendToServer($msg);
-	debug "Sent Remove a friend\n", "sendPacket";
-}
 
 # 0x0204,18
 


### PR DESCRIPTION
Rework sendFriendRemove, sendRepairItem, sendAdoptRequest and sendAdoptReply to use Network::PacketParser::reconstruct instead of manually packing stuff.

Also those methods were merged into Network::Send

Behavior is unchanged.