### PR TITLE
[eventMacro]Improve reuse of code

### DIFF
--- a/plugins/eventMacro/eventMacro/Condition/IsInCoordinate.pm
+++ b/plugins/eventMacro/eventMacro/Condition/IsInCoordinate.pm
@@ -1,7 +1,6 @@
 package eventMacro::Condition::IsInCoordinate;
 
 use strict;
-use Globals qw( $char $field );
 
 use base 'eventMacro::Condition::IsInMapAndCoordinate';
 
@@ -10,65 +9,13 @@ use base 'eventMacro::Condition::IsInMapAndCoordinate';
 sub _parse_syntax {
 	my ( $self, $condition_code ) = @_;
 	
-	$self->{is_on_stand_by} = 0;
-	
-	$self->{fulfilled_coordinate} = undef;
-	$self->{fulfilled_member_index} = undef;
-	
-	$self->{var_to_member_index_coord_x} = {};
-	$self->{var_to_member_index_coord_y} = {};
-	
-	$self->{x_validators} = {};
-	$self->{y_validators} = {};
-	
-	my $var_exists_hash = {};
-	
-	my $member_index = 0;
-	foreach my $member (split(/\s*,\s*/, $condition_code)) {
-		my ($coord_x, $coord_y) = split(/\s+/, $member);
-		
-		unless (defined $coord_x && defined $coord_y) {
-			$self->{error} = "List member '".$member."' must have a x and a y coordinate defined";
-			return 0;
-		}
-		
-		my $x_validator = eventMacro::Validator::NumericComparison->new( $coord_x );
-		
-		if (defined $x_validator->error) {
-			$self->{error} = $x_validator->error;
-			return 0;
-		} else {
-			my @vars = @{$x_validator->variables};
-			foreach my $var (@vars) {
-				push ( @{ $self->{var_to_member_index_coord_x}{$var->{display_name}} }, $member_index );
-				push ( @{ $self->{variables} }, $var ) unless (exists $var_exists_hash->{$var->{display_name}});
-				$var_exists_hash->{$var->{display_name}} = undef;
-			}
-		}
-		
-		my $y_validator = eventMacro::Validator::NumericComparison->new( $coord_y );
-		
-		if (defined $y_validator->error) {
-			$self->{error} = $y_validator->error;
-			return 0;
-		} else {
-			my @vars = @{$y_validator->variables};
-			foreach my $var (@vars) {
-				push ( @{ $self->{var_to_member_index_coord_y}{$var->{display_name}} }, $member_index );
-				push ( @{ $self->{variables} }, $var ) unless (exists $var_exists_hash->{$var->{display_name}});
-				$var_exists_hash->{$var->{display_name}} = undef;
-			}
-		}
-		
-		$self->{x_validators}{$member_index} = $x_validator;
-		$self->{y_validators}{$member_index} = $y_validator;
-		
-	} continue {
-		$member_index++;
+	#if $condition_code have other thing besides letters, spaces and commas
+	if ($condition_code =~ /[^\d\s,.]+/) {
+		$self->{error} = "This Condition only accept coordinates";
+		return 0;
 	}
 	
-	$self->{index_of_last_validator} = $member_index-1;
-	return 1;
+	$self->SUPER::_parse_syntax( $condition_code );
 }
 
 1;

--- a/plugins/eventMacro/eventMacro/Condition/IsInCoordinate.pm
+++ b/plugins/eventMacro/eventMacro/Condition/IsInCoordinate.pm
@@ -3,13 +3,9 @@ package eventMacro::Condition::IsInCoordinate;
 use strict;
 use Globals qw( $char $field );
 
-use base 'eventMacro::Condition';
+use base 'eventMacro::Condition::IsInMapAndCoordinate';
 
 #Use: x1 y1, x2 y2, x3min..x3max y3, x4 y4min..y4max, x5min..x5max y5min..y5max
-
-sub _hooks {
-	['packet/actor_movement_interrupted','packet/high_jump','packet/character_moves','packet_mapChange','packet/map_property3'];
-}
 
 sub _parse_syntax {
 	my ( $self, $condition_code ) = @_;
@@ -22,8 +18,8 @@ sub _parse_syntax {
 	$self->{var_to_member_index_coord_x} = {};
 	$self->{var_to_member_index_coord_y} = {};
 	
-	$self->{x_validators} = [];
-	$self->{y_validators} = [];
+	$self->{x_validators} = {};
+	$self->{y_validators} = {};
 	
 	my $var_exists_hash = {};
 	
@@ -64,113 +60,15 @@ sub _parse_syntax {
 			}
 		}
 		
-		push ( @{ $self->{x_validators} }, $x_validator );
-		push ( @{ $self->{y_validators} }, $y_validator );
+		$self->{x_validators}{$member_index} = $x_validator;
+		$self->{y_validators}{$member_index} = $y_validator;
 		
 	} continue {
 		$member_index++;
 	}
 	
+	$self->{index_of_last_validator} = $member_index-1;
 	return 1;
-}
-
-sub update_validator_var {
-	my ( $self, $var_name, $var_value ) = @_;
-	
-	my %members_index_changed;
-	
-	foreach my $member_index (@{$self->{var_to_member_index_coord_x}{$var_name}}) {
-		@{$self->{x_validators}}[$member_index]->update_vars($var_name, $var_value);
-		$members_index_changed{$member_index} = undef;
-	}
-	
-	foreach my $member_index (@{$self->{var_to_member_index_coord_y}{$var_name}}) {
-		@{$self->{y_validators}}[$member_index]->update_vars($var_name, $var_value);
-		$members_index_changed{$member_index} = undef;
-	}
-	
-	my $changed_fulfilled_index = 0;
-	if (defined $self->{fulfilled_member_index}) {
-		foreach my $changed_index (keys %members_index_changed) {
-			if ($changed_index == $self->{fulfilled_member_index}) {
-				$changed_fulfilled_index = 1;
-			}
-		}
-	}
-	
-	if (!defined $self->{fulfilled_member_index} || $changed_fulfilled_index) {
-		$self->check_location;
-	}
-}
-
-sub validator_x_check {
-	my ( $self, $validator_index, $check ) = @_;
-	return @{$self->{x_validators}}[$validator_index]->validate($check);
-}
-
-sub validator_y_check {
-	my ( $self, $validator_index, $check ) = @_;
-	return @{$self->{y_validators}}[$validator_index]->validate($check);
-}
-
-sub validate_condition {
-	my ( $self, $callback_type, $callback_name, $args ) = @_;
-	
-	if ($callback_type eq 'variable') {
-		$self->update_validator_var($callback_name, $args);
-		
-	} elsif ($callback_type eq 'hook') {
-		
-		if ($callback_name eq 'packet/character_moves' || ($callback_name eq 'packet/actor_movement_interrupted' && Actor::get($args->{ID})->isa('Actor::You')) || ($callback_name eq 'packet/high_jump' && Actor::get($args->{ID})->isa('Actor::You'))) {
-			return $self->SUPER::validate_condition if (
-				defined $self->{fulfilled_coordinate} &&
-			    $self->validator_x_check( $self->{fulfilled_member_index}, $char->{pos_to}{x} ) &&
-				$self->validator_y_check( $self->{fulfilled_member_index}, $char->{pos_to}{y} )
-			);
-			$self->check_location;
-			
-		} elsif ($callback_name eq 'packet_mapChange') {
-			$self->{fulfilled_coordinate} = undef;
-			$self->{fulfilled_member_index} = undef;
-			$self->{is_on_stand_by} = 1;
-			
-		} elsif ($callback_name eq 'packet/map_property3') {
-			if ($self->{is_on_stand_by} == 1) {
-				$self->{is_on_stand_by} = 0;
-				$self->check_location;
-			}
-		}
-		
-	} elsif ($callback_type eq 'recheck') {
-		$self->check_location;
-		
-	}
-	return $self->SUPER::validate_condition( (defined $self->{fulfilled_coordinate} ? 1 : 0) );
-}
-
-sub check_location {
-	my ( $self ) = @_;
-	my $counter;
-	$self->{fulfilled_coordinate} = undef;
-	$self->{fulfilled_member_index} = undef;
-	
-	foreach my $validator_index	(0..$#{$self->{x_validators}}) {
-		next unless ( $self->validator_x_check( $validator_index, $char->{pos_to}{x} ) );
-		next unless ( $self->validator_y_check( $validator_index, $char->{pos_to}{y} ) );
-		$self->{fulfilled_coordinate} = sprintf("%d %d %s", $char->{pos_to}{x}, $char->{pos_to}{y}, $field->baseName);
-		$self->{fulfilled_member_index} = $validator_index;
-		last;
-	}
-}
-
-sub get_new_variable_list {
-	my ($self) = @_;
-	my $new_variables;
-	
-	$new_variables->{".".$self->{name}."Last"} = $self->{fulfilled_coordinate};
-	$new_variables->{".".$self->{name}."LastMemberIndex"} = $self->{fulfilled_member_index};
-	
-	return $new_variables;
 }
 
 1;

--- a/plugins/eventMacro/eventMacro/Condition/IsNotInCoordinate.pm
+++ b/plugins/eventMacro/eventMacro/Condition/IsNotInCoordinate.pm
@@ -1,13 +1,16 @@
-package eventMacro::Condition::IsNotInMapAndCoordinate;
+package eventMacro::Condition::IsNotInCoordinate;
 
 use strict;
 use Globals qw( $char $field );
 
-use base 'eventMacro::Condition::IsInMapAndCoordinate';
+use base 'eventMacro::Condition::IsInCoordinate';
+
+#Use: x1 y1, x2 y2, x3min..x3max y3, x4 y4min..y4max, x5min..x5max y5min..y5max
 
 sub _parse_syntax {
 	my ( $self, $condition_code ) = @_;
 	
+	#if $condition_code have other thing besides letters, spaces and commas
 	if ($condition_code =~ /,/) {
 		$self->{error} = "You can't use comma separated values on this Condition";
 		return 0;
@@ -23,9 +26,6 @@ sub check_location {
 	$self->{fulfilled_coordinate} = undef;
 	$self->{fulfilled_member_index} = undef;
 	foreach my $validator_index (0..$self->{index_of_last_validator}) {
-		if (exists $self->{map_validators}{$validator_index}) {
-			next unless ( $self->validator_map_check( $validator_index, $field->baseName ) );
-		}
 		
 		if (exists $self->{x_validators}{$validator_index}) {
 			next unless ( $self->validator_x_check( $validator_index, $char->{pos_to}{x} ) );

--- a/plugins/eventMacro/eventMacro/Condition/IsNotInMapAndCoordinate.pm
+++ b/plugins/eventMacro/eventMacro/Condition/IsNotInMapAndCoordinate.pm
@@ -1,207 +1,16 @@
 package eventMacro::Condition::IsNotInMapAndCoordinate;
 
 use strict;
-use Globals;
-use Utils;
-use eventMacro::Data;
-use eventMacro::Utilities qw(find_variable);
+use Globals qw( $char $field );
 
-use base 'eventMacro::Condition';
-
-#Use: map1 x1 y1, x2 y2, map2 x3min..x3max y3, x4 y4min..y4max, map3 x5min..x5max y5min..y5max, map4
-
-sub _hooks {
-	['packet/actor_movement_interrupted','packet/high_jump','packet/character_moves','packet_mapChange','packet/map_property3'];
-}
-
-sub _parse_syntax {
-	my ( $self, $condition_code ) = @_;
-	
-	if ($condition_code =~ /,/) {
-		$self->{error} = "Comma separated values are not accepted on this condition";
-		return 0;
-	}
-	
-	$self->{is_on_stand_by} = 0;
-	
-	$self->{fulfilled_coordinate} = undef;
-	$self->{fulfilled_member_index} = undef;
-	
-	$self->{var_to_member_index_coord_x} = {};
-	$self->{var_to_member_index_coord_y} = {};
-	$self->{var_to_member_index_map} = {};
-	
-	$self->{x_validators} = {};
-	$self->{y_validators} = {};
-	$self->{map_validators} = {};
-	
-	my $var_exists_hash = {};
-		
-	my $member_index = 0;
-	my ($map, $coord_x, $coord_y);
-	my @parts = split(/\s+/, $condition_code);
-	
-	my $has_coords = 0;
-	my $has_map = 0;
-	
-	if (@parts == 0 || @parts > 3) {
-		$self->{error} = "'".$condition_code."' must have a map and/or a coordinate";
-		return 0;
-		
-	} elsif (@parts == 1) {
-		$has_map = 1;
-		$map = $parts[0];
-		
-	} elsif (@parts == 2) {
-		$has_coords = 1;
-		$coord_x = $parts[0];
-		$coord_y = $parts[1];
-		
-	} elsif (@parts == 3) {
-		$has_map = 1;
-		$has_coords = 1;
-		$map = $parts[0];
-		$coord_x = $parts[1];
-		$coord_y = $parts[2];
-	}
-	if ($has_coords) {
-		my $x_validator = eventMacro::Validator::NumericComparison->new( $coord_x );
-		
-		if (defined $x_validator->error) {
-			$self->{error} = $x_validator->error;
-			return 0;
-		} else {
-			my @vars = @{$x_validator->variables};
-			foreach my $var (@vars) {
-				push ( @{ $self->{var_to_member_index_coord_x}{$var->{display_name}} }, $member_index );
-				push ( @{ $self->{variables} }, $var ) unless (exists $var_exists_hash->{$var->{display_name}});
-				$var_exists_hash->{$var->{display_name}} = undef;
-			}
-		}
-		
-		my $y_validator = eventMacro::Validator::NumericComparison->new( $coord_y );
-		
-		if (defined $y_validator->error) {
-			$self->{error} = $y_validator->error;
-			return 0;
-		} else {
-			my @vars = @{$y_validator->variables};
-			foreach my $var (@vars) {
-				push ( @{ $self->{var_to_member_index_coord_y}{$var->{display_name}} }, $member_index );
-				push ( @{ $self->{variables} }, $var ) unless (exists $var_exists_hash->{$var->{display_name}});
-				$var_exists_hash->{$var->{display_name}} = undef;
-			}
-		}
-		
-		$self->{x_validators}{$member_index} = $x_validator;
-		$self->{y_validators}{$member_index} = $y_validator;
-	}
-	
-	if ($has_map) {
-		if (my $var = find_variable($map)) {
-			if ($var =~ /^\./) {
-				$self->{error} = "System variables should not be used in automacros (The ones starting with a dot '.')";
-				$self->{parsed} = 0;
-				return;
-			}
-			push ( @{ $self->{var_to_member_index_map}{$var->{display_name}} }, $member_index );
-			push ( @{ $self->{variables} }, $var ) unless (exists $var_exists_hash->{$var->{display_name}});
-			$var_exists_hash->{$var->{display_name}} = undef;
-			$self->{map_validators}{$member_index} = undef;
-		} else {
-			$self->{map_validators}{$member_index} = $map;
-		}
-	}
-	
-	$self->{index_of_last_validator} = $member_index;
-	return 1;
-}
-
-sub update_validator_var {
-	my ( $self, $var_name, $var_value ) = @_;
-	
-	my %members_index_changed;
-	
-	foreach my $member_index (@{$self->{var_to_member_index_coord_x}{$var_name}}) {
-		$self->{x_validators}{$member_index}->update_vars($var_name, $var_value);
-		$members_index_changed{$member_index} = undef;
-	}
-	
-	foreach my $member_index (@{$self->{var_to_member_index_coord_y}{$var_name}}) {
-		$self->{y_validators}{$member_index}->update_vars($var_name, $var_value);
-		$members_index_changed{$member_index} = undef;
-	}
-	
-	foreach my $member_index (@{$self->{var_to_member_index_map}{$var_name}}) {
-		$self->{map_validators}{$member_index} = $var_value;
-		$members_index_changed{$member_index} = undef;
-	}
-	
-	if (!defined $self->{fulfilled_member_index} || exists $members_index_changed{$self->{fulfilled_member_index}}) {
-		$self->check_location;
-	}
-}
-
-sub validator_x_check {
-	my ( $self, $validator_index, $check ) = @_;
-	return $self->{x_validators}{$validator_index}->validate($check);
-}
-
-sub validator_y_check {
-	my ( $self, $validator_index, $check ) = @_;
-	return $self->{y_validators}{$validator_index}->validate($check);
-}
-
-sub validator_map_check {
-	my ( $self, $validator_index, $check ) = @_;
-	return ($self->{map_validators}{$validator_index} eq $check ? 1 : 0);
-}
-
-sub validate_condition {
-	my ( $self, $callback_type, $callback_name, $args ) = @_;
-	
-	if ($callback_type eq 'variable') {
-		$self->update_validator_var($callback_name, $args);
-		
-	} elsif ($callback_type eq 'hook') {
-		
-		if ($callback_name eq 'packet/character_moves' || ($callback_name eq 'packet/actor_movement_interrupted' && Actor::get($args->{ID})->isa('Actor::You')) || ($callback_name eq 'packet/high_jump' && Actor::get($args->{ID})->isa('Actor::You'))) {
-			return $self->SUPER::validate_condition if (
-				defined $self->{fulfilled_coordinate} &&
-				!exists $self->{x_validators}{$self->{fulfilled_member_index}}
-			);
-			return $self->SUPER::validate_condition if (
-				defined $self->{fulfilled_coordinate} &&
-			    $self->validator_x_check( $self->{fulfilled_member_index}, $char->{pos_to}{x} ) &&
-				$self->validator_y_check( $self->{fulfilled_member_index}, $char->{pos_to}{y} )
-			);
-			$self->check_location;
-			
-		} elsif ($callback_name eq 'packet_mapChange') {
-			$self->{fulfilled_coordinate} = undef;
-			$self->{fulfilled_member_index} = undef;
-			$self->{is_on_stand_by} = 1;
-			
-		} elsif ($callback_name eq 'packet/map_property3') {
-			if ($self->{is_on_stand_by} == 1) {
-				$self->{is_on_stand_by} = 0;
-				$self->check_location;
-			}
-		}
-		
-	} elsif ($callback_type eq 'recheck') {
-		$self->check_location;
-		
-	}
-	return $self->SUPER::validate_condition( (defined $self->{fulfilled_coordinate} ? 0 : 1) );
-}
+use base 'eventMacro::Condition::IsInMapAndCoordinate';
 
 sub check_location {
 	my ( $self ) = @_;
 	my $counter;
+	my $found;
 	$self->{fulfilled_coordinate} = undef;
 	$self->{fulfilled_member_index} = undef;
-	
 	foreach my $validator_index (0..$self->{index_of_last_validator}) {
 		if (exists $self->{map_validators}{$validator_index}) {
 			next unless ( $self->validator_map_check( $validator_index, $field->baseName ) );
@@ -211,21 +20,11 @@ sub check_location {
 			next unless ( $self->validator_x_check( $validator_index, $char->{pos_to}{x} ) );
 			next unless ( $self->validator_y_check( $validator_index, $char->{pos_to}{y} ) );
 		}
-		
-		$self->{fulfilled_coordinate} = sprintf("%d %d %s", $char->{pos_to}{x}, $char->{pos_to}{y}, $field->baseName);
-		$self->{fulfilled_member_index} = $validator_index;
-		last;
+		$found = 1;
 	}
-}
-
-sub get_new_variable_list {
-	my ($self) = @_;
-	my $new_variables;
-	
-	$new_variables->{".".$self->{name}."Last"} = $self->{fulfilled_coordinate};
-	$new_variables->{".".$self->{name}."LastMemberIndex"} = $self->{fulfilled_member_index};
-	
-	return $new_variables;
+	if (!defined $found) {
+		$self->{fulfilled_coordinate} = sprintf("%d %d %s", $char->{pos_to}{x}, $char->{pos_to}{y}, $field->baseName);
+	}
 }
 
 1;

--- a/plugins/eventMacro/eventMacro/Condition/NotInMap.pm
+++ b/plugins/eventMacro/eventMacro/Condition/NotInMap.pm
@@ -4,6 +4,17 @@ use strict;
 use Globals qw( $field );
 use base 'eventMacro::Condition::InMap';
 
+sub _parse_syntax {
+	my ( $self, $condition_code ) = @_;
+	
+	if ($condition_code =~ /,/) {
+		$self->{error} = "You can't use comma separated values on this Condition";
+		return 0;
+	}
+	
+	$self->SUPER::_parse_syntax( $condition_code );
+}
+
 sub validate_condition {
 	my ( $self, $callback_type, $callback_name, $args ) = @_;
 	

--- a/plugins/eventMacro/eventMacro/Condition/NotInMap.pm
+++ b/plugins/eventMacro/eventMacro/Condition/NotInMap.pm
@@ -1,61 +1,19 @@
 package eventMacro::Condition::NotInMap;
 
 use strict;
-
-use base 'eventMacro::Condition';
-use eventMacro::Utilities qw( find_variable );
-
 use Globals qw( $field );
-
-sub _hooks {
-	['packet_mapChange'];
-}
-
-sub _parse_syntax {
-	my ( $self, $condition_code ) = @_;
-	
-	$self->{wanted_map} = undef;
-	
-	if (my $var = find_variable($condition_code)) {
-		if ($var =~ /^\./) {
-			$self->{error} = "System variables should not be used in automacros (The ones starting with a dot '.')";
-			return 0;
-		}
-		$self->{wanted_map} = undef;
-		push(@{$self->{variables}}, $var);
-		
-	} else {
-		$self->{wanted_map} = $condition_code;
-	}
-	
-	
-	return 1;
-}
+use base 'eventMacro::Condition::InMap';
 
 sub validate_condition {
 	my ( $self, $callback_type, $callback_name, $args ) = @_;
 	
 	if ($callback_type eq 'variable') {
-		$self->{wanted_map} = $args;
+		$self->update_validator_var($callback_name, $args);
 	}
 	
-	return unless (defined $self->{wanted_map});
+	$self->{lastMap} = $field->baseName;
 	
-	if ($field->baseName ne $self->{wanted_map}) {
-		$self->{lastMap} = $field->baseName;
-		return $self->SUPER::validate_condition(1);
-	} else {
-		return $self->SUPER::validate_condition(0);
-	}
-}
-
-sub get_new_variable_list {
-	my ($self) = @_;
-	my $new_variables;
-	
-	$new_variables->{".".$self->{name}."Last"} = $self->{lastMap};
-	
-	return $new_variables;
+	return $self->eventMacro::Condition::validate_condition( $self->validator_check_opposite($self->{lastMap}) );
 }
 
 1;

--- a/plugins/eventMacro/eventMacro/Conditiontypes/ListConditionState.pm
+++ b/plugins/eventMacro/eventMacro/Conditiontypes/ListConditionState.pm
@@ -19,6 +19,11 @@ sub validator_check {
 	return $self->{validator}->validate($possible_member);
 }
 
+sub validator_check_opposite {
+	my ( $self, $possible_member ) = @_;
+	return $self->{validator}->validate_opposite($possible_member);
+}
+
 sub update_validator_var {
 	my ( $self, $var_name, $var_value ) = @_;
 	$self->{validator}->update_vars($var_name, $var_value);

--- a/plugins/eventMacro/eventMacro/Validator/ListMemberCheck.pm
+++ b/plugins/eventMacro/eventMacro/Validator/ListMemberCheck.pm
@@ -72,5 +72,16 @@ sub validate {
 	return 0;
 }
 
+sub validate_opposite {
+	my ( $self, $possible_member ) = @_;
+	return 0 if ($self->{list_is_any});
+	
+	foreach my $list_member (@{$self->{list}}) {
+		next unless (defined $list_member);
+		return 0 if ($list_member eq $possible_member);
+	}
+	
+	return 1;
+}
 
 1;


### PR DESCRIPTION
### Changes:
**IsInCoordinate** and **IsNotInMapAndCoordinate** now are childs of **IsInMapAndCoordinate**

**IsInCoordinate** now have only the `sub parse_syntax` , the change is to accept only coordinates
**IsNotInMapAndCoordinate** now have only the `sub check_location` the change is to be true only if you not in any of the specified maps/coodinates. So, if the condition is like this: `IsNotInMapAndCoordinate prontera, morocc, geffen, aldebaran, yuno` , the condition will only be true if you not in any of these maps
(but i wonder if it is correct to keep it like this)

**NotInMap** Same of last condition