### PR TITLE
Make a check for when have more than 30000 of same item

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1029,7 +1029,7 @@ sub processTransferItems {
 			my ( $name, $list ) = @$_;
 			next if $list->isReady;
 			#name can be storage, inventory or cart
-			error T( "Your $name is not available. Unable to transfer item '%s'.\n", $row->{item} );
+			error TF( "Your %s is not available. Unable to transfer item '%s'.\n", $name, $row->{item} );
 			redo;
 		}
 

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1037,7 +1037,7 @@ sub processTransferItems {
 		my $item = $source->get( $row->{item}->{binID} );
 		
 		if ( !$item || $item->nameString ne $row->{item}->nameString ) {
-			error TF( "$row->{source} item '%s' disappeared!\n", $row->{item} );
+			error TF( "%s item '%s' disappeared!\n", $row->{source}, $row->{item} );
 			redo;
 		}
 

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1069,11 +1069,11 @@ sub processTransferItems {
 		my $stack_limit = $target->item_max_stack( $row->{item}->{nameID} );
 		
 		my $amount = min($stack_limit, min( $item->{amount}, $row->{amount} || $item->{amount} ));
-		if ( ( $stack_limit - $amount ) < 0 || ($target_item->{amount} - $stack_limit) == 0) {
+		if ( $stack_limit - $amount < 0 || $target_item->{amount} - $stack_limit == 0) {
 			error TF("Unable to add %s to %s. You can't stack over %s of this item\n", $item->name, $row->{target}, $stack_limit);
 			redo;
 			
-		} elsif ( ($target_item->{amount} + $amount) > $stack_limit ) {
+		} elsif ( $target_item->{amount} + $amount > $stack_limit ) {
 			warning TF("Amount of %s will surpass the maximum %s capacity (%d), transfering maximum possible (%d)\n",
 			$row->{item}->name, $row->{target}, $stack_limit, $stack_limit - $target_item->{amount} );
 			

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1068,19 +1068,17 @@ sub processTransferItems {
 		my $target_item = $target->getByName( $row->{item}->{name} );
 		my $stack_limit = $target->item_max_stack( $row->{item}->{nameID} );
 		
-		my $amount;
-		if (( $stack_limit - $target_item->{amount} ) <= 0) {
+		my $amount = min($stack_limit, min( $item->{amount}, $row->{amount} || $item->{amount} ));
+		if ( ( $stack_limit - $amount ) < 0 || ($target_item->{amount} - $stack_limit) == 0) {
 			error TF("Unable to add %s to %s. You can't stack over %s of this item\n", $item->name, $row->{target}, $stack_limit);
 			redo;
 			
-		} elsif ( ($stack_limit - $target_item->{amount} ) < min( $item->{amount}, $row->{amount} ) ) {
+		} elsif ( ($target_item->{amount} + $amount) > $stack_limit ) {
 			warning TF("Amount of %s will surpass the maximum %s capacity (%d), transfering maximum possible (%d)\n",
 			$row->{item}->name, $row->{target}, $stack_limit, $stack_limit - $target_item->{amount} );
 			
 			$amount = $stack_limit - $target_item->{amount};
 			
-		} else {
-			$amount = min( $item->{amount}, $row->{amount} || $item->{amount} );
 		}
 		# Transfer the item!
 		$messageSender->$method( $item->{ID}, $amount );

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1068,7 +1068,9 @@ sub processTransferItems {
 		my $target_item = $target->getByName( $row->{item}->name );
 		
 		# Transfer the item!
-		if ( (30000 - $target_item->{amount} ) < min( $item->{amount}, $row->{amount} ) ) {
+		if ((30000 - $target_item->{amount} ) <= 0) {
+			error TF("Unable to add %s to %s. You can't stack over 30,000 of the same item\n", $item->name, $row->{target});
+		} elsif ( (30000 - $target_item->{amount} ) < min( $item->{amount}, $row->{amount} ) ) {
 			warning TF("Amount of %s will surpass the maximun %s capacity (30000), transfering maximum possible (%d)\n", $row->{item}->name, $row->{target}, 30000 - $target_item->{amount} );
 			$messageSender->$method( $item->{ID}, ( 30000 - $target_item->{amount} ) );
 		} else {

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4769,8 +4769,7 @@ sub cmdStorage {
 }
 
 sub cmdStorage_add {
-	my $name = shift;
-	my $amount = shift;
+	my ($name, $amount) = @_;
 
 	my @items = $char->inventory->getMultiple( $name );
 	if ( !@items ) {
@@ -4782,8 +4781,7 @@ sub cmdStorage_add {
 }
 
 sub cmdStorage_addfromcart {
-	my $name = shift;
-	my $amount = shift;
+	my ($name, $amount) = @_;
 
 	if (!$char->cart->isReady) {
 		error T("Error in function 'storage_gettocart' (Cart Management)\nYou do not have a cart.\n");
@@ -4800,8 +4798,7 @@ sub cmdStorage_addfromcart {
 }
 
 sub cmdStorage_get {
-	my $name = shift;
-	my $amount = shift;
+	my ($name, $amount) = @_;
 	
 	my @items = $char->storage->getMultiple( $name );
 	if ( !@items ) {
@@ -4813,8 +4810,7 @@ sub cmdStorage_get {
 }
 
 sub cmdStorage_gettocart {
-	my $name = shift;
-	my $amount = shift;
+	my ($name, $amount) = @_;
 
 	if ( !$char->cart->isReady ) {
 		error T( "Error in function 'storage_gettocart' (Cart Management)\nYou do not have a cart.\n" );

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4731,14 +4731,21 @@ sub cmdStorage {
 			cmdStorage_desc($items);
 		} elsif (($switch =~ /^(add|addfromcart|get|gettocart)$/ && ($items || $args =~ /$switch 0/)) || $switch eq 'close') {
 			if ($char->storage->isReady()) {
+				my ( $name, $amount );
+				if ( $items =~ /^[^"'].* .+$/ ) {
+					# Backwards compatibility: "storage add Empty Bottle 1" still works.
+					( $name, $amount ) = $items =~ /^(.*?)(?: (\d+))?$/;
+				} else {
+					( $name, $amount ) = parseArgs( $items );
+				}
 				if ($switch eq 'add') {
-					cmdStorage_add($items);
+					cmdStorage_add($name, $amount);
 				} elsif ($switch eq 'addfromcart') {
-					cmdStorage_addfromcart($items);
+					cmdStorage_addfromcart($name, $amount);
 				} elsif ($switch eq 'get') {
-					cmdStorage_get($items);
+					cmdStorage_get($name, $amount);
 				} elsif ($switch eq 'gettocart') {
-					cmdStorage_gettocart($items);
+					cmdStorage_gettocart($name, $amount);
 				} elsif ($switch eq 'close') {
 					cmdStorage_close();
 				}
@@ -4762,15 +4769,9 @@ sub cmdStorage {
 }
 
 sub cmdStorage_add {
-	my $items = shift;
+	my $name = shift;
+	my $amount = shift;
 
-	my ( $name, $amount );
-	if ( $items =~ /^[^"'].* .+$/ ) {
-		# Backwards compatibility: "storage add Empty Bottle 1" still works.
-		( $name, $amount ) = $items =~ /^(.*?)(?: (\d+))?$/;
-	} else {
-		( $name, $amount ) = parseArgs( $items );
-	}
 	my @items = $char->inventory->getMultiple( $name );
 	if ( !@items ) {
 		error TF( "Inventory item '%s' does not exist.\n", $name );
@@ -4781,20 +4782,14 @@ sub cmdStorage_add {
 }
 
 sub cmdStorage_addfromcart {
-	my $items = shift;
+	my $name = shift;
+	my $amount = shift;
 
 	if (!$char->cart->isReady) {
 		error T("Error in function 'storage_gettocart' (Cart Management)\nYou do not have a cart.\n");
 		return;
 	}
-
-	my ( $name, $amount );
-	if ( $items =~ /^[^"'].* .+$/ ) {
-		# Backwards compatibility: "storage addfromcart Empty Bottle 1" still works.
-		( $name, $amount ) = $items =~ /^(.*?)(?: (\d+))?$/;
-	} else {
-		( $name, $amount ) = parseArgs( $items );
-	}
+	
 	my @items = $char->cart->getMultiple( $name );
 	if ( !@items ) {
 		error TF( "Cart item '%s' does not exist.\n", $name );
@@ -4805,15 +4800,9 @@ sub cmdStorage_addfromcart {
 }
 
 sub cmdStorage_get {
-	my $items = shift;
-
-	my ( $name, $amount );
-	if ( $items =~ /^[^"'].* .+$/ ) {
-		# Backwards compatibility: "storage get Empty Bottle 1" still works.
-		( $name, $amount ) = $items =~ /^(.*?)(?: (\d+))?$/;
-	} else {
-		( $name, $amount ) = parseArgs( $items );
-	}
+	my $name = shift;
+	my $amount = shift;
+	
 	my @items = $char->storage->getMultiple( $name );
 	if ( !@items ) {
 		error TF( "Storage item '%s' does not exist.\n", $name );
@@ -4824,20 +4813,14 @@ sub cmdStorage_get {
 }
 
 sub cmdStorage_gettocart {
-	my $items = shift;
+	my $name = shift;
+	my $amount = shift;
 
 	if ( !$char->cart->isReady ) {
 		error T( "Error in function 'storage_gettocart' (Cart Management)\nYou do not have a cart.\n" );
 		return;
 	}
 
-	my ( $name, $amount );
-	if ( $items =~ /^[^"'].* .+$/ ) {
-		# Backwards compatibility: "storage get Empty Bottle 1" still works.
-		( $name, $amount ) = $items =~ /^(.*?)(?: (\d+))?$/;
-	} else {
-		( $name, $amount ) = parseArgs( $items );
-	}
 	my @items = $char->storage->getMultiple( $name );
 	if ( !@items ) {
 		error TF( "Storage item '%s' does not exist.\n", $name );


### PR DESCRIPTION
### Things to discuss:
* i think that variable `$target_item` have a very bad name (i've didn't think too much) and i'm looking for some tip to give a better name.
that variable store the item object on the target inventory

* Also, if i use `$row->{item}`, shows the name of item along with it's index. If i use `$row->{item}->name` the name show without the index of it
Which one you guys think is better?

### Before: 
![image](https://user-images.githubusercontent.com/11494727/47892877-e79a8b00-de38-11e8-9ff3-07624b5b4e6c.png)



### After:
![image](https://user-images.githubusercontent.com/11494727/47892955-37795200-de39-11e8-9ca3-641ab50b16ff.png)

### When already have 30,000 of the item and you try to add more
![image](https://user-images.githubusercontent.com/11494727/47893238-ad31ed80-de3a-11e8-8358-abebd6c6d41e.png)

#### Additional thing:
I removed a little bit of repetitive code on Commands.pm

**Thanks to @lututui for provided me a better sentence to use on error message**