### PR TITLE
Fix issue #841: After kill kore move away from another monsters

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -626,7 +626,8 @@ sub processEscapeUnknownMaps {
 				ai_route($field->baseName, $randX, $randY,
 					 maxRouteTime => $config{route_randomWalk_maxRouteTime},
 					 attackOnRoute => 2,
-					 noMapRoute => ($config{route_randomWalk} == 2 ? 1 : 0) );
+					 noMapRoute => ($config{route_randomWalk} == 2 ? 1 : 0),
+					 isRandomWalk => 1);
 			}
 		}
 	}
@@ -2154,7 +2155,8 @@ sub processRandomWalk {
 			ai_route($field->baseName, $randX, $randY,
 				maxRouteTime => $config{route_randomWalk_maxRouteTime},
 				attackOnRoute => 2,
-				noMapRoute => ($config{route_randomWalk} == 2 ? 1 : 0) );
+				noMapRoute => ($config{route_randomWalk} == 2 ? 1 : 0),
+				isRandomWalk => 1);
 		}
 	}
 }
@@ -2975,6 +2977,9 @@ sub processAutoAttack {
 		# If an appropriate monster's found, attack it. If not, wait ai_attack_auto secs before searching again.
 		if ($attackTarget) {
 			ai_setSuspend(0);
+			
+			AI::dequeue() while (AI::is(qw/move route mapRoute/) && AI::args()->{isRandomWalk});
+			
 			$char->attack($attackTarget);
 		} else {
 			$timeout{'ai_attack_auto'}{'time'} = time;

--- a/src/Actor.pm
+++ b/src/Actor.pm
@@ -785,7 +785,7 @@ sub route {
 	} else {
 		$task = new Task::Route(@params);
 	}
-	$task->{$_} = $args{$_} for qw(attackID attackOnRoute noSitAuto LOSSubRoute);
+	$task->{$_} = $args{$_} for qw(attackID attackOnRoute noSitAuto LOSSubRoute isRandomWalk);
 	
 	$self->queue('route', $task);
 }


### PR DESCRIPTION
This bug was caused by randomWalk not being unstacked from queue when we stack an attack to the queue.