### PR TITLE
Fix for unsucessful initialized talks to NPCs

### DIFF
--- a/src/Task/TalkNPC.pm
+++ b/src/Task/TalkNPC.pm
@@ -788,6 +788,10 @@ sub cancelTalk {
 		$self->conversation_end;
 		$ai_v{'npc_talk'}{'talk'} = 'close';
 		
+	} elsif (!$ai_v{'npc_talk'}{'talk'}) {
+		$self->conversation_end;
+		$ai_v{'npc_talk'}{'talk'} = 'close';
+		
 	}
 	
 }


### PR DESCRIPTION
Under some game circustances you won't initialize a conversation to a NPC after clicking to talk to it, like on the KVM NPCs (where it randomly closes your quest log and you need to click on it again to start the talk).

In these cenarios Openkore fails to handle the situation and start an infinite loop; since it wont receive a response from the NPC neither a chat box, the conversation will reaches the timeout and openkore will call $self->cancelTalk, but $ai_v{'npc_talk'}{'talk'} turns to be empty and the sub cancelTalk can't deal with empty values on it.

This extra elsif will deal with empty values for $ai_v{'npc_talk'}{'talk'}, fixing this issue.