### PR TITLE
change relog command

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4250,7 +4250,10 @@ sub cmdReloadCode2 {
 
 sub cmdRelog {
 	my (undef, $arg) = @_;
-	if (!$arg || $arg =~ /^\d+$/) {
+	#stay offline if arg is 0
+	if (defined $arg && $arg == 0) {
+		offlineMode();
+	} elsif (!$arg || $arg =~ /^\d+$/) {
 		@cmdQueueList = ();
 		$cmdQueue = 0;
 		relog($arg);


### PR DESCRIPTION
The idea here is:
if user type `relog 0` it will stay disconnected
the command is retrocompatibility, since all other options for this command continue to work in the same way