### PR TITLE
[eventMacro] new condition: SystemMsg

### DIFF
--- a/plugins/eventMacro/eventMacro/Condition/SystemMsg.pm
+++ b/plugins/eventMacro/eventMacro/Condition/SystemMsg.pm
@@ -1,0 +1,32 @@
+package eventMacro::Condition::SystemMsg;
+
+use strict;
+
+use base 'eventMacro::Condition::BaseMsg';
+
+sub _hooks {
+	my ( $self ) = @_;
+	my $hooks = $self->SUPER::_hooks;
+	my @other_hooks = ('packet_sysMsg');
+	push(@{$hooks}, @other_hooks);
+	return $hooks;
+}
+
+sub validate_condition {
+	my ( $self, $callback_type, $callback_name, $args ) = @_;
+	
+	$self->{message} = undef;
+	$self->{source} = undef;
+	
+	if ($callback_type eq 'hook') {
+		$self->{message} = $args->{Msg};
+		$self->{source} = undef;
+	}
+	return $self->SUPER::validate_condition( $callback_type, $callback_name, $args );
+}
+
+sub usable {
+	1;
+}
+
+1;


### PR DESCRIPTION
In some cases, npcs send broadcasts on the map, like on quests or challenges

Some times it is used the local_broadcast, but sometimes are used the system broadcast (yelllow sentence on top of game)

This condition is to when system broadcast is used
[](url)
Tested on [izlude Arena](https://browiki.org/wiki/Arena_de_Batalha)