### PR TITLE
removing "x2" from sage_autospell packet

### DIFF
--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -281,7 +281,7 @@ sub new {
 		'01C5' => ['cart_item_added', 'a2 V v C4 a8', [qw(ID amount nameID type identified broken upgrade cards)]],
 		'01C8' => ['item_used', 'a2 v a4 v C', [qw(ID itemID actorID remaining success)]],
 		'01C9' => ['area_spell', 'a4 a4 v2 C2 C Z80', [qw(ID sourceID x y type fail scribbleLen scribbleMsg)]],
-		'01CD' => ['sage_autospell', 'x2 a*', [qw(autospell_list)]],
+		'01CD' => ['sage_autospell', 'a*', [qw(autospell_list)]],
 		'01CF' => ['devotion', 'a4 a20 v', [qw(sourceID targetIDs range)]],
 		'01D0' => ['revolving_entity', 'a4 v', [qw(sourceID entity)]],
 		'01D1' => ['blade_stop', 'a4 a4 V', [qw(sourceID targetID active)]],


### PR DESCRIPTION
### before: 
![image](https://user-images.githubusercontent.com/11494727/44952121-814fb700-ae4d-11e8-9d97-4aac8036b013.png)

### after:
![image](https://user-images.githubusercontent.com/11494727/44952128-b3611900-ae4d-11e8-862f-b8c6083bc700.png)




### the credits for this change goes to @lututui , he discovered this bug
