### PR TITLE
Cleanup CZ_USE_SKILL_TOGROUND_WITHTALKBOX and CZ_USE_SKILL_TOGROUND_WITHTALKBOX2

### DIFF
--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -2943,4 +2943,19 @@ sub sendMercenaryCommand {
 	debug "Sent Mercenary Command $command", "sendPacket", 2;
 }
 
+sub sendSkillUseLocInfo {
+	my ($self, $ID, $lvl, $x, $y, $moreinfo) = @_;
+	
+	$self->sendToServer($self->reconstruct({
+		switch => 'skill_use_location_text',
+		lvl => $lvl,
+		ID => $ID,
+		x => $x,
+		y => $y,
+		info => $moreinfo
+	}));
+	
+	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+}
+
 1;

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -132,6 +132,7 @@ sub new {
 		'0187' => ['ban_check', 'a4', [qw(accountID)]],
 		'018A' => ['quit_request', 'v', [qw(type)]],
 		'018E' => ['make_item_request', 'v4', [qw(nameID material_nameID1 material_nameID2 material_nameID3)]], # Forge Item / Create Potion
+		'0190' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 		'0193' => ['actor_name_request', 'a4', [qw(ID)]],
 		'0197' => ['gm_reset_state_skill', 'v', [qw(type)]],
 		'0198' => ['gm_change_cell_type', 'v v v', [qw(x y type)]],
@@ -212,6 +213,7 @@ sub new {
 		'0364' => ['storage_item_add', 'a2 V', [qw(ID amount)]],
 		'0365' => ['storage_item_remove', 'a2 V', [qw(ID amount)]],
 		'0366' => ['skill_use_location', 'v4', [qw(lv skillID x y)]],
+		'0367' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 		'0368' => ['actor_info_request', 'a4', [qw(ID)]],
 		'0369' => ['actor_name_request', 'a4', [qw(ID)]],
 		'0436' => ['map_login', 'a4 a4 a4 V C', [qw(accountID charID sessionID tick sex)]],

--- a/src/Network/Send/kRO/RagexeRE_2008_08_27a.pm
+++ b/src/Network/Send/kRO/RagexeRE_2008_08_27a.pm
@@ -32,6 +32,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x7 V x2 v x a4', [qw(lv skillID targetID)]],#22
+		'007E' => ['skill_use_location_text', 'v x8 v x2 v x2 v x3 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x2 C x4 C', [qw(head body)]],
 		'0089' => ['sync', 'x5 V', [qw(time)]], # TODO
 		'008C' => ['actor_info_request', 'x8 a4', [qw(ID)]],
@@ -48,6 +49,7 @@ sub new {
 		'0436' => undef,
 		'0437' => undef,
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -55,19 +57,12 @@ sub new {
 		item_use 009F
 		map_login 009B
 		skill_use 0072
+		skill_use_location_text 007E
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-
-	my $msg = pack('v x8 v x2 v x2 v x3 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/RagexeRE_2010_11_24a.pm
+++ b/src/Network/Send/kRO/RagexeRE_2010_11_24a.pm
@@ -41,12 +41,14 @@ sub new {
 		'0364' => ['storage_item_add', 'a2 V', [qw(ID amount)]],#8
 		'0365' => ['storage_item_remove', 'a2 V', [qw(ID amount)]],#8
 		'0366' => ['skill_use_location', 'v4', [qw(lv skillID x y)]],#10
+		'0367' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 		'0369' => ['actor_name_request', 'a4', [qw(ID)]],#6
 		'0368' => ['actor_info_request', 'a4', [qw(ID)]],#6
 		'0811' => ['buy_bulk_openShop', 'a4 c a*', [qw(limitZeny result itemInfo)]],#-1
 		'0815' => ['buy_bulk_closeShop'],#2
 		'0817' => ['buy_bulk_request', 'a4', [qw(ID)]],#6
-		);
+	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -63,17 +65,12 @@ sub new {
 		storage_item_add 0364
 		storage_item_remove 0365
 		sync 0360
+		skill_use_location_text 0367
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
-	$self;
-}
-
-# 0x0367,90,useskilltoposinfo,2:4:6:8:10
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	$self->sendToServer(pack('v5 Z80', 0x0367, $lv, $ID, $x, $y, $moreinfo));
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/RagexeRE_2011_10_05a.pm
+++ b/src/Network/Send/kRO/RagexeRE_2011_10_05a.pm
@@ -32,6 +32,7 @@ sub new {
 		'0361' => undef,
 		'0362' => undef,
 		'0364' => undef,
+		'0366' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 		'0367' => ['sync', 'V', [qw(time)]],#6
 		'0369' => undef,
 		'0436' => ['map_login', 'a4 a4 a4 V C', [qw(accountID charID sessionID tick sex)]],#19 
@@ -47,7 +48,8 @@ sub new {
 		'08A4' => ['storage_item_add', 'a2 V', [qw(ID amount)]],#8
 		'08AD' => undef,
 		'0365' => ['buy_bulk_openShop', 'a4 c a*', [qw(limitZeny result itemInfo)]],#-1
-		);
+	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -66,17 +68,12 @@ sub new {
 		storage_item_add 08A4
 		storage_item_remove 0802
 		sync 0367
+		skill_use_location_text 0366
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
-	$self;
-}
-
-# 0x0366,90,useskilltoposinfo,2:4:6:8:10
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	$self->sendToServer(pack('v5 Z80', 0x0366, $lv, $ID, $x, $y, $moreinfo));
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/RagexeRE_2012_03_07f.pm
+++ b/src/Network/Send/kRO/RagexeRE_2012_03_07f.pm
@@ -33,6 +33,7 @@ sub new {
 		'0361' => undef,
 		'0362' => undef,
 		'0364' => undef,
+		'0366' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 		'0369' => ['friend_request', 'a*', [qw(username)]],#26
 		'07E4' => undef,
 		'0802' => undef,
@@ -56,6 +57,7 @@ sub new {
 		'0817' => ['buy_bulk_closeShop'],#2
 		'0815' => ['buy_bulk_openShop', 'a4 c a*', [qw(limitZeny result itemInfo)]],#-1
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 
 	my %handlers = qw(
@@ -74,10 +76,12 @@ sub new {
 		storage_item_add 093B
 		storage_item_remove 0963
 		sync 0887
+		skill_use_location_text 0366
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 
-	$self;
+	return $self;
 }
 
 sub sendCharCreate {
@@ -85,12 +89,6 @@ sub sendCharCreate {
 	my $msg = pack('v a24 C v2', 0x0970, stringToBytes($name), $slot, $hair_color, $hair_style);
 	$self->sendToServer($msg);
 	debug "Sent sendCharCreate\n", "sendPacket", 2;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	$self->sendToServer(pack('v5 Z80', 0x0366, $lv, $ID, $x, $y, $moreinfo));
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
 }
 
 1;

--- a/src/Network/Send/kRO/RagexeRE_2012_05_15a.pm
+++ b/src/Network/Send/kRO/RagexeRE_2012_05_15a.pm
@@ -56,7 +56,9 @@ sub new {
 		'092C' => ['buy_bulk_closeShop'],#2
 		'0815' => undef,
 		'0891' => ['buy_bulk_openShop', 'a4 c a*', [qw(limitZeny result itemInfo)]],#-1
+		'08A2' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -79,17 +81,12 @@ sub new {
 		storage_item_remove 0869
 		sync 087D
 		party_join_request_by_name 091F
+		skill_use_location_text 08A2
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
-	$self;
-}
-
-#0x08A2,90,useskilltoposinfo,2:4:6:8:10
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	$self->sendToServer(pack('v5 Z80', 0x08A2, $lv, $ID, $x, $y, $moreinfo));
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	return $self;
 }
 
 #0x089A,36,storagepassword,0

--- a/src/Network/Send/kRO/RagexeRE_2012_06_18a.pm
+++ b/src/Network/Send/kRO/RagexeRE_2012_06_18a.pm
@@ -57,7 +57,9 @@ sub new {
 		'0817' => ['buy_bulk_closeShop'],#2
 		'0891' => undef,
 		'0815' => ['buy_bulk_openShop', 'a4 c a*', [qw(limitZeny result itemInfo)]],#-1
+		'0366' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -80,17 +82,11 @@ sub new {
 		storage_item_add 07EC
 		storage_item_remove 0364
 		sync 035F
+		skill_use_location_text 0366
 	);
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
 	$self;
-}
-
-#0x0366,90,useskilltoposinfo,2:4:6:8:10
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	$self->sendToServer(pack('v5 Z80', 0x0366, $lv, $ID, $x, $y, $moreinfo));
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
 }
 
 #0x0819,36,storagepassword,0

--- a/src/Network/Send/kRO/RagexeRE_2013_05_15a.pm
+++ b/src/Network/Send/kRO/RagexeRE_2013_05_15a.pm
@@ -57,7 +57,9 @@ sub new {
 		'0819' => ['search_store_info', 'v C V2 C2 a*', [qw(len type max_price min_price item_count card_count item_card_list)]],
 		'0835' => ['search_store_request_next_page'],
 		'0838' => ['search_store_select', 'a4 a4 v', [qw(accountID storeID nameID)]],
+		'0366' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -81,16 +83,12 @@ sub new {
 		search_store_info 0819
 		search_store_request_next_page 0835
 		search_store_select 0838
+		skill_use_location_text 0366
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	$self->sendToServer(pack('v5 Z80', 0x0366, $lv, $ID, $x, $y, $moreinfo));
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_0.pm
+++ b/src/Network/Send/kRO/Sakexe_0.pm
@@ -129,6 +129,7 @@ sub new {
 		'0187' => ['ban_check', 'a4', [qw(accountID)]],
 		'018A' => ['quit_request', 'v', [qw(type)]],
 		'018E' => ['make_item_request', 'v4', [qw(nameID material_nameID1 material_nameID2 material_nameID3)]], # Forge Item / Create Potion
+		'0190' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 		'0193' => ['actor_name_request', 'a4', [qw(ID)]],
 		'0197' => ['gm_reset_state_skill', 'v', [qw(type)]],
 		'0198' => ['gm_change_cell_type', 'v v v', [qw(x y type)]],
@@ -187,6 +188,7 @@ sub new {
 		'02C7' => ['party_join_request_by_name_reply', 'a4 C', [qw(accountID flag)]],
 		'02DB' => ['battleground_chat', 'v Z*', [qw(len message)]],
 		'02F1' => ['notify_progress_bar_complete'],
+		'0367' => ['skill_use_location_text', 'v5 Z80', [qw(lvl ID x y info)]],
 		'07DA' => ['party_leader', 'a4', [qw(accountID)]],
 		'0802' => ['booking_register', 'v8', [qw(level MapID job0 job1 job2 job3 job4 job5)]],
 		'0804' => ['booking_search', 'v3 L s', [qw(level MapID job LastIndex ResultCount)]],
@@ -595,17 +597,6 @@ sub sendGuildPositionInfo {
 # 0x018c,29
 # 0x018d,-1
 # 0x018f,6
-
-# 0x0190,90,useskilltoposinfo,2:4:6:8:10
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-
-	my $msg = pack('v5 Z80', 0x0190, $lv, $ID, $x, $y, $moreinfo);
-
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
-}
-
 # 0x0191,86
 # 0x0192,24
 # 0x0194,30

--- a/src/Network/Send/kRO/Sakexe_2004_07_05a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_07_05a.pm
@@ -36,18 +36,19 @@ sub new {
 		'00A7' => ['item_use', 'x3 a2 x2 a4', [qw(ID targetID)]],#13
 		'0113' => ['skill_use', 'x2 v x3 v a4', [qw(lv skillID targetID)]],#15
 		'0116' => ['skill_use_location', 'x2 v x3 v3', [qw(lv skillID x y)]],
+		'0190' => ['skill_use_location_text', 'v x2 v x3 v3 Z80', [qw(lvl ID x y info)]],
 		'0208' => ['friend_response', 'a4 a4 V', [qw(friendAccountID friendCharID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x2 v x3 v3 Z80', 0x0190, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 0190
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2004_07_13a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_07_13a.pm
@@ -38,17 +38,18 @@ sub new {
 		'00A7' => ['item_use', 'x4 a2 x5 a4', [qw(ID targetID)]],#17
 		'0113' => ['skill_use', 'x5 V v x2 a4', [qw(lv skillID targetID)]],#19
 		'0116' => ['skill_use_location', 'x5 v2 x4 v2', [qw(lv skillID x y)]],
+		'0190' => ['skill_use_location_text', 'v x5 v2 x4 v2 Z80', [qw(lvl ID x y info)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x5 v2 x4 v2 Z80', 0x0190, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 0190
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2004_07_26a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_07_26a.pm
@@ -39,7 +39,7 @@ sub new {
 		'0094' => ['item_take', 'x4 a4', [qw(ID)]],
 		'009B' => ['character_move', 'x a3', [qw(coords)]],
 		'009F' => ['actor_look_at', 'x3 C x6 C', [qw(head body)]],
-		'00A2' => undef,
+		'00A2' => ['skill_use_location_text', 'v x v x v x9 v x2 v Z80', [qw(lvl ID x y info)]],
 		'00A7' => ['actor_name_request', 'x6 a4', [qw(ID)]],
 		'00F3' => ['public_chat', 'x2 Z*', [qw(message)]],
 		'00F5' => ['item_use', 'x4 a2 x5 a4', [qw(ID targetID)]],#17
@@ -49,6 +49,7 @@ sub new {
 		'0190' => ['storage_item_remove', 'x8 a2 x10 V', [qw(ID amount)]],
 		'0193' => ['actor_action', 'x a4 x C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	# since there is only one available switch alternative per kRO ST,
@@ -69,19 +70,12 @@ sub new {
 		storage_item_add 0113
 		storage_item_remove 0190
 		sync 00F7
+		skill_use_location_text 00A2
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-
-	my $msg = pack('v x v x v x9 v x2 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	return $self;
 }
 
 sub sendStorageClose {

--- a/src/Network/Send/kRO/Sakexe_2004_08_09a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_08_09a.pm
@@ -39,6 +39,7 @@ sub new {
 		'0094' => ['item_take', 'x7 a4', [qw(ID)]],
 		'009B' => ['character_move', 'x10 a3', [qw(coords)]],
 		'009F' => ['actor_look_at', 'x5 C x3 C', [qw(head body)]],
+		'00A2' => ['skill_use_location_text', 'v x3 v x8 v x12 v x7 v Z80', [qw(lvl ID x y info)]],
 		'00A7' => ['actor_name_request', 'x5 a4', [qw(ID)]],
 		'00F5' => ['item_use', 'x7 a2 x9 a4', [qw(ID targetID)]],#24
 		'00F7' => ['sync', 'x7 V', [qw(time)]],
@@ -46,16 +47,16 @@ sub new {
 		'0190' => ['storage_item_remove', 'x9 a2 x9 V', [qw(ID amount)]],
 		'0193' => ['actor_action', 'x5 a4 x6 C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x3 v x8 v x12 v x7 v Z80', 0x00A2, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 00A2
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2004_09_06a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_09_06a.pm
@@ -35,7 +35,7 @@ sub new {
 		'007E' => ['storage_item_add', 'x a2 x10 V', [qw(ID amount)]],
 		'0085' => ['actor_action', 'x7 a4 x9 C', [qw(targetID type)]],
 		'0089' => ['character_move', 'x4 a3', [qw(coords)]],
-		'008C' => undef,
+		'008C' => ['skill_use_location_text', 'v x8 v x2 v x2 v x3 v Z80', [qw(lvl ID x y info)]],
 		'009B' => ['actor_info_request', 'x8 a4', [qw(ID)]],
 		'0094' => ['item_drop', 'x4 a2 x7 v', [qw(ID amount)]],
 		'009F' => ['public_chat', 'x2 Z*', [qw(message)]],
@@ -49,6 +49,7 @@ sub new {
 		'0190' => ['skill_use', 'x7 V x2 v x a4', [qw(lv skillID targetID)]],#22
 		'0193' => ['storage_item_remove', 'x a2 x8 V', [qw(ID amount)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -67,17 +68,12 @@ sub new {
 		storage_item_add 007E
 		storage_item_remove 0193
 		sync 0116
+		skill_use_location_text 008C
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x8 v x2 v x2 v x3 v Z80', 0x008C, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	return $self;
 }
 
 sub sendStorageClose {

--- a/src/Network/Send/kRO/Sakexe_2004_09_20a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_09_20a.pm
@@ -35,6 +35,7 @@ sub new {
 		'007E' => ['storage_item_add', 'x4 a2 x13 V', [qw(ID amount)]],
 		'0085' => ['actor_action', 'x a4 x C', [qw(targetID type)]],
 		'0089' => ['character_move', 'x9 a3', [qw(coords)]],
+		'008C' => ['skill_use_location_text', 'v x14 v x2 v x v x2 v Z80', [qw(lvl ID x y info)]],
 		'0094' => ['item_drop', 'x10 a2 x3 v', [qw(ID amount)]],
 		'009B' => ['actor_info_request', 'x4 a4', [qw(ID)]],
 		'00A2' => ['actor_name_request', 'x4 a4', [qw(ID)]],
@@ -46,16 +47,16 @@ sub new {
 		'0190' => ['skill_use', 'x2 v x v x a4', [qw(lv skillID targetID)]],#14
 		'0193' => ['storage_item_remove', 'x2 a2 x2 V', [qw(ID amount)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x14 v x2 v x v x2 v Z80', 0x008C, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 008C
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2004_10_05a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_10_05a.pm
@@ -34,6 +34,7 @@ sub new {
 		'0072' => ['item_use', 'x4 a2 x5 a4', [qw(ID targetID)]],#17
 		'007E' => ['storage_item_add', 'x3 a2 x5 V', [qw(ID amount)]],
 		'0089' => ['character_move', 'x1 a3', [qw(coords)]],
+		'008C' => ['skill_use_location_text', 'v2 x2 v x9 v x2 v Z80', [qw(lvl ID x y info)]],
 		'0094' => ['item_drop', 'x3 a2 x5 v', [qw(ID amount)]],
 		'009B' => ['actor_info_request', 'x9 a4', [qw(ID)]],
 		'00A2' => ['actor_name_request', 'x6 a4', [qw(ID)]],
@@ -45,16 +46,16 @@ sub new {
 		'0190' => ['skill_use', 'x5 V x v x2 a4', [qw(lv skillID targetID)]],#20
 		'0193' => ['storage_item_remove', 'x8 a2 x10 V', [qw(ID amount)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v2 x2 v x9 v x2 v Z80', 0x008C, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 008C
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2004_10_25a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_10_25a.pm
@@ -34,6 +34,7 @@ sub new {
 		'0072' => ['item_use', 'x3 a2 x2 a4', [qw(ID targetID)]],#13
 		'007E' => ['storage_item_add', 'x4 a2 x V', [qw(ID amount)]],
 		'0085' => ['actor_action', 'x2 a4 x6 C', [qw(targetID type)]],
+		'008C' => ['skill_use_location_text', 'v x4 v x v x12 v x v Z80', [qw(lvl ID x y info)]],
 		'0094' => ['item_drop', 'x4 a2 x2 v', [qw(ID amount)]],
 		'009B' => ['actor_info_request', 'x4 a4', [qw(ID)]],
 		'00A2' => ['actor_name_request', 'x10 a4', [qw(ID)]],
@@ -45,16 +46,16 @@ sub new {
 		'0190' => ['skill_use', 'x3 V x2 v x10 a4', [qw(lv skillID targetID)]],#26
 		'0193' => ['storage_item_remove', 'x10 a2 x4 V', [qw(ID amount)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x4 v x v x12 v x v Z80', 0x008C, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 008C
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2004_11_29a.pm
+++ b/src/Network/Send/kRO/Sakexe_2004_11_29a.pm
@@ -44,11 +44,12 @@ sub new {
 		'00F3' => ['actor_look_at', 'x C x3 C', [qw(head body)]],
 		'00F5' => ['map_login', 'x a4 x3 a4 x6 a4 V C', [qw(accountID charID sessionID tick sex)]],
 		'00F7' => ['actor_name_request', 'x8 a4', [qw(ID)]],
-		'0113' => undef,
+		'0113' => ['skill_use_location_text', 'v x2 v x3 v x11 v x4 v Z80', [qw(lvl ID x y info)]],
 		'0116' => ['item_drop', 'x2 a2 x4 v', [qw(ID amount)]],
 		'0190' => ['item_use', 'x a2 x6 a4', [qw(ID targetID)]],#15
 		'0193' => ['storage_item_remove', 'x2 a2 x11 V', [qw(ID amount)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -64,22 +65,17 @@ sub new {
 		skill_use_location 007E
 		storage_item_add 0094
 		sync 0089
+		skill_use_location_text 0113
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
-	$self;
+	return $self;
 }
 
 sub sendStorageClose {
 	$_[0]->sendToServer(pack('v', 0x009B));
 	debug "Sent Storage Done\n", "sendPacket", 2;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x2 v x3 v x11 v x4 v Z80', 0x0113, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2005_01_10b.pm
+++ b/src/Network/Send/kRO/Sakexe_2005_01_10b.pm
@@ -32,7 +32,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x7 V x4 v x4 a4', [qw(lv skillID targetID)]],#26
-		'007E' => undef,
+		'007E' => ['skill_use_location_text', 'v x8 v x6 v x2 v x8 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x10 C x9 C', [qw(head body)]],
 		'0089' => ['sync', 'x3 V', [qw(time)]],
 		'008C' => ['actor_info_request', 'x2 a4', [qw(ID)]],
@@ -49,6 +49,7 @@ sub new {
 		'0190' => ['actor_action', 'x7 a4 x6 C', [qw(targetID type)]],
 		'0193' => undef,
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
 	my %handlers = qw(
@@ -63,16 +64,10 @@ sub new {
 		skill_use_location 0113
 		storage_item_remove 00F7
 	);
+	
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x8 v x6 v x2 v x8 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	return $self;
 }
 
 sub sendStorageClose {

--- a/src/Network/Send/kRO/Sakexe_2005_05_09a.pm
+++ b/src/Network/Send/kRO/Sakexe_2005_05_09a.pm
@@ -32,6 +32,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x4 V v x9 a4', [qw(lv skillID targetID)]],#25
+		'007E' => ['skill_use_location_text', 'v x3 v x2 v x v x6 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x5 v x C', [qw(head body)]],
 		'0089' => ['sync', 'x2 V', [qw(time)]],
 		'008C' => ['actor_info_request', 'x5 a4', [qw(ID)]],
@@ -46,16 +47,16 @@ sub new {
 		'0116' => ['item_drop', 'x3 a2 x v', [qw(ID amount)]],
 		'0190' => ['actor_action', 'x3 a4 x9 C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x3 v x2 v x v x6 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 007E
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2005_06_28a.pm
+++ b/src/Network/Send/kRO/Sakexe_2005_06_28a.pm
@@ -32,6 +32,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x4 V x7 v x11 a4', [qw(lv skillID targetID)]],#34
+		'007E' => ['skill_use_location_text', 'v x10 v x v x v x11 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x6 v x6 C', [qw(head body)]],
 		'0089' => ['sync', 'x7 V', [qw(time)]],
 		'008C' => ['actor_info_request', 'x2 a4', [qw(ID)]],
@@ -46,16 +47,16 @@ sub new {
 		'0116' => ['item_drop', 'x a2 x5 v', [qw(ID amount)]],
 		'0190' => ['actor_action', 'x9 a4 x8 C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x10 v x v x v x11 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 007E
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2005_07_18a.pm
+++ b/src/Network/Send/kRO/Sakexe_2005_07_18a.pm
@@ -33,6 +33,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x3 V x2 v x2 a4', [qw(lv skillID targetID)]],#19
+		'007E' => ['skill_use_location_text', 'v x7 v x4 v x6 v x3 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x4 C x3 C', [qw(head body)]],
 		'0089' => ['sync', 'x V', [qw(time)]],
 		'008C' => ['actor_info_request', 'x5 a4', [qw(ID)]],
@@ -47,16 +48,16 @@ sub new {
 		'0116' => ['item_drop', 'x4 a2 x2 v', [qw(ID amount)]],
 		'0190' => ['actor_action', 'x3 a4 x11 C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x7 v x4 v x6 v x3 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 007E
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2005_07_19b.pm
+++ b/src/Network/Send/kRO/Sakexe_2005_07_19b.pm
@@ -32,6 +32,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x4 V x7 v x11 a4', [qw(lv skillID targetID)]],#34
+		'007E' => ['skill_use_location_text', 'v x10 v x v x v x11 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x6 C x7 C', [qw(head body)]],
 		'0089' => ['sync', 'x7 V', [qw(time)]], # TODO
 		'008C' => ['actor_info_request', 'x2 a4', [qw(ID)]],
@@ -46,16 +47,16 @@ sub new {
 		'0116' => ['item_drop', 'x a2 x5 v', [qw(ID amount)]],
 		'0190' => ['actor_action', 'x9 a4 x8 C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x10 v x v x v x11 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 007E
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2006_03_27a.pm
+++ b/src/Network/Send/kRO/Sakexe_2006_03_27a.pm
@@ -32,6 +32,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x9 V x3 v x2 a4', [qw(lv skillID targetID)]],#26
+		'007E' => ['skill_use_location_text', 'v x3 v x8 v x12 v x7 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x5 C x3 C', [qw(head body)]],
 		# 0089 unchanged
 		'008C' => ['actor_info_request', 'x6 a4', [qw(ID)]],
@@ -46,16 +47,16 @@ sub new {
 		'0116' => ['item_drop', 'x6 a2 x5 v', [qw(ID amount)]],
 		'0190' => ['actor_action', 'x5 a4 x6 C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x3 v x8 v x12 v x7 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 007E
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2007_01_08a.pm
+++ b/src/Network/Send/kRO/Sakexe_2007_01_08a.pm
@@ -32,6 +32,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x8 V v x10 a4', [qw(lv skillID targetID)]],#30
+		'007E' => ['skill_use_location_text', 'v x8 v x7 v x2 v x13 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x8 C x2 C', [qw(head body)]],
 		'0089' => ['sync', 'x5 V', [qw(time)]], # TODO
 		'008C' => ['actor_info_request', 'x11 a4', [qw(ID)]],
@@ -46,16 +47,16 @@ sub new {
 		'0116' => ['item_drop', 'x9 a2 x4 v', [qw(ID amount)]],
 		'0190' => ['actor_action', 'x2 a4 x C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x8 v x7 v x2 v x13 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 007E
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;

--- a/src/Network/Send/kRO/Sakexe_2007_02_12a.pm
+++ b/src/Network/Send/kRO/Sakexe_2007_02_12a.pm
@@ -32,6 +32,7 @@ sub new {
 	
 	my %packets = (
 		'0072' => ['skill_use', 'x4 V v x9 a4', [qw(lv skillID targetID)]],#25
+		'007E' => ['skill_use_location_text', 'v x3 v x2 v x v x6 v Z80', [qw(lvl ID x y info)]],
 		'0085' => ['actor_look_at', 'x5 C x2 C', [qw(head body)]],
 		'0089' => ['sync', 'x2 V', [qw(time)]], # TODO
 		'0094' => ['storage_item_add', 'x5 a2 x V', [qw(ID amount)]],
@@ -46,16 +47,16 @@ sub new {
 		'0116' => ['item_drop', 'x3 a2 x v', [qw(ID amount)]],
 		'0190' => ['actor_action', 'x3 a4 x9 C', [qw(targetID type)]],
 	);
+	
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 	
-	$self;
-}
-
-sub sendSkillUseLocInfo {
-	my ($self, $ID, $lv, $x, $y, $moreinfo) = @_;
-	my $msg = pack('v x3 v x2 v x v x6 v Z80', 0x007E, $lv, $ID, $x, $y, $moreinfo);
-	$self->sendToServer($msg);
-	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
+	my %handlers = qw(
+		skill_use_location_text 007E
+	);
+	
+	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
+	
+	return $self;
 }
 
 1;


### PR DESCRIPTION
Add 0190 and 0367 as skill_use_location_text
Cleanup skill_use_location_text shuffles in kRO servertypes
sendSkillUseLocInfo merged into Network::Send
sendSkillUseLocInfo now uses Network::PacketParser::reconstruct