### PR TITLE
add warning log and error log to eventMacro

### DIFF
--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1139,6 +1139,18 @@ sub next {
 		$self->parse_log($log_command);
 		
 	##########################################
+	# warning log command
+	} elsif ($self->{current_line} =~ /^warning\s+/) {
+		my ($warning_command) = $self->{current_line} =~ /^warning\s+(.*)/;
+		$self->parse_warning_log($warning_command);
+	
+	##########################################
+	# error log command
+	} elsif ($self->{current_line} =~ /^error\s+/) {
+		my ($error_command) = $self->{current_line} =~ /^error\s+(.*)/;
+		$self->parse_error_log($error_command);
+	
+	##########################################
 	# pause command
 	} elsif ($self->{current_line} =~ /^pause/) {
 		my ($pause_command) = $self->{current_line} =~ /^pause\s*(.*)/;
@@ -1639,6 +1651,34 @@ sub parse_log {
 		$self->error("Could not define log value");
 	} else {
 		message "[eventmacro log] $parsed_log\n", "eventMacro";
+	}
+	$self->timeout($self->macro_delay);
+	$self->next_line;
+}
+
+sub parse_warning_log {
+	my ($self, $log_command) = @_;
+	my $parsed_log = $self->parse_command($log_command);
+	return if (defined $self->error);
+	
+	unless (defined $parsed_log) {
+		$self->error("Could not define warning log value");
+	} else {
+		Log::warning "[eventMacro log] $parsed_log\n", "eventMacro";
+	}
+	$self->timeout($self->macro_delay);
+	$self->next_line;
+}
+
+sub parse_error_log {
+	my ($self, $log_command) = @_;
+	my $parsed_log = $self->parse_command($log_command);
+	return if (defined $self->error);
+	
+	unless (defined $parsed_log) {
+		$self->error("Could not define error log value");
+	} else {
+		Log::error "[eventMacro log] $parsed_log\n", "eventMacro";
 	}
 	$self->timeout($self->macro_delay);
 	$self->next_line;

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1134,21 +1134,9 @@ sub next {
 		
 	##########################################
 	# log command
-	} elsif ($self->{current_line} =~ /^log\s+/) {
-		my ($log_command) = $self->{current_line} =~ /^log\s+(.*)/;
-		$self->parse_log($log_command);
-		
-	##########################################
-	# warning log command
-	} elsif ($self->{current_line} =~ /^warning\s+/) {
-		my ($warning_command) = $self->{current_line} =~ /^warning\s+(.*)/;
-		$self->parse_warning_log($warning_command);
-	
-	##########################################
-	# error log command
-	} elsif ($self->{current_line} =~ /^error\s+/) {
-		my ($error_command) = $self->{current_line} =~ /^error\s+(.*)/;
-		$self->parse_error_log($error_command);
+	} elsif ($self->{current_line} =~ /^(log|warning|error)\s+(.*)/) {
+		my ($type, $log_text) = ($1, $2);
+		$self->parse_log($type, $log_text);
 	
 	##########################################
 	# pause command
@@ -1643,42 +1631,22 @@ sub parse_do {
 
 #From here functions are intended to parse/execute macro commands
 sub parse_log {
-	my ($self, $log_command) = @_;
-	my $parsed_log = $self->parse_command($log_command);
-	return if (defined $self->error);
+	my ($self, $type, $log_text) = @_;
+	my $parsed_log = $self->parse_command($log_text);
+	#type can be message, warning or error
+	#log_text have the text that will be printed
 	
+	return if (defined $self->error);
 	unless (defined $parsed_log) {
 		$self->error("Could not define log value");
 	} else {
-		message "[eventmacro log] $parsed_log\n", "eventMacro";
-	}
-	$self->timeout($self->macro_delay);
-	$self->next_line;
-}
-
-sub parse_warning_log {
-	my ($self, $log_command) = @_;
-	my $parsed_log = $self->parse_command($log_command);
-	return if (defined $self->error);
-	
-	unless (defined $parsed_log) {
-		$self->error("Could not define warning log value");
-	} else {
-		Log::warning "[eventMacro log] $parsed_log\n", "eventMacro";
-	}
-	$self->timeout($self->macro_delay);
-	$self->next_line;
-}
-
-sub parse_error_log {
-	my ($self, $log_command) = @_;
-	my $parsed_log = $self->parse_command($log_command);
-	return if (defined $self->error);
-	
-	unless (defined $parsed_log) {
-		$self->error("Could not define error log value");
-	} else {
-		Log::error "[eventMacro log] $parsed_log\n", "eventMacro";
+		$type = "message" if $type eq "log";
+		if (my $sub_ref = Log->can($type)) {
+			$sub_ref->("[eventmacro $type] $parsed_log\n", "eventMacro");
+		} else {
+			$self->error("Unknown error found while trying to print '$type' log. Report to developers");
+			return;
+		}
 	}
 	$self->timeout($self->macro_delay);
 	$self->next_line;


### PR DESCRIPTION
Before, if you want to show a log with red colors you would have to do this:
```perl
do eval Log::error "This is an error message\n"
```

now you can simply do this
`error This is an error message`


automacro that it can be used to test:
```
automacro test {
    BaseLevel > 0
    exclusive 1
    run-once 1
    call {
        log this is a normal log message
        warning this is a warning message
        error this is a error message
    }
}
```
Output:
![image](https://user-images.githubusercontent.com/11494727/47523399-504c9b00-d86e-11e8-8202-050c4b4ab184.png)
