### PR TITLE
[eventMacro] fix switch block

### DIFF
--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -427,8 +427,8 @@ sub scanBlocks {
 	my $block_starts = [];
 	
 	for (my $line = 0; $line < @{$script}; $line++) {
-		if ($script->[$line] =~ /^(if|switch|while)\s+\(.*\)\s+{$/) {
-			push @$block_starts, { type => $1, start => $line };
+		if ($script->[$line] =~ /^(if|switch|while|case)\s+\(.*\)\s+{$|^(else)\s+.*{/) {
+			push @$block_starts, { type => $1 || $2, start => $line };
 		} elsif ($script->[$line] eq '}') {
 			my $block = pop @$block_starts;
 			$block->{end} = $line;


### PR DESCRIPTION
switch blocks was not working as expected, and they were not working because of this
this solves the problem

```perl
macro test {                           #macro begin
    log begin                          #line index 00
    $i = 1                             #line index 01
    if (5 > 7) {                       #line index 02
        log "hey!"                     #line index 03
    } elsif ( 1 = 1) {                 #line index 04
        log "men..."                   #line index 05
    } else {                           #line index 06
        log "woman..."                 #line index 07
    }                                  #line index 08
    switch ($i) {                      #line index 09
        case (= 1) {                   #line index 10
            log "case 1"               #line index 11
        }                              #line index 12
        case (= 2) {                   #line index 13
            log "case 2"               #line index 14
        }                              #line index 15
        else {                         #line index 16
            if (me = you) {            #line index 17
                log "if inside case"   #line index 18
            } else {                   #line index 19
                log "else inside case" #line index 20
            }                          #line index 21
        }                              #line index 22
    }                                  #line index 23
}                                      #macro end
```

before commit:

```
$blocks = {
        'end_to_start' => {
                            '22' => {
                                      'end' => 22
                                    },
                            '8' => {
                                     'type' => 'if',
                                     'end' => 8,
                                     'start' => 2
                                   },
                            '21' => {
                                      'type' => 'if',
                                      'end' => 21,
                                      'start' => 17
                                    },
                            '23' => {
                                      'end' => 23
                                    },
                            '12' => {
                                      'type' => 'switch',
                                      'end' => 12,
                                      'start' => 9
                                    },
                            '15' => {
                                      'end' => 15
                                    }
                          },
        'start_to_end' => {
                            '' => $blocks->{'end_to_start'}{'23'},
                            '9' => $blocks->{'end_to_start'}{'12'},
                            '17' => $blocks->{'end_to_start'}{'21'},
                            '2' => $blocks->{'end_to_start'}{'8'}
                          }
      };
```

**as you guys can see, the swich block is ending on the wrong line (12, should be 23)
and one of 'start_to_end' keys are null, this shoudn't even be possible**

after commit:

```
$blocks = {
            'end_to_start' => {
                                '22' => {
                                          'type' => 'else',
                                          'end' => 22,
                                          'start' => 16
                                        },
                                '8' => {
                                         'type' => 'if',
                                         'end' => 8,
                                         'start' => 2
                                       },
                                '21' => {
                                          'type' => 'if',
                                          'end' => 21,
                                          'start' => 17
                                        },
                                '23' => {
                                          'type' => 'switch',
                                          'end' => 23,
                                          'start' => 9
                                        },
                                '12' => {
                                          'type' => 'case',
                                          'end' => 12,
                                          'start' => 10
                                        },
                                '15' => {
                                          'type' => 'case',
                                          'end' => 15,
                                          'start' => 13
                                        }
                              },
            'start_to_end' => {
                                '9' => $blocks->{'end_to_start'}{'23'},
                                '16' => $blocks->{'end_to_start'}{'22'},
                                '13' => $blocks->{'end_to_start'}{'15'},
                                '10' => $blocks->{'end_to_start'}{'12'},
                                '17' => $blocks->{'end_to_start'}{'21'},
                                '2' => $blocks->{'end_to_start'}{'8'}
                              }
          };
```

it starts to count case and else too, but that's OK