### PR TITLE
fix error in relog command

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -285,7 +285,7 @@ sub run {
 	}
 
 	# Remove trailing spaces from input
-	$input =~ s/^\s+//;
+	$input =~ s/^\s+|\s+$//g;
 
 	my @commands = split(';;', $input);
 	# Loop through all of the commands...


### PR DESCRIPTION
when it were merge my PR that changed relog command, it went with a bug that @lututui reported to me (thanks)
when you put a space but with no arguments, change to offline (should relog in 5 seconds) and generates this error: 
![image](https://user-images.githubusercontent.com/11494727/48308964-6b99f480-e556-11e8-88f6-097936357f01.png)

This PR fix this
