### PR TITLE
iRO: Update prontera Kafra warp position

### DIFF
--- a/tables/iRO/official/portals.txt
+++ b/tables/iRO/official/portals.txt
@@ -1,0 +1,3206 @@
+#format: <source coordinate><destination coordinate>[zenny cost][conversation sequence]
+alberta 195 151 alb2trea 62 69 0 c c r0
+alb2trea 39 50 alberta 192 169 0 r0
+alberta 247 122 tur_dun01 157 39 10000 c r1 c r0 c c c
+alberta 245 45 lou_fild01 190 101 10000 c r1 c c r0
+alberta 247 42 ayothaya 149 71 10000 c r1 c c r0 n
+lou_fild01 190 100 alberta 235 45 0 c r0
+tur_dun01 165 29 alberta 241 115 0 c r0 c c
+alberta 245 93 amatsu 197 83 10000 c r1 c c c r0 n
+amatsu 194 79 alberta 243 91 0 c r0 n
+alberta 245 69 gon_fild01 258 82 0 c r1 c c r0 n
+gon_fild01 255 79 alberta 243 67 0 c r0 n
+izlude 201 181 izlu2dun 107 50 150 c r0
+izlu2dun 108 27 izlude 176 182 0 c r0
+prt_fild05 270 212 prt_sewb1 135 248 0 c r0
+aldebaran 223 222 xmas_fild01 78 68 0 c r1 c c n
+moc_fild12 35 303 cmd_fild08 331 319 0 c r0 n
+ayothaya 152 68 alberta 247 42 0 c r0 n
+ama_in02 115 177 ama_dun01 229 10 0 c r1 c r0 n
+ama_dun01 229 7 ama_in02 119 181 0 c r0 n
+
+# VIP Warps
+#yuno 142 183 prontera 116 72 1800 c c c c c r0
+#yuno 142 183 izlude 94 103 1800 c c c c c r1
+#yuno 142 183 geffen 120 39 1800 c c c c c r2
+#yuno 142 183 morocc 156 47 1800 c c c c c r3
+#yuno 142 183 payon 161 58 1800 c c c c c r4
+#yuno 142 183 alberta 117 56 1800 c c c c c r5
+#yuno 142 183 comodo 209 143 1800 c c c c c r6
+#yuno 152 187 aldebaran 168 112 1200 c r2 c r0
+#aldebaran 143 119 geffen 120 39 2300 c r2 c r0
+#aldebaran 143 119 yuno 158 125 1200 c r2 c r1
+#aldebaran 143 119 izude 94 103 1800 c r2 c r2
+#aldebaran 143 119 mjolnir_02 99 351 1700 c r2 c r3
+#morocc 156 97 prontera 116 72 1200 c r2 c r0
+#morocc 156 97 payon 161 58 1200 c r2 c r1
+#morocc 156 97 alberta 117 56 1800 c r2 c r2
+#morocc 156 97 comodo 209 143 1800 c r2 c r3
+#morocc 156 97 cmd_fild07 127 134 1200 c r2 c r4
+#morocc 160 258 prontera 116 72 1200 c r2 c r0
+#morocc 160 258 payon 161 58 1200 c r2 c r1
+#morocc 160 258 alberta 117 56 1800 c r2 c r2
+#morocc 160 258 comodo 209 143 1800 c r2 c r3
+#morocc 160 258 cmd_fild07 127 134 1200 c r2 c r4
+#cmd_fild07 136 134 morocc 156 47 1200 c c r2 c r0
+#cmd_fild07 136 134 comodo 209 143 1200 c c r2 c r1
+#comodo 195 150 morocc 156 47 1800 c c r2 c r0
+#comodo 195 150 cmd_fild07 127 134 1200 c c r2 c r1
+#comodo 195 150 umbala 100 154 1800 c c r2 c r2
+#umbala 87 160 comodo 209 143 1800 c r2 c r0
+#prontera 146 89 izlude 94 103 600 c r2 c r0
+#prontera 146 89 geffen 120 39 1200 c r2 c r1
+#prontera 146 89 payon 161 58 1200 c r2 c r2
+#prontera 146 89 morocc 156 47 1200 c r2 c r3
+#prontera 146 89 gef_fild10 52 326 1700 c r2 c r4
+#prontera 146 89 alberta 117 56 1800 c r2 c r5
+#prontera 151 29 izlude 94 103 600 c r2 c r0
+#prontera 151 29 geffen 120 39 1200 c r2 c r1
+#prontera 151 29 payon 161 58 1200 c r2 c r2
+#prontera 151 29 morocc 156 47 1200 c r2 c r3
+#prontera 151 29 gef_fild10 52 326 1700 c r2 c r4
+#prontera 151 29 alberta 117 56 1800 c r2 c r5
+#prontera 282 200 izlude 94 103 600 c r2 c r0
+#prontera 282 200 geffen 120 39 1200 c r2 c r1
+#prontera 282 200 payon 161 58 1200 c r2 c r2
+#prontera 282 200 morocc 156 47 1200 c r2 c r3
+#prontera 282 200 gef_fild10 52 326 1700 c r2 c r4
+#prontera 282 200 alberta 117 56 1800 c r2 c r5
+#prontera 29 207 izlude 94 103 600 c r2 c r0
+#prontera 29 207 geffen 120 39 1200 c r2 c r1
+#prontera 29 207 payon 161 58 1200 c r2 c r2
+#prontera 29 207 morocc 156 47 1200 c r2 c r3
+#prontera 29 207 gef_fild10 52 326 1700 c r2 c r4
+#prontera 29 207 alberta 117 56 1800 c r2 c r5
+#payon 175 226 prontera 116 72 1200 c r2 c r0
+#payon 175 226 alberta 117 56 1200 c r2 c r1
+#payon 175 226 morocc 156 47 1200 c r2 c r2
+#payon 181 104 prontera 116 72 1200 c r2 c r0
+#payon 181 104 alberta 117 56 1200 c r2 c r1
+#payon 181 104 morocc 156 47 1200 c r2 c r2
+#alberta 113 60 payon 161 58 1200 c r2 c r0
+#alberta 113 60 morocc 156 47 1800 c r2 c r1
+#alberta 113 60 prontera 116 72 1800 c r2 c r2
+#alberta 28 229 payon 161 58 1200 c r2 c r0
+#alberta 28 229 morocc 156 47 1800 c r2 c r1
+#alberta 28 229 prontera 116 72 1800 c r2 c r2
+#izlude 134 88 geffen 120 39 1200 c r2 c r0
+#izlude 134 88 payon 161 58 1200 c r2 c r1
+#izlude 134 88 morocc 156 47 1200 c r2 c r2
+#izlude 134 88 aldebaran 168 112 1800 c r2 c r3
+# to add: Eden warper, Prontera warper
+
+# Non-VIP Warps
+prontera 146 89 izlude 94 103 2000 c r2 c r0
+prontera 146 89 geffen 120 39 2000 c r2 c r1
+prontera 146 89 payon 161 58 2000 c r2 c r2
+prontera 146 89 morocc 156 47 2000 c r2 c r3
+prontera 146 89 alberta 117 56 2000 c r2 c r4
+prontera 146 89 aldebaran 168 112 2000 c r2 c r5
+prontera 146 89 comodo 209 143 3000 c r2 c r6
+prontera 146 89 umbala 100 154 3000 c r2 c r7
+prontera 151 29 izlude 94 103 2000 c r2 c r0
+prontera 151 29 geffen 120 39 2000 c r2 c r1
+prontera 151 29 payon 161 58 2000 c r2 c r2
+prontera 151 29 morocc 156 47 2000 c r2 c r3
+prontera 151 29 alberta 117 56 2000 c r2 c r4
+prontera 151 29 aldebaran 168 112 2000 c r2 c r5
+prontera 151 29 comodo 209 143 3000 c r2 c r6
+prontera 151 29 umbala 100 154 3000 c r2 c r7
+prontera 282 200 izlude 94 103 2000 c r2 c r0
+prontera 282 200 geffen 120 39 2000 c r2 c r1
+prontera 282 200 payon 161 58 2000 c r2 c r2
+prontera 282 200 morocc 156 47 2000 c r2 c r3
+prontera 282 200 alberta 117 56 2000 c r2 c r4
+prontera 282 200 aldebaran 168 112 2000 c r2 c r5
+prontera 282 200 comodo 209 143 3000 c r2 c r6
+prontera 282 200 umbala 100 154 3000 c r2 c r7
+prontera 35 208 izlude 94 103 2000 c r2 c r0
+prontera 35 208 geffen 120 39 2000 c r2 c r1
+prontera 35 208 payon 161 58 2000 c r2 c r2
+prontera 35 208 morocc 156 47 2000 c r2 c r3
+prontera 35 208 alberta 117 56 2000 c r2 c r4
+prontera 35 208 aldebaran 168 112 2000 c r2 c r5
+prontera 35 208 comodo 209 143 3000 c r2 c r6
+prontera 35 208 umbala 100 154 3000 c r2 c r7
+prontera 98 120 yuno 157 167 1800 c c r0 c
+geffen 120 62 prontera 116 72 1200 c r2 c r0
+geffen 120 62 aldebaran 168 112 1200 c r2 c r1
+geffen 120 62 gef_fild10 52 326 1200 c r2 c r2
+geffen 120 62 mjolnir_02 99 351 1700 c r2 c r3
+geffen 203 123 prontera 116 72 1200 c r2 c r0
+geffen 203 123 aldebaran 168 112 1200 c r2 c r1
+geffen 203 123 gef_fild10 52 326 1200 c r2 c r2
+geffen 203 123 mjolnir_02 99 351 1700 c r2 c r3
+aldebaran 143 119 geffen 120 39 2000 c r2 c r0
+izlude 134 88 prontera 116 72 2000 c r2 c r0
+yuno 152 187 einbroch 67 195 2000 c r2 c r0
+yuno 152 187 lighthalzen 159 90 2000 c r2 c r1
+yuno 152 187 hugel 98 150 2000 c r2 c r2
+yuno 152 187 rachel 119 135 2000 c r2 c r3
+yuno 327 108 aldebaran 168 112 2000 c r2 c r0
+yuno 142 183 prontera 116 72 1800 c c r0 c n
+morocc 156 97 prontera 116 72 2000 c r2 c r0
+comodo 195 150 morocc 156 47 2000 c c r2 c r0
+payon 181 104 prontera 116 72 2000 c r2 c r0
+payon 175 226 prontera 116 72 1200 c r2 c r0
+alberta 113 60 payon 161 58 2000 c r2 c r0
+rachel 109 138 veins 205 101 2200 c r2 c r0
+rachel 109 138 yuno 158 125 3000 c r2 c r1
+veins 208 128 rachel 115 125 2200 c r2 c r0
+veins 208 128 yuno 158 125 3000 c r2 c r1
+moc_para01 14 32 prontera 116 72 1800 c c r0 c n
+
+# Training Grounds
+new_1-1 148 112 new_1-2 100 9
+new_2-1 148 112 new_2-2 100 9
+new_3-1 148 112 new_3-2 100 9
+new_4-1 148 112 new_4-2 100 9
+new_5-1 148 112 new_5-2 100 9
+new_1-2 100 6 new_1-1 144 112
+new_2-2 100 6 new_2-1 144 112
+new_3-2 100 6 new_3-1 144 112
+new_4-2 100 6 new_4-1 144 112
+new_5-2 100 6 new_5-1 144 112
+
+# Training Grounds entrance
+new_1-2 100 29 new_1-2 100 70 0 c r0 c c
+new_2-2 100 29 new_2-2 100 70 0 c r0 c c
+new_3-2 100 29 new_3-2 100 70 0 c r0 c c
+new_4-2 100 29 new_4-2 100 70 0 c r0 c c
+new_5-2 100 29 new_5-2 100 70 0 c r0 c c
+
+# Training Grounds Kafra
+new_1-2 118 108 prontera 150 50 0 c c c r0 c c c r0 c
+new_2-2 118 108 prontera 150 50 0 c c c r0 c c c r0 c
+new_3-2 118 108 prontera 150 50 0 c c c r0 c c c r0 c
+new_4-2 118 108 prontera 150 50 0 c c c r0 c c c r0 c
+new_5-2 118 108 prontera 150 50 0 c c c r0 c c c r0 c
+new_1-2 118 108 morocc 155 110 0 c c c r0 c c c r1 c
+new_2-2 118 108 morocc 155 110 0 c c c r0 c c c r1 c
+new_3-2 118 108 morocc 155 110 0 c c c r0 c c c r1 c
+new_4-2 118 108 morocc 155 110 0 c c c r0 c c c r1 c
+new_5-2 118 108 morocc 155 110 0 c c c r0 c c c r1 c
+new_1-2 118 108 payon 166 67 0 c c c r0 c c c r2 c
+new_2-2 118 108 payon 166 67 0 c c c r0 c c c r2 c
+new_3-2 118 108 payon 166 67 0 c c c r0 c c c r2 c
+new_4-2 118 108 payon 166 67 0 c c c r0 c c c r2 c
+new_5-2 118 108 payon 166 67 0 c c c r0 c c c r2 c
+new_1-2 118 108 alberta 114 58 0 c c c r0 c c c r3 c
+new_2-2 118 108 alberta 114 58 0 c c c r0 c c c r3 c
+new_3-2 118 108 alberta 114 58 0 c c c r0 c c c r3 c
+new_4-2 118 108 alberta 114 58 0 c c c r0 c c c r3 c
+new_5-2 118 108 alberta 114 58 0 c c c r0 c c c r3 c
+new_1-2 118 108 geffen 122 65 0 c c c r0 c c c r4 c
+new_2-2 118 108 geffen 122 65 0 c c c r0 c c c r4 c
+new_3-2 118 108 geffen 122 65 0 c c c r0 c c c r4 c
+new_4-2 118 108 geffen 122 65 0 c c c r0 c c c r4 c
+new_5-2 118 108 geffen 122 65 0 c c c r0 c c c r4 c
+
+new_1-2 126 106 new_1-2 160 171
+new_2-2 126 106 new_2-2 160 171
+new_3-2 126 106 new_3-2 160 171
+new_4-2 126 106 new_4-2 160 171
+new_5-2 126 106 new_5-2 160 171
+new_1-2 156 171 new_1-2 123 106
+new_2-2 156 171 new_2-2 123 106
+new_3-2 156 171 new_3-2 123 106
+new_4-2 156 171 new_4-2 123 106
+new_5-2 156 171 new_5-2 123 106
+new_1-2 73 106 new_1-2 41 172
+new_2-2 73 106 new_2-2 41 172
+new_3-2 73 106 new_3-2 41 172
+new_4-2 73 106 new_4-2 41 172
+new_5-2 73 106 new_5-2 41 172
+new_1-2 46 172 new_1-2 78 106
+new_2-2 46 172 new_2-2 78 106
+new_3-2 46 172 new_3-2 78 106
+new_4-2 46 172 new_4-2 78 106
+new_5-2 46 172 new_5-2 78 106
+
+new_1-3 96 174 new_1-4 99 10 0 c r0 c
+new_2-3 96 174 new_2-4 99 10 0 c r0 c
+new_3-3 96 174 new_3-4 99 10 0 c r0 c
+new_4-3 96 174 new_4-4 99 10 0 c r0 c
+new_5-3 96 174 new_5-4 99 10 0 c r0 c
+
+# Training Grounds exit
+new_1-4 100 29 moc_ruins 155 44 0 c c c c c r0 c c c c r1 r0 r0 r0 r1 r1 c c r0 c r0 c r0 c r1 c c r0 c r1 c r1 c r1 c c r2 c r2 c r2 c r0 c r2 c r2 c r0 c r1 c c c c c c c c c c r0 c c c c c c c c
+new_2-4 100 29 moc_ruins 155 44 0 c c c c c r0 c c c c r1 r0 r0 r0 r1 r1 c c r0 c r0 c r0 c r1 c c r0 c r1 c r1 c r1 c c r2 c r2 c r2 c r0 c r2 c r2 c r0 c r1 c c c c c c c c c c r0 c c c c c c c c
+new_3-4 100 29 moc_ruins 155 44 0 c c c c c r0 c c c c r1 r0 r0 r0 r1 r1 c c r0 c r0 c r0 c r1 c c r0 c r1 c r1 c r1 c c r2 c r2 c r2 c r0 c r2 c r2 c r0 c r1 c c c c c c c c c c r0 c c c c c c c c
+new_4-4 100 29 moc_ruins 155 44 0 c c c c c r0 c c c c r1 r0 r0 r0 r1 r1 c c r0 c r0 c r0 c r1 c c r0 c r1 c r1 c r1 c c r2 c r2 c r2 c r0 c r2 c r2 c r0 c r1 c c c c c c c c c c r0 c c c c c c c c
+new_5-4 100 29 moc_ruins 155 44 0 c c c c c r0 c c c c r1 r0 r0 r0 r1 r1 c c r0 c r0 c r0 c r1 c c r0 c r1 c r1 c r1 c c r2 c r2 c r2 c r0 c r2 c r2 c r0 c r1 c c c c c c c c c c r0 c c c c c c c c
+
+# Izlude Arena
+arena_room 105 93 prt_are_in 60 14 0 c r0
+prt_are_in 54 13 arena_room 100 77
+
+# Anthell
+#anthell01 35 267 moc_fild20 161 144
+#anthell02 171 170 moc_fild20 333 315
+#moc_fild20 156 143 anthell01 35 263
+#moc_fild20 337 315 anthell02 168 170
+anthell01 35 267 cmd_fild08 335 355
+anthell02 171 170 cmd_fild08 344 82
+cmd_fild08 335 355 anthell01 35 263
+cmd_fild08 348 82 anthell02 171 170
+
+# Morroc area (Episode 12)
+moc_fild01 84 19 moc_fild20 209 333
+moc_fild07 380 202 moc_fild20 36 177
+moc_fild11 189 360 moc_fild20 197 24
+moc_fild11 377 197 moc_fild20 36 177
+moc_fild13 32 171 moc_fild20 349 179
+moc_fild16 124 381 moc_fild20 197 24
+moc_fild16 333 380 moc_fild20 197 24
+moc_fild20 38 174 morocc 160 61 0 c r1 c c c c r1 c c r1
+moc_fild20 38 183 morocc 160 61 0 c r1 c c c c r1 c c r1
+moc_fild20 189 21 morocc 160 61 0 c r1 c c c c r1 c c r1
+moc_fild20 200 21 morocc 160 61 0 c r1 c c c c r1 c c r1
+moc_fild20 354 183 morocc 160 61 0 c r1 c c c c r1 c c r1
+moc_fild20 354 174 morocc 160 61 0 c r1 c c c c r1 c c r1
+moc_fild20 203 336 moc_fild01 86 32 0 c r1 c c c c r2
+moc_fild20 215 336 moc_fild01 86 32 0 c r1 c c c c r2
+moc_fild20 203 336 morocc 160 61 0 c r1 c c c c r1 c c r1
+moc_fild20 215 336 morocc 160 61 0 c r1 c c c c r1 c c r1
+morocc 299 207 moc_fild20 36 177
+prt_fild09 95 19 moc_fild20 209 333
+prt_fild09 246 17 moc_fild20 209 333
+prt_fild10 263 23 moc_fild20 209 333
+
+# Dimensional Gorge (Episode 12)
+# moc_fild20 -> moc_fild21 npcs are only available with the quest and a party with at least two members online
+moc_fild20 38 174 moc_fild21 38 193 0 c r1 c c c
+moc_fild20 38 183 moc_fild21 38 193 0 c r1 c c c
+moc_fild20 189 21 moc_fild21 38 193 0 c r1 c c c
+moc_fild20 200 21 moc_fild21 38 193 0 c r1 c c c
+moc_fild20 354 183 moc_fild21 38 193 0 c r1 c c c
+moc_fild20 354 174 moc_fild21 38 193 0 c r1 c c c
+moc_fild20 203 336 moc_fild21 38 193 0 c r1 c c c
+moc_fild20 215 336 moc_fild21 38 193 0 c r1 c c c
+moc_fild21 26 196 moc_fild20 349 179
+moc_fild22 32 196 moc_fild20 349 179
+
+# Battlegrounds (Episode 12)
+aldebaran 146 109 bat_room 154 150 0 c c r0 c
+geffen 109 66 bat_room 154 150 0 c c r0 c
+lighthalzen 153 86 bat_room 154 150 0 c c r0 c
+moc_ruins 75 162 bat_room 154 150 0 c c r0 c
+payon 189 105 bat_room 154 150 0 c c r0 c
+prontera 123 83 bat_room 154 150 0 c c r0 c
+rachel 149 138 bat_room 154 150 0 c c r0 c
+
+# following is a single warp, depends of entrance npc used
+# currently unsupported, do not enable that
+#bat_room 148 150 aldebaran 168 112 0 c r0 c
+#bat_room 148 150 geffen 120 39 0 c r0 c
+#bat_room 148 150 lighthalzen 159 93 0 c r0 c
+#bat_room 148 150 moc_ruins 152 48 0 c r0 c
+#bat_room 148 150 payon 161 58 0 c r0 c
+#bat_room 148 150 prontera 116 72 0 c r0 c
+#bat_room 148 150 rachel 115 124 0 c r0 c
+
+# following bat_room npcs are only available with base lvl 80
+# Tierra 1 Blue
+bat_room 124 178 bat_room 57 223 0 c r0 c
+bat_room 57 220 bat_room 154 150
+# Tierra 1 Red
+bat_room 125 121 bat_room 57 207 0 c r0 c
+bat_room 57 211 bat_room 154 150
+# Flavius 1 Blue
+bat_room 133 178 bat_room 85 223 0 c r0 c
+bat_room 85 220 bat_room 154 150
+# Flavius 1 Red
+bat_room 133 121 bat_room 85 207 0 c r0 c
+bat_room 85 211 bat_room 154 150
+# Tierra 2 Blue
+bat_room 140 178 bat_room 114 223 0 c r0 c
+bat_room 113 220 bat_room 154 150
+# Tierra 2 Red
+bat_room 140 121 bat_room 114 207 0 c r0 c
+bat_room 113 211 bat_room 154 150
+# Flavius 2 Blue
+bat_room 148 178 bat_room 141 224 0 c r0 c
+bat_room 141 220 bat_room 154 150
+bat_b02 10 293 bat_room 154 150 0 c
+# Flavius 2 Red
+bat_room 148 121 bat_room
+bat_room  bat_room 154 150
+bat_b02 189 14 bat_room 154 150 0 c
+
+# The New World (Episode 13)
+mid_camp 213 286 moc_fild20 342 179 0 c c r0
+
+# Battlegrounds (Episode 13)
+# KVM Blue
+bat_room 164 178 bat_room 169 223 0 c r0 c
+bat_room 169 220 bat_room 154 150
+#(chatroom) bat_room 169 226 bat_c01 53 131
+bat_c01 51 130 bat_room 154 150 0 c
+# KVM Red
+bat_room 164 121 bat_room 169 207 0 c r0 c
+bat_room 169 211 bat_room 154 150
+#(chatroom) bat_room 169 205 bat_c01 147 56
+bat_c01 148 54 bat_room 154 150 0 c
+
+# iRO custom novice version of prt_fild08
+izlude 20 98 prt_fild08a 367 212
+moc_fild01 239 382 prt_fild08a 233 16
+moc_fild01 56 384 prt_fild08a 55 21
+prontera 156 22 prt_fild08a 170 378
+prt_fild07 383 239 prt_fild08a 16 239
+prt_fild07 385 186 prt_fild08a 16 187
+prt_fild08a 16 187 prt_fild07 385 186
+prt_fild08a 16 239 prt_fild07 383 239
+prt_fild08a 55 21 moc_fild01 56 384
+prt_fild08a 170 378 prontera 156 22
+prt_fild08a 233 16 moc_fild01 239 382
+prt_fild08a 371 212 izlude 24 98
+
+#################### Criatura Academy ####################
+izlude 125 257 iz_ac01 99 29
+izlude 130 257 iz_ac01 99 29
+iz_ac01 100 24 izlude 127 253
+# Eden Teleport Officer
+iz_ac01 106 36 moc_para01 31 14 0 c r0 c
+# Garden
+iz_ac01 45 80 new_1-3 95 171 0 c r0 c
+new_1-3 96 176 iz_ac01 49 73
+# Second floor
+iz_ac01 78 25 iz_ac02 104 27
+iz_ac01 122 25 iz_ac02 104 27
+iz_ac02 94 27 iz_ac01 78 28
+iz_ac02 113 27 iz_ac01 122 28
+# Free Warps (Kafra)
+iz_ac01 95 46 iz_ac01 97 86 0 c c c r2 c c c r1 r0
+iz_ac01 95 46 iz_ac02 104 179 0 c c c r2 c c c r1 r1
+iz_ac01 95 46 izlude 128 98 0 c c c r2 c c c r1 r2 c r1
+iz_ac02 101 176 iz_ac01 97 86 0 c c c r2 c c c r1 r0
+iz_ac02 101 176 izlude 128 98 0 c c c r2 c c c r1 r2 c r1
+
+alb_ship 26 166 alberta 170 170
+alb_ship 37 174 alb_ship 68 99
+alb_ship 41 163 alberta 178 165
+alb_ship 68 99 alb_ship 37 174
+alb_ship 160 171 alberta 209 173
+alb2trea 88 111 treasure01 69 22
+alberta 15 234 pay_fild03 392 63
+alberta 33 42 alberta_in 78 44
+alberta 65 233 alberta_in 14 141
+alberta 93 205 alberta_in 114 130
+alberta 98 153 alberta_in 189 89
+alberta 99 221 alberta_in 125 160
+alberta 117 38 alberta_in 180 34
+alberta 170 170 alb_ship 26 166
+alberta 178 165 alb_ship 41 163
+alberta 209 173 alb_ship 160 171
+alberta_in 14 141 alberta 65 233
+alberta_in 22 113 alberta_in 22 130
+alberta_in 22 130 alberta_in 22 113
+alberta_in 22 153 alberta_in 22 170
+alberta_in 22 170 alberta_in 22 153
+alberta_in 24 33 alberta_in 64 31
+alberta_in 24 54 alberta_in 64 57
+alberta_in 64 31 alberta_in 24 33
+alberta_in 64 57 alberta_in 24 54
+alberta_in 78 44 alberta 33 42
+alberta_in 114 49 alberta_in 159 153
+alberta_in 114 97 alberta_in 159 175
+alberta_in 114 130 alberta 93 205
+alberta_in 114 183 alberta_in 152 186
+alberta_in 125 160 alberta 99 221
+alberta_in 152 186 alberta_in 114 183
+alberta_in 159 153 alberta_in 114 49
+alberta_in 159 175 alberta_in 114 97
+alberta_in 180 34 alberta 117 38
+alberta_in 189 89 alberta 98 153
+alde_dun01 167 158 c_tower2 142 283
+alde_dun01 292 306 alde_dun02 43 20
+alde_dun01 302 25 c_tower1 123 22
+alde_dun02 43 20 alde_dun01 292 306
+alde_dun02 122 169 c_tower3 42 41
+alde_dun02 187 234 alde_dun04 32 74
+alde_dun02 279 250 alde_dun03 12 267
+alde_dun03 12 267 alde_dun02 279 250
+alde_dun03 191 31 c_tower3 212 159
+alde_dun03 276 48 c_tower1 235 226
+alde_dun03 277 183 c_tower2 24 24
+alde_dun03 264 16 alde_dun04 78 268 0 c r2 c
+alde_dun04 32 74 alde_dun02 187 239
+alde_dun04 208 58 alde_dun04 268 74
+alde_dun04 272 74 alde_dun04 208 58
+aldeba_in 24 224 aldebaran 51 218
+aldeba_in 27 34 aldebaran 72 197
+aldeba_in 27 71 aldeba_in 27 102
+aldeba_in 27 102 aldeba_in 27 71
+aldeba_in 37 238 aldeba_in 64 157
+aldeba_in 64 157 aldeba_in 37 238
+aldeba_in 83 191 aldeba_in 83 224
+aldeba_in 83 224 aldeba_in 83 191
+aldeba_in 94 38 aldebaran 197 70
+aldeba_in 97 102 aldeba_in 103 61
+aldeba_in 103 61 aldeba_in 97 102
+aldeba_in 103 157 aldeba_in 134 237
+aldeba_in 134 237 aldeba_in 103 157
+aldeba_in 144 92 aldeba_in 149 55
+aldeba_in 148 224 aldebaran 61 229
+aldeba_in 149 55 aldeba_in 144 92
+aldeba_in 149 123 aldebaran 225 54
+aldeba_in 157 193 aldebaran 233 105
+aldeba_in 208 117 aldebaran 118 63
+aldeba_in 217 71 aldeba_in 218 104
+aldeba_in 217 131 aldeba_in 217 160
+aldeba_in 217 160 aldeba_in 217 131
+aldeba_in 218 104 aldeba_in 217 71
+aldeba_in 245 237 aldebaran 89 234
+aldebaran 35 140 alde_gld 284 160
+aldebaran 51 218 aldeba_in 24 224
+aldebaran 61 229 aldeba_in 148 224
+aldebaran 72 197 aldeba_in 27 34
+aldebaran 89 234 aldeba_in 245 237
+aldebaran 118 63 aldeba_in 208 117
+aldebaran 138 34 mjolnir_12 199 378
+aldebaran 140 135 c_tower1 199 159
+aldebaran 140 243 yuno_fild01 208 18
+aldebaran 197 70 aldeba_in 94 38
+aldebaran 225 54 aldeba_in 149 123
+aldebaran 233 105 aldeba_in 157 193
+alde_gld 48 79 aldeg_cas01 34 252
+alde_gld 95 253 aldeg_cas02 88 159
+alde_gld 142 81 aldeg_cas03 114 290
+alde_gld 243 242 aldeg_cas04 145 17
+alde_gld 259 90 aldeg_cas05 216 107
+alde_gld 284 160 aldebaran 35 140
+aldeg_cas01 34 252 alde_gld 48 83
+aldeg_cas01 50 222 aldeg_cas01 104 108
+aldeg_cas01 104 112 aldeg_cas01 45 224
+aldeg_cas01 66 191 aldeg_cas01 122 61
+aldeg_cas01 126 61 aldeg_cas01 62 191
+aldeg_cas01 54 27 aldeg_cas01 62 191
+aldeg_cas01 26 188 aldeg_cas01 50 70
+aldeg_cas01 46 70 aldeg_cas01 24 188
+aldeg_cas01 70 112 aldeg_cas01 42 225
+aldeg_cas01 39 222 aldeg_cas01 70 108
+aldeg_cas01 89 23 aldeg_cas01 207 132
+aldeg_cas01 207 128 aldeg_cas01 89 27
+aldeg_cas01 206 188 aldeg_cas01 216 50
+aldeg_cas01 216 54 aldeg_cas01 206 184
+aldeg_cas01 232 186 aldeg_cas01 42 197
+aldeg_cas01 46 197 aldeg_cas01 232 182
+aldeg_cas01 171 175 aldeg_cas01 35 197
+aldeg_cas01 31 197 aldeg_cas01 175 175
+aldeg_cas02 88 159 alde_gld 95 249
+aldeg_cas02 84 208 aldeg_cas02 105 84
+aldeg_cas02 105 88 aldeg_cas02 79 208
+aldeg_cas02 45 39 aldeg_cas02 79 208
+aldeg_cas02 50 185 aldeg_cas02 192 192
+aldeg_cas02 192 196 aldeg_cas02 50 180
+aldeg_cas02 33 174 aldeg_cas02 126 61
+aldeg_cas02 130 61 aldeg_cas02 33 179
+aldeg_cas02 22 194 aldeg_cas02 88 13
+aldeg_cas02 88 9 aldeg_cas02 22 190
+aldeg_cas02 121 88 aldeg_cas02 177 135
+aldeg_cas02 177 131 aldeg_cas02 121 84
+aldeg_cas02 206 196 aldeg_cas02 197 13
+aldeg_cas02 197 9 aldeg_cas02 206 192
+aldeg_cas03 114 290 alde_gld 142 85
+aldeg_cas03 92 217 aldeg_cas03 127 90
+aldeg_cas03 130 90 aldeg_cas03 96 215
+aldeg_cas03 87 247 aldeg_cas03 54 90
+aldeg_cas03 51 90 aldeg_cas03 87 251
+aldeg_cas03 93 124 aldeg_cas03 87 251
+aldeg_cas03 44 222 aldeg_cas03 213 182
+aldeg_cas03 214 186 aldeg_cas03 49 222
+aldeg_cas03 91 57 aldeg_cas03 60 236
+aldeg_cas03 60 241 aldeg_cas03 91 61
+aldeg_cas03 79 130 aldeg_cas03 201 149
+aldeg_cas03 201 145 aldeg_cas03 79 126
+aldeg_cas03 199 190 aldeg_cas03 195 51
+aldeg_cas03 195 54 aldeg_cas03 199 186
+aldeg_cas04 145 17 alde_gld 239 242
+aldeg_cas04 197 40 aldeg_cas04 26 88
+aldeg_cas04 22 88 aldeg_cas04 192 41
+aldeg_cas04 175 54 aldeg_cas04 74 88
+aldeg_cas04 50 132 aldeg_cas04 74 88
+aldeg_cas04 78 88 aldeg_cas04 174 58
+aldeg_cas04 185 87 aldeg_cas04 111 210
+aldeg_cas04 108 210 aldeg_cas04 186 92
+aldeg_cas04 171 100 aldeg_cas04 152 210
+aldeg_cas04 156 210 aldeg_cas04 169 97
+aldeg_cas04 196 86 aldeg_cas04 49 57
+aldeg_cas04 49 53 aldeg_cas04 196 82
+aldeg_cas04 21 123 aldeg_cas04 125 168
+aldeg_cas04 121 168 aldeg_cas04 25 123
+aldeg_cas04 132 209 aldeg_cas04 14 196
+aldeg_cas04 17 196 aldeg_cas04 132 228
+aldeg_cas05 216 107 alde_gld 264 90
+aldeg_cas05 194 71 aldeg_cas05 129 194
+aldeg_cas05 125 194 aldeg_cas05 199 70
+aldeg_cas05 164 86 aldeg_cas05 66 189
+aldeg_cas05 70 189 aldeg_cas05 166 81
+aldeg_cas05 150 67 aldeg_cas05 9 187
+aldeg_cas05 5 187 aldeg_cas05 151 62
+aldeg_cas05 165 232 aldeg_cas05 193 49
+aldeg_cas05 188 49 aldeg_cas05 165 288
+aldeg_cas05 195 42 aldeg_cas05 19 227
+aldeg_cas05 15 227 aldeg_cas05 195 46
+aldeg_cas05 13 175 aldeg_cas05 162 194
+aldeg_cas05 166 194 aldeg_cas05 13 179
+aldeg_cas05 156 231 aldeg_cas05 18 88
+aldeg_cas05 14 88 aldeg_cas05 156 227
+ama_dun01 235 144 ama_dun02 30 40
+ama_dun02 30 40 ama_dun01 235 144
+ama_dun02 196 123 ama_dun03 120 9
+ama_dun03 120 9 ama_dun02 196 123
+ama_in01 31 176 amatsu 177 138
+ama_in01 33 24 amatsu 94 117
+ama_in01 34 96 amatsu 168 182
+ama_in01 76 178 amatsu 248 160
+ama_in01 86 23 amatsu 132 117
+ama_in01 88 94 amatsu 52 148
+ama_in01 157 25 amatsu 217 116
+ama_in01 162 34 ama_in01 166 73
+ama_in01 166 73 ama_in01 162 34
+ama_in01 174 121 ama_fild01 330 141
+ama_in01 175 171 ama_fild01 174 331
+ama_in02 56 44 ama_in02 59 141
+ama_in02 59 141 ama_in02 56 44
+ama_in02 59 160 ama_in02 215 149
+ama_in02 65 37 ama_in02 195 44
+ama_in02 126 164 ama_in02 222 161
+ama_in02 195 44 ama_in02 65 37
+ama_in02 215 149 ama_in02 59 160
+ama_in02 222 161 ama_in02 126 164
+ama_in02 226 45 amatsu 85 235
+ama_fild01 75 30 amatsu 248 292
+ama_fild01 174 331 ama_in01 175 171
+ama_fild01 330 141 ama_in01 174 121
+amatsu 52 148 ama_in01 88 94
+amatsu 85 235 ama_in02 226 45
+amatsu 94 117 ama_in01 33 24
+amatsu 132 117 ama_in01 86 23
+amatsu 168 182 ama_in01 34 96
+amatsu 177 138 ama_in01 31 176
+amatsu 217 116 ama_in01 157 25
+amatsu 248 160 ama_in01 76 178
+amatsu 248 292 ama_fild01 75 30
+anthell01 253 32 anthell02 32 267
+anthell02 32 267 anthell01 253 32
+ayothaya 62 104 ayo_in01 191 183
+ayothaya 111 109 ayo_in01 180 129
+ayothaya 129 86 ayo_in01 21 178
+ayothaya 130 75 ayo_in01 17 153
+ayothaya 130 97 ayo_in01 177 129
+ayothaya 165 90 ayo_in01 77 174
+ayothaya 173 77 ayo_in01 85 149
+ayothaya 177 90 ayo_in01 95 175
+ayothaya 192 150 ayo_in01 10 94
+ayothaya 202 140 ayo_in01 31 78
+ayothaya 202 161 ayo_in01 31 108
+ayothaya 208 283 ayo_in02 100 152
+ayothaya 211 150 ayo_in01 50 94
+ayothaya 229 69 ayo_in01 137 192
+ayothaya 276 176 ayo_fild01 32 240
+ayo_in01 10 94 ayothaya 189 150
+ayo_in01 13 82 ayo_in01 18 14
+ayo_in01 13 107 ayo_in01 132 27
+ayo_in01 17 153 ayothaya 132 73
+ayo_in01 21 14 ayo_in01 13 82
+ayo_in01 23 176 ayothaya 129 86
+ayo_in01 31 78 ayothaya 202 137
+ayo_in01 31 111 ayothaya 202 161
+ayo_in01 46 183 ayothaya 130 97
+ayo_in01 48 82 ayo_in01 63 14
+ayo_in01 48 107 ayo_in01 179 27
+ayo_in01 50 94 ayothaya 214 150
+ayo_in01 60 14 ayo_in01 48 82
+ayo_in01 73 174 ayo_in01 184 194
+ayo_in01 85 149 ayothaya 173 74
+ayo_in01 98 175 ayothaya 177 90
+ayo_in01 135 27 ayo_in01 13 107
+ayo_in01 137 195 ayothaya 229 69
+ayo_in01 176 27 ayo_in01 48 107
+ayo_in01 177 129 ayothaya 111 109
+ayo_in01 194 183 ayothaya 62 104
+ayo_in02 100 148 ayothaya 208 283
+ayo_fild01 32 240 ayothaya 273 176
+ayo_fild01 129 197 ayo_fild02 100 100 0 c c c c c r0 c c c
+ayo_fild01 129 197 ayo_fild02 30 135 c w1 c w1 c1 w1 c1 w1 c1 r0 c w1 c w1 c n
+ayo_fild02 285 149 ayo_dun01 275 18
+ayo_fild02 25 154 ayo_fild01 115 200 c r0 c n
+ayo_dun01 274 14 ayo_fild02 279 150
+ayo_dun01 24 283 ayo_dun02 23 26 c n
+ayo_dun02 24 22 ayo_dun01 24 279
+beach_dun 276 67 comodo 24 214
+beach_dun2 154 13 comodo 176 358
+beach_dun2 258 244 um_fild01 31 274
+beach_dun3 17 265 comodo 333 175
+beach_dun3 286 57 cmd_fild01 26 318
+c_tower1 123 22 alde_dun01 302 25
+c_tower1 200 157 aldebaran 139 135
+c_tower1 235 226 c_tower2 273 26
+c_tower2 24 24 alde_dun03 277 183
+c_tower2 142 283 c_tower3 60 147
+c_tower2 273 26 c_tower1 235 226
+c_tower3 42 41 alde_dun02 122 169
+c_tower3 60 147 c_tower2 142 283
+c_tower3 212 159 alde_dun03 276 48
+cmd_fild01 26 318 beach_dun3 286 57
+cmd_fild01 222 24 cmd_fild02 222 376
+cmd_fild01 362 73 cmd_fild03 23 68
+cmd_fild01 362 263 cmd_fild03 23 269
+cmd_fild01 77 366 um_fild03 114 50
+cmd_fild01 178 370 um_fild03 243 26
+cmd_fild02 222 376 cmd_fild01 222 24
+cmd_fild02 358 95 cmd_fild04 31 92
+cmd_fild02 382 269 cmd_fild04 21 275
+cmd_fild03 23 68 cmd_fild01 362 73
+cmd_fild03 23 269 cmd_fild01 362 263
+cmd_fild03 181 17 cmd_fild04 180 372
+cmd_fild03 384 165 cmd_fild05 21 163
+cmd_fild04 21 275 cmd_fild02 382 269
+cmd_fild04 31 92 cmd_fild02 358 95
+cmd_fild04 180 372 cmd_fild03 181 17
+cmd_fild04 376 287 cmd_fild06 21 285
+cmd_fild05 21 163 cmd_fild03 384 165
+cmd_fild05 148 19 cmd_fild06 150 380
+cmd_fild06 21 285 cmd_fild04 376 287
+cmd_fild06 150 380 cmd_fild05 148 19
+cmd_fild06 151 27 cmd_fild07 149 379
+cmd_fild06 368 96 cmd_fild08 15 102
+cmd_fild06 372 359 cmd_fild08 25 355
+cmd_fild06 379 174 cmd_fild08 25 170
+cmd_fild07 149 379 cmd_fild06 151 27
+cmd_fild07 389 186 cmd_fild09 12 170
+cmd_fild08 15 102 cmd_fild06 368 96
+cmd_fild08 25 170 cmd_fild06 379 174
+cmd_fild08 25 355 cmd_fild06 372 359
+cmd_fild08 76 31 cmd_fild09 75 382
+cmd_fild08 309 48 cmd_fild09 309 381
+cmd_fild08 354 324 moc_fild12 26 305
+cmd_fild09 12 170 cmd_fild07 389 186
+cmd_fild09 75 382 cmd_fild08 76 31
+cmd_fild09 309 381 cmd_fild08 309 48
+cmd_fild09 369 164 moc_fild18 51 170
+cmd_in01 90 174 comodo 92 128
+cmd_in01 109 125 comodo 271 271
+cmd_in01 120 67 comodo 145 328
+cmd_in01 123 186 comodo 265 74
+cmd_in01 183 81 comodo 236 298
+cmd_in01 183 123 comodo 192 294
+cmd_in02 58 74 cmd_in02 168 113
+cmd_in02 69 129 comodo 115 291
+cmd_in02 74 21 comodo 140 90
+cmd_in02 90 37 cmd_in02 187 78
+cmd_in02 98 216 cmd_in02 208 206
+cmd_in02 139 97 comodo 126 98
+cmd_in02 139 169 comodo 130 195
+cmd_in02 168 113 cmd_in02 58 74
+cmd_in02 178 136 comodo 140 111
+cmd_in02 187 78 cmd_in02 90 37
+cmd_in02 208 206 cmd_in02 98 216
+cmd_in02 216 97 comodo 153 97
+comodo 24 214 beach_dun 276 67
+comodo 92 128 cmd_in01 90 174
+comodo 115 291 cmd_in02 69 129
+comodo 126 98 cmd_in02 139 97
+comodo 130 195 cmd_in02 139 169
+comodo 140 90 cmd_in02 74 21
+comodo 140 111 cmd_in02 178 136
+comodo 145 328 cmd_in01 120 67
+comodo 153 97 cmd_in02 216 97
+comodo 176 358 beach_dun2 154 13
+comodo 192 294 cmd_in01 183 123
+comodo 236 298 cmd_in01 183 81
+comodo 265 74 cmd_in01 123 186
+comodo 271 271 cmd_in01 109 125
+comodo 333 175 beach_dun3 17 265
+einbroch 150 25 ein_fild08 164 377
+einbroch 157 331 ein_fild04 184 31
+einbroch 232 272 einbech 43 215 200 c c r0 n
+einbech 39 215 einbroch 226 276 200 c r0 n
+einbech 145 112 ein_in01 268 104
+einbech 177 136 ein_in01 190 35
+einbech 138 252 ein_dun01 22 14
+einbech 62 29 ein_fild09 74 350
+ein_in01 288 89 einbech 157 106
+ein_in01 190 38 einbech 172 134
+ein_dun01 261 255 ein_dun02 291 292
+ein_dun01 22 11 einbech 138 249
+ein_dun02 286 292 ein_dun01 261 258
+ein_fild04 184 26 einbroch 157 327
+ein_fild06 355 95 yuno_fild07 66 79
+ein_fild06 135 36 ein_fild07 147 359
+ein_fild06 251 365 yuno_fild04 249 25
+ein_fild06 335 176 yuno_fild07 76 220
+ein_fild07 144 362 ein_fild06 135 39
+ein_fild07 183 43 ein_fild10 196 368
+ein_fild08 164 380 einbroch 150 28
+ein_fild08 361 129 ein_fild09 37 135
+ein_fild09 71 352 einbech 62 32
+ein_fild09 34 135 ein_fild08 358 130
+ein_fild09 328 344 ein_fild10 28 330
+ein_fild10 25 330 ein_fild09 325 344
+ein_fild10 196 371 ein_fild07 179 46
+gef_dun00 104 103 gef_tower 153 28
+gef_dun00 107 168 gef_dun01 115 240
+gef_dun01 115 240 gef_dun00 107 169
+gef_dun01 197 38 gef_dun02 106 134
+gef_dun02 106 134 gef_dun01 197 38
+gef_fild00 40 199 geffen 217 119
+gef_fild00 267 382 mjolnir_06 265 29
+gef_fild00 381 137 prt_fild00 18 129
+gef_fild01 16 102 gef_fild09 368 95
+gef_fild01 69 17 gef_fild03 66 382
+gef_fild01 382 111 prt_fild04 17 114
+gef_fild02 14 78 gef_fild03 382 77
+gef_fild02 16 275 gef_fild03 382 277
+gef_fild02 266 18 prt_fild10 227 299
+gef_fild02 380 68 prt_fild07 13 64
+gef_fild02 380 156 prt_fild07 17 145
+gef_fild02 380 289 prt_fild07 14 289
+gef_fild03 18 52 gef_fild10 370 56
+gef_fild03 66 382 gef_fild01 69 17
+gef_fild03 312 16 prt_fild11 302 301
+gef_fild03 382 77 gef_fild02 14 78
+gef_fild03 382 277 gef_fild02 16 275
+gef_fild04 16 309 gef_fild05 364 309
+gef_fild04 187 39 geffen 119 213
+gef_fild04 261 362 mjolnir_01 284 18
+gef_fild04 362 322 mjolnir_06 18 331
+gef_fild05 15 201 gef_fild06 382 211
+gef_fild05 64 15 gef_fild07 64 363
+gef_fild05 364 309 gef_fild04 16 309
+gef_fild06 18 304 glast_01 380 304
+gef_fild06 218 17 gef_fild08 200 355
+gef_fild06 382 211 gef_fild05 15 201
+gef_fild07 18 191 gef_fild08 360 187
+gef_fild07 40 19 gef_fild13 41 373
+gef_fild07 64 363 gef_fild05 64 15
+gef_fild07 339 187 geffen 26 119
+gef_fild08 200 355 gef_fild06 218 17
+gef_fild08 215 18 gef_fild12 221 374
+gef_fild08 360 187 gef_fild07 18 191
+gef_fild09 23 56 gef_fild13 380 56
+gef_fild09 225 25 gef_fild10 251 371
+gef_fild09 368 95 gef_fild01 16 102
+gef_fild10 27 219 gef_fild14 371 219
+gef_fild10 63 337 in_orcs01 30 154
+gef_fild10 104 21 gef_fild11 111 364
+gef_fild10 136 331 in_orcs01 124 171
+gef_fild10 138 284 in_orcs01 29 116
+gef_fild10 215 51 in_orcs01 162 55
+gef_fild10 223 205 in_orcs01 108 86
+gef_fild10 251 371 gef_fild09 225 25
+gef_fild10 370 56 gef_fild03 18 52
+gef_fild11 111 364 gef_fild10 104 21
+gef_fild11 377 293 prt_fild11 17 281
+gef_fild12 221 374 gef_fild08 215 18
+gef_fild12 368 180 gef_fild13 25 202
+gef_fild12 373 50 gef_fild13 25 59
+gef_fild13 25 59 gef_fild12 373 50
+gef_fild13 25 202 gef_fild12 368 180
+gef_fild13 41 373 gef_fild07 40 19
+gef_fild13 77 284 gefg_cas03 68 290
+gef_fild13 83 185 gefg_cas03 93 159
+gef_fild13 112 269 gefg_cas03 103 283
+gef_fild13 139 240 gefg_cas03 130 250
+gef_fild13 150 54 gefg_cas01 34 136
+gef_fild13 196 281 gefg_cas04 24 145
+gef_fild13 200 25 gef_fild14 180 360
+gef_fild13 210 75 gefg_cas01 99 178
+gef_fild13 256 57 gefg_cas05 7 134
+gef_fild13 305 83 gefg_cas05 99 204
+gef_fild13 308 244 gefg_cas02 70 147
+gef_fild13 380 56 gef_fild09 23 56
+gef_fild14 180 360 gef_fild13 200 25
+gef_fild14 371 219 gef_fild10 27 219
+gef_tower 38 160 gef_tower 42 86
+gef_tower 42 86 gef_tower 38 160
+gef_tower 42 86 gef_tower 66 156
+gef_tower 44 36 gef_tower 106 158
+gef_tower 52 135 gef_tower 158 174
+gef_tower 52 181 geffen 120 114
+gef_tower 60 34 gef_tower 62 87
+gef_tower 62 87 gef_tower 60 34
+gef_tower 66 156 gef_tower 42 86
+gef_tower 106 69 gef_tower 106 115
+gef_tower 106 115 gef_tower 106 69
+gef_tower 106 158 gef_tower 44 36
+gef_tower 116 31 gef_tower 118 68
+gef_tower 118 68 gef_tower 116 31
+gef_tower 118 114 gef_tower 120 158
+gef_tower 120 158 gef_tower 118 114
+gef_tower 153 28 gef_dun00 104 103
+gef_tower 156 93 gef_tower 158 104
+gef_tower 158 104 gef_tower 156 93
+gef_tower 158 128 gef_tower 158 150
+gef_tower 158 150 gef_tower 158 128
+gef_tower 158 174 gef_tower 52 135
+geffen 26 119 gef_fild07 339 187
+geffen 43 85 geffen_in 70 132
+geffen 61 180 geffen_in 163 94
+geffen 98 141 geffen_in 28 156
+geffen 119 213 gef_fild04 187 39
+geffen 120 114 gef_tower 52 181
+geffen 138 138 geffen_in 28 106
+geffen 172 174 geffen_in 70 48
+geffen 182 59 geffen_in 106 181
+geffen 217 119 gef_fild00 40 199
+geffen_in 26 37 geffen_in 26 60
+geffen_in 26 60 geffen_in 26 37
+geffen_in 28 106 geffen 138 138
+geffen_in 28 156 geffen 98 141
+geffen_in 41 67 geffen_in 52 65
+geffen_in 52 65 geffen_in 41 67
+geffen_in 70 48 geffen 172 174
+geffen_in 70 83 geffen_in 72 98
+geffen_in 70 132 geffen 43 85
+geffen_in 70 149 geffen_in 70 158
+geffen_in 70 158 geffen_in 70 149
+geffen_in 72 98 geffen_in 70 83
+geffen_in 79 107 geffen_in 104 109
+geffen_in 87 65 geffen_in 100 67
+geffen_in 100 67 geffen_in 87 65
+geffen_in 104 109 geffen_in 79 107
+geffen_in 106 181 geffen 182 59
+geffen_in 113 163 geffen_in 136 169
+geffen_in 114 37 geffen_in 114 60
+geffen_in 114 60 geffen_in 114 37
+geffen_in 136 169 geffen_in 113 163
+geffen_in 138 149 geffen_in 138 162
+geffen_in 138 162 geffen_in 138 149
+geffen_in 163 94 geffen 61 180
+gefg_cas01 170 14 gefg_cas01 50 84
+gefg_cas01 170 34 gefg_cas01 30 167
+gefg_cas01 181 52 gefg_cas01 198 160
+gefg_cas01 202 160 gefg_cas01 185 52
+gefg_cas01 209 34 gefg_cas01 56 170
+gefg_cas01 31 185 gefg_cas01 33 47
+gefg_cas01 33 51 gefg_cas01 35 185
+gefg_cas01 34 136 gef_fild13 150 50
+gefg_cas01 34 167 gefg_cas01 174 34
+gefg_cas01 39 196 gefg_cas01 62 13
+gefg_cas01 54 84 gefg_cas01 174 14
+gefg_cas01 58 185 gefg_cas01 90 47
+gefg_cas01 59 170 gefg_cas01 205 34
+gefg_cas01 62 9 gefg_cas01 39 192
+gefg_cas01 90 51 gefg_cas01 54 185
+gefg_cas01 99 178 gef_fild13 214 75
+gefg_cas02 148 18 gefg_cas02 35 150
+gefg_cas02 150 36 gefg_cas02 152 186
+gefg_cas02 152 190 gefg_cas02 150 41
+gefg_cas02 174 11 gefg_cas02 21 13
+gefg_cas02 184 36 gefg_cas02 48 155
+gefg_cas02 185 18 gefg_cas02 53 136
+gefg_cas02 22 160 gefg_cas02 34 17
+gefg_cas02 25 13 gefg_cas02 170 11
+gefg_cas02 34 13 gefg_cas02 22 156
+gefg_cas02 34 152 gefg_cas02 153 18
+gefg_cas02 34 68 gefg_cas02 50 175
+gefg_cas02 35 173 gefg_cas02 76 42
+gefg_cas02 46 175 gefg_cas02 34 64
+gefg_cas02 48 159 gefg_cas02 184 41
+gefg_cas02 57 136 gefg_cas02 180 18
+gefg_cas02 70 147 gef_fild13 308 240
+gefg_cas02 80 42 gefg_cas02 39 173
+gefg_cas03 103 283 gef_fild13 117 273
+gefg_cas03 106 217 gefg_cas03 131 15
+gefg_cas03 115 210 gefg_cas03 92 215
+gefg_cas03 130 250 gef_fild13 143 240
+gefg_cas03 135 15 gefg_cas03 110 217
+gefg_cas03 135 92 gefg_cas03 34 282
+gefg_cas03 152 92 gefg_cas03 59 255
+gefg_cas03 154 16 gefg_cas03 252 11
+gefg_cas03 17 206 gefg_cas03 29 219
+gefg_cas03 212 46 gefg_cas03 225 158
+gefg_cas03 225 154 gefg_cas03 212 42
+gefg_cas03 237 74 gefg_cas03 62 213
+gefg_cas03 256 11 gefg_cas03 159 16
+gefg_cas03 266 47 gefg_cas03 45 175
+gefg_cas03 27 215 gefg_cas03 17 202
+gefg_cas03 34 286 gefg_cas03 131 92
+gefg_cas03 38 243 gefg_cas03 29 219
+gefg_cas03 38 259 gefg_cas03 43 271
+gefg_cas03 42 175 gefg_cas03 266 43
+gefg_cas03 43 191 gefg_cas03 70 185
+gefg_cas03 47 271 gefg_cas03 38 255
+gefg_cas03 50 248 gefg_cas03 54 229
+gefg_cas03 58 232 gefg_cas03 62 213
+gefg_cas03 63 255 gefg_cas03 156 92
+gefg_cas03 65 215 gefg_cas03 233 74
+gefg_cas03 66 223 gefg_cas03 96 53
+gefg_cas03 68 290 gef_fild13 74 287
+gefg_cas03 70 182 gefg_cas03 39 191
+gefg_cas03 79 244 gefg_cas03 91 250
+gefg_cas03 88 248 gefg_cas03 76 242
+gefg_cas03 90 218 gefg_cas03 111 210
+gefg_cas03 92 53 gefg_cas03 62 223
+gefg_cas03 93 159 gef_fild13 83 181
+gefg_cas03 93 209 gefg_cas03 92 250
+gefg_cas03 95 251 gefg_cas03 91 209
+gefg_cas04 140 168 gefg_cas04 178 61
+gefg_cas04 142 33 gefg_cas04 52 21
+gefg_cas04 142 55 gefg_cas04 32 180
+gefg_cas04 174 36 gefg_cas04 53 192
+gefg_cas04 178 57 gefg_cas04 143 166
+gefg_cas04 18 82 gefg_cas04 34 215
+gefg_cas04 18 9 gefg_cas04 57 220
+gefg_cas04 24 145 gef_fild13 193 278
+gefg_cas04 27 180 gefg_cas04 142 59
+gefg_cas04 34 211 gefg_cas04 18 78
+gefg_cas04 42 81 gefg_cas04 42 13
+gefg_cas04 42 9 gefg_cas04 42 77
+gefg_cas04 52 25 gefg_cas04 142 37
+gefg_cas04 53 196 gefg_cas04 170 36
+gefg_cas04 57 224 gefg_cas04 18 13
+gefg_cas05 149 44 gefg_cas05 37 20
+gefg_cas05 178 72 gefg_cas05 46 165
+gefg_cas05 190 20 gefg_cas05 194 151
+gefg_cas05 194 147 gefg_cas05 190 16
+gefg_cas05 206 44 gefg_cas05 93 20
+gefg_cas05 37 16 gefg_cas05 153 44
+gefg_cas05 43 62 gefg_cas05 78 138
+gefg_cas05 44 143 gefg_cas05 70 155
+gefg_cas05 50 165 gefg_cas05 178 68
+gefg_cas05 66 76 gefg_cas05 80 155
+gefg_cas05 68 150 gefg_cas05 44 147
+gefg_cas05 7 134 gef_fild13 252 57
+gefg_cas05 74 138 gefg_cas05 47 62
+gefg_cas05 83 152 gefg_cas05 66 72
+gefg_cas05 87 165 gefg_cas05 84 62
+gefg_cas05 88 62 gefg_cas05 83 165
+gefg_cas05 93 16 gefg_cas05 202 44
+gefg_cas05 99 204 gef_fild13 305 87
+gl_cas01 185 236 gl_cas01 167 191
+gl_cas01 200 18 glast_01 200 297
+gl_cas01 200 165 gl_cas02 104 15
+gl_cas01 215 236 gl_cas01 234 192
+gl_cas01 149 314 gl_prison 11 70
+gl_cas01 167 191 gl_prison 11 70
+gl_cas01 234 192 gl_prison 11 70
+gl_cas01 371 301 gl_prison 11 70
+gl_cas01 215 236 gl_cas01 135 40
+gl_cas02 104 15 gl_cas01 200 165
+gl_cas02 104 193 glast_01 199 322
+gl_cas02 104 193 glast_01 199 325
+gl_church 16 299 gl_chyard 147 287
+gl_church 156 4 glast_01 200 137
+gl_church 301 46 gl_chyard 147 12
+gl_chyard 12 149 gl_sew02 30 273
+gl_chyard 147 12 gl_church 301 46
+gl_chyard 147 287 gl_church 16 299
+gl_dun01 133 277 gl_sew04 104 78
+gl_dun01 225 18 gl_dun02 224 277
+gl_dun02 224 277 gl_dun01 225 18
+gl_in01 81 68 glast_01 162 330
+gl_in01 83 174 glast_01 179 360
+gl_in01 106 125 glast_01 220 360
+gl_in01 118 59 glast_01 237 330
+gl_knt01 12 148 gl_knt02 10 138
+gl_knt01 104 204 gl_knt01 123 292
+gl_knt01 128 292 gl_knt01 104 199
+gl_knt01 150 6 glast_01 77 193
+gl_knt01 150 291 gl_knt02 157 292
+gl_knt01 231 197 gl_sew02 296 18
+gl_knt01 287 144 gl_knt02 289 138
+gl_knt02 10 138 gl_knt01 12 148
+gl_knt02 157 292 gl_knt01 150 291
+gl_knt02 289 138 gl_knt01 287 144
+gl_prison 11 70 gl_cas01 234 192
+gl_prison 149 183 gl_prison1 150 10
+gl_prison1 62 187 gl_sew01 258 258
+gl_prison1 150 10 gl_prison 149 183
+gl_sew01 19 21 gl_sew02 109 294
+gl_sew01 258 258 gl_prison1 62 187
+gl_sew02 30 273 gl_chyard 12 149
+gl_sew02 109 294 gl_sew01 19 21
+gl_sew02 290 156 gl_step 120 124
+gl_sew02 296 18 gl_knt01 231 197
+gl_sew02 299 294 gl_sew03 171 286
+gl_sew03 64 10 gl_sew04 68 280
+gl_sew03 171 286 gl_sew02 299 294
+gl_sew04 68 280 gl_sew03 64 10
+gl_sew04 104 78 gl_dun01 133 277
+gl_step 8 7 glast_01 51 108
+gl_step 120 124 gl_sew02 290 156
+glast_01 51 108 gl_step 8 7
+glast_01 77 193 gl_knt01 150 6
+glast_01 162 330 gl_in01 81 68
+glast_01 179 360 gl_in01 83 174
+glast_01 200 137 gl_church 156 4
+glast_01 200 297 gl_cas01 200 18
+glast_01 199 322 gl_cas02 104 189
+glast_01 220 360 gl_in01 106 125
+glast_01 237 330 gl_in01 118 59
+glast_01 380 304 gef_fild06 18 304
+gon_dun01 153 45 gonryun 159 201
+gon_dun01 162 273 gon_dun02 14 113
+gon_dun02 14 113 gon_dun01 162 273
+gon_dun02 44 166 gon_dun02 94 118
+gon_dun02 44 213 gon_dun02 56 119
+gon_dun02 56 119 gon_dun02 44 213
+gon_dun02 63 66 gon_dun02 199 94
+gon_dun02 76 100 gon_dun02 145 66
+gon_dun02 92 190 gon_dun02 196 20
+gon_dun02 94 118 gon_dun02 180 189
+gon_dun02 145 66 gon_dun02 196 20
+gon_dun02 148 236 gon_dun02 234 191
+gon_dun02 165 189 gon_dun02 235 138
+gon_dun02 168 92 gon_dun02 276 76
+gon_dun02 171 258 gon_dun02 76 100
+gon_dun02 180 189 gon_dun02 94 118
+gon_dun02 196 20 gon_dun02 92 190
+gon_dun02 199 94 gon_dun02 63 66
+gon_dun02 234 191 gon_dun02 148 236
+gon_dun02 235 138 gon_dun02 165 189
+gon_dun02 251 268 gon_dun03 68 6
+gon_dun02 276 76 gon_dun02 168 92
+gon_dun03 68 6 gon_dun02 251 268
+gon_in 31 97 gon_in 42 35
+gon_in 42 35 gon_in 31 97
+gon_in 47 24 gonryun 109 131
+gon_in 72 67 gonryun 107 184
+gon_in 95 26 gonryun 195 93
+gon_in 109 98 gonryun 221 162
+gon_in 149 24 gonryun 215 114
+gon_in 184 11 gon_in 186 85
+gon_in 184 36 gon_in 186 107
+gon_in 186 85 gon_in 184 11
+gon_in 186 107 gon_in 184 36
+gon_fild01 192 265 gonryun 161 8
+gonryun 107 184 gon_in 72 67
+gonryun 109 131 gon_in 47 24
+gonryun 159 201 gon_dun01 153 45
+gonryun 161 8 gon_fild01 192 265
+gonryun 195 93 gon_in 95 26
+gonryun 215 114 gon_in 149 24
+gonryun 221 162 gon_in 109 98
+hu_fild04 122 27 yuno_fild02 117 375
+in_moc_16 18 8 moc_fild16 205 296
+in_orcs01 29 116 gef_fild10 138 284
+in_orcs01 30 154 gef_fild10 63 337
+in_orcs01 30 182 orcsdun01 32 172
+in_orcs01 108 86 gef_fild10 223 205
+in_orcs01 108 114 orcsdun02 180 15
+in_orcs01 124 171 gef_fild10 136 331
+in_orcs01 162 55 gef_fild10 215 51
+in_sphinx1 80 191 in_sphinx2 149 77
+in_sphinx1 288 6 moc_fild19 98 99
+in_sphinx2 149 77 in_sphinx1 80 191
+in_sphinx2 276 272 in_sphinx3 210 57
+in_sphinx3 12 69 in_sphinx4 10 224
+in_sphinx3 35 227 in_sphinx3 60 227
+in_sphinx3 60 227 in_sphinx3 35 227
+in_sphinx3 70 83 in_sphinx3 70 111
+in_sphinx3 70 111 in_sphinx3 70 83
+in_sphinx3 210 57 in_sphinx2 276 272
+in_sphinx4 10 224 in_sphinx3 12 69
+in_sphinx4 120 113 in_sphinx5 100 96
+in_sphinx5 100 96 in_sphinx4 120 113
+iz_dun00 39 41 iz_dun01 41 32
+iz_dun00 168 173 izlu2dun 108 83
+iz_dun00 352 342 iz_dun01 253 258
+iz_dun01 41 32 iz_dun00 39 41
+iz_dun01 118 170 iz_dun02 236 198
+iz_dun01 253 258 iz_dun00 352 342
+iz_dun02 236 198 iz_dun01 118 170
+iz_dun02 339 331 iz_dun03 29 63
+iz_dun03 29 63 iz_dun02 339 331
+iz_dun03 264 245 iz_dun04 26 24
+iz_dun04 26 24 iz_dun03 264 245
+izlu2dun 108 83 iz_dun00 168 173
+izlude 30 78 prt_fild08 371 212
+izlude 52 140 izlude_in 74 158
+izlude 109 151 izlude_in 65 84
+izlude 148 148 izlude_in 116 46
+izlude 216 129 izlude_in 148 127
+izlude_in 65 84 izlude 109 151
+izlude_in 74 158 izlude 52 140
+izlude_in 87 169 izlude_in 108 169
+izlude_in 108 169 izlude_in 87 169
+izlude_in 116 46 izlude 148 148
+izlude_in 148 127 izlude 216 129
+izlude_in 171 97 izlude_in 172 116
+izlude_in 172 116 izlude_in 171 97
+izlude_in 172 139 izlude_in 172 158
+izlude_in 172 158 izlude_in 172 139
+juperos_01 51 249 jupe_cave 29 52
+jupe_cave 147 52 yuno_fild07 202 175
+jupe_cave 29 52 juperos_01 54 246
+lhz_cube 231 12 lighthalzen 310 302
+lhz_cube 231 96 lhz_dun02 220 6
+lhz_dun01 149 9 lhz_dun02 153 19
+lhz_dun01 18 145 lhz_dun02 17 150
+lhz_dun01 281 150 lhz_dun02 282 153
+lhz_dun01 149 291 lhz_in01 33 224
+lhz_dun02 224 6 lhz_cube 231 90
+lhz_dun02 149 149 lhz_dun03 140 133
+lhz_dun03 139 137 lhz_dun02 149 142
+lhz_dun02 283 153 lhz_dun01 281 154
+lhz_dun02 17 153 lhz_dun01 18 150
+lhz_dun02 146 19 lhz_dun02 17 156
+lhz_dun02 17 156 lhz_dun02 159 33
+lhz_dun02 146 19 lhz_dun01 144 9
+lhz_dun02 17 156 lhz_dun01 18 150
+lhz_dun02 282 161 lhz_dun01 281 154
+lhz_in01 88 215 lhz_in01 106 18
+lhz_in01 106 15 lhz_in01 88 211
+lhz_in01 251 226 lhz_in01 225 226
+lhz_in01 231 227 lhz_in01 257 226
+lhz_in01 188 253 lhz_in01 191 52
+lhz_in01 194 55 lhz_in01 188 250
+lhz_in01 76 254 lhz_in01 100 52
+lhz_in01 98 55 lhz_in01 76 250
+lhz_in01 149 55 lhz_in01 188 250
+lhz_in01 158 15 lhz_in01 140 211
+lhz_in01 140 215 lhz_in01 158 18
+lhz_in02 21 191 lighthalzen 202 160
+lhz_in02 39 204 lhz_in02 41 136
+lhz_in02 36 136 lhz_in02 34 204
+lhz_in02 13 155 lhz_in02 84 223
+lhz_in02 79 223 lhz_in02 17 155
+lhz_in02 94 212 lhz_in02 94 144
+lhz_in02 89 144 lhz_in02 89 212
+lhz_in02 103 155 lhz_in02 44 154
+lhz_in02 49 154 lhz_in02 98 155
+lighthalzen 267 200 lighthalzen 303 229 0 c n
+lighthalzen 294 223 lighthalzen 260 199 0 c n
+lighthalzen 313 301 lhz_cube 231 12 0 c c r0 n
+lighthalzen 198 163 lhz_in02 21 195
+louyang 218 19 lou_fild01 233 356
+louyang 130 63 lou_in02 72 31
+louyang 37 271 lou_dun01 218 195
+louyang 136 97 lou_in02 247 171
+louyang 145 174 lou_in02 126 168
+louyang 125 121 lou_in02 198 161
+louyang 218 255 lou_in01 101 122
+lou_fild01 233 356 louyang 218 22
+lou_in01 101 119 louyang 218 255
+lou_in02 72 28 louyang 130 63
+lou_in02 249 173 louyang 136 97
+lou_in02 126 165 louyang 145 174
+lou_in02 198 159 louyang 124 118
+lou_in02 203 159 louyang 129 118
+lou_dun01 221 195 louyang 37 271
+lou_dun01 40 201 lou_dun02 288 18
+lou_dun02 288 18 lou_dun01 40 201
+lou_dun02 165 269 lou_dun03 165 35
+lou_dun03 165 35 lou_dun02 165 269
+mag_dun01 125 67 yuno_fild03 33 140
+mag_dun01 243 240 mag_dun02 48 33
+mag_dun02 48 33 mag_dun01 243 240
+mjo_dun01 14 283 mjo_dun02 384 343
+mjo_dun01 52 14 mjolnir_02 79 365
+mjo_dun02 31 21 mjo_dun03 302 264
+mjo_dun02 39 21 mjo_dun03 308 264
+mjo_dun02 384 343 mjo_dun01 14 283
+mjo_dun03 302 264 mjo_dun02 31 21
+mjo_dun03 308 264 mjo_dun02 39 21
+mjolnir_01 284 18 gef_fild04 261 362
+mjolnir_01 381 256 mjolnir_02 28 258
+mjolnir_02 28 258 mjolnir_01 381 256
+mjolnir_02 79 365 mjo_dun01 52 14
+mjolnir_02 326 289 mjolnir_03 21 258
+mjolnir_02 361 18 mjolnir_06 366 383
+mjolnir_03 21 258 mjolnir_02 326 289
+mjolnir_03 212 17 mjolnir_07 214 383
+mjolnir_03 242 204 mjolnir_04 122 208
+mjolnir_04 122 208 mjolnir_03 242 204
+mjolnir_04 160 46 mjolnir_08 159 373
+mjolnir_04 387 174 mjolnir_05 16 171
+mjolnir_05 16 171 mjolnir_04 387 174
+mjolnir_05 220 382 mjolnir_12 220 26
+mjolnir_05 235 16 mjolnir_10 235 381
+mjolnir_06 18 331 gef_fild04 362 322
+mjolnir_06 265 29 gef_fild00 267 382
+mjolnir_06 366 383 mjolnir_02 361 18
+mjolnir_06 382 377 mjolnir_07 16 377
+mjolnir_06 383 74 mjolnir_07 17 77
+mjolnir_07 16 377 mjolnir_06 382 377
+mjolnir_07 17 77 mjolnir_06 383 74
+mjolnir_07 156 16 prt_fild00 159 383
+mjolnir_07 214 383 mjolnir_03 212 17
+mjolnir_07 383 233 mjolnir_08 30 234
+mjolnir_07 383 362 mjolnir_08 29 346
+mjolnir_08 29 346 mjolnir_07 383 362
+mjolnir_08 30 234 mjolnir_07 383 233
+mjolnir_08 159 373 mjolnir_04 160 46
+mjolnir_08 185 28 mjolnir_09 194 367
+mjolnir_08 369 257 mjolnir_10 15 258
+mjolnir_09 30 249 prt_fild00 383 249
+mjolnir_09 106 28 prt_fild05 105 381
+mjolnir_09 194 367 mjolnir_08 185 28
+mjolnir_09 300 28 prt_fild05 292 385
+mjolnir_09 373 288 prt_fild01 20 292
+mjolnir_10 15 258 mjolnir_08 369 257
+mjolnir_10 66 15 prt_fild01 66 373
+mjolnir_10 235 381 mjolnir_05 235 16
+mjolnir_10 265 13 prt_fild01 261 373
+mjolnir_10 384 220 mjolnir_11 20 220
+mjolnir_11 20 220 mjolnir_10 384 220
+mjolnir_11 174 20 prt_fild02 173 382
+mjolnir_12 44 17 prt_maze01 17 115
+mjolnir_12 199 378 aldebaran 138 34
+mjolnir_12 220 26 mjolnir_05 220 382
+moc_castle 94 183 morocc 160 183
+moc_fild01 22 242 prt_fild09 383 223
+moc_fild01 56 384 prt_fild08 55 21
+moc_fild01 239 382 prt_fild08 233 16
+moc_fild01 321 16 moc_fild02 67 342
+moc_fild01 379 162 pay_fild04 17 165
+moc_fild02 67 342 moc_fild01 321 16
+moc_fild02 71 18 moc_fild13 146 368
+moc_fild02 228 29 moc_fild13 298 370
+moc_fild02 332 19 moc_fild03 70 341
+moc_fild02 350 339 pay_fild04 194 17
+moc_fild02 378 272 pay_gld 16 276
+moc_fild03 17 37 moc_fild13 308 49
+moc_fild03 70 341 moc_fild02 332 19
+moc_fild03 179 16 pay_fild11 38 330
+moc_fild03 303 170 pay_fild01 13 152
+moc_fild07 198 21 morocc 160 297
+moc_fild11 26 161 moc_fild12 289 168
+moc_fild11 212 29 moc_fild17 218 369
+moc_fild12 118 30 moc_fild18 158 382
+moc_fild12 159 381 morocc 160 17
+moc_fild12 289 168 moc_fild11 26 161
+moc_fild13 146 368 moc_fild02 71 18
+moc_fild13 298 370 moc_fild02 228 29
+moc_fild13 308 49 moc_fild03 17 37
+moc_fild16 16 179 moc_fild17 369 272
+moc_fild16 205 296 in_moc_16 18 8
+moc_fild17 30 300 moc_fild18 382 305
+moc_fild17 218 369 moc_fild11 212 29
+moc_fild17 369 272 moc_fild16 16 179
+moc_fild18 51 170 cmd_fild09 369 164
+moc_fild18 158 382 moc_fild12 118 30
+moc_fild18 382 305 moc_fild17 30 300
+moc_fild19 71 170 moc_ruins 71 16
+moc_fild19 98 99 in_sphinx1 288 6
+moc_fild19 169 107 morocc 24 164
+moc_pryd01 10 195 moc_pryd02 10 192
+moc_pryd01 10 195 moc_pryd02 10 195
+moc_pryd01 90 109 moc_prydb1 100 191
+moc_pryd01 195 9 moc_ruins 54 161
+moc_pryd02 10 195 moc_pryd01 10 192
+moc_pryd02 10 195 moc_pryd01 10 195
+moc_pryd02 100 99 moc_pryd03 100 97
+moc_pryd03 12 15 moc_pryd04 12 15
+moc_pryd03 15 187 moc_pryd04 15 187
+moc_pryd03 100 97 moc_pryd02 100 99
+moc_pryd03 184 11 moc_pryd04 184 11
+moc_pryd03 188 184 moc_pryd04 188 184
+moc_pryd04 12 15 moc_pryd03 12 15
+moc_pryd04 15 187 moc_pryd03 15 187
+moc_pryd04 184 11 moc_pryd03 184 11
+moc_pryd04 188 184 moc_pryd03 188 184
+moc_pryd05 94 98 moc_prydb1 100 55
+moc_pryd05 223 9 moc_pryd06 195 8
+moc_pryd06 195 8 moc_pryd05 223 9
+moc_prydb1 59 115 moc_prydb1 87 115
+moc_prydb1 87 115 moc_prydb1 59 115
+moc_prydb1 100 55 moc_pryd05 94 98
+moc_prydb1 100 77 moc_prydb1 100 104
+moc_prydb1 100 104 moc_prydb1 100 77
+moc_prydb1 100 191 moc_pryd01 90 109
+moc_prydb1 111 115 moc_prydb1 142 115
+moc_prydb1 142 115 moc_prydb1 111 115
+moc_ruins 54 161 moc_pryd01 195 9
+moc_ruins 71 16 moc_fild19 71 170
+moc_ruins 159 37 morocc 25 294
+monk_test 329 61 job_monk 226 175 0 c c r0 c
+morocc 24 164 moc_fild19 169 107
+morocc 25 294 moc_ruins 159 37
+morocc 46 46 morocc_in 68 75
+morocc 52 259 morocc_in 183 65
+morocc 85 55 morocc_in 44 146
+morocc 98 68 morocc_in 44 178
+morocc 160 17 moc_fild12 159 381
+morocc 160 183 moc_castle 94 183
+morocc 160 297 moc_fild07 198 21
+morocc 197 66 morocc_in 83 90
+morocc 253 56 morocc_in 134 77
+morocc 274 269 morocc_in 136 136
+morocc 284 170 morocc_in 108 179
+morocc_in 23 161 morocc_in 34 161
+morocc_in 34 161 morocc_in 23 161
+morocc_in 44 146 morocc 85 55
+morocc_in 44 178 morocc 98 68
+morocc_in 55 95 morocc_in 68 95
+morocc_in 55 123 morocc_in 68 123
+morocc_in 57 161 morocc_in 70 161
+morocc_in 68 42 morocc_in 68 62
+morocc_in 68 62 morocc_in 68 42
+morocc_in 68 75 morocc 46 46
+morocc_in 68 95 morocc_in 55 95
+morocc_in 68 123 morocc_in 55 123
+morocc_in 70 161 morocc_in 57 161
+morocc_in 83 90 morocc 197 66
+morocc_in 86 101 morocc_in 86 117
+morocc_in 86 117 morocc_in 86 101
+morocc_in 93 95 morocc_in 105 95
+morocc_in 93 123 morocc_in 106 123
+morocc_in 105 95 morocc_in 93 95
+morocc_in 106 123 morocc_in 93 123
+morocc_in 108 179 morocc 284 170
+morocc_in 134 77 morocc 253 56
+morocc_in 136 136 morocc 274 269
+morocc_in 144 109 morocc_in 144 122
+morocc_in 144 122 morocc_in 144 109
+morocc_in 144 151 morocc_in 144 166
+morocc_in 144 166 morocc_in 144 151
+morocc_in 149 129 morocc_in 166 130
+morocc_in 166 130 morocc_in 149 129
+morocc_in 171 37 morocc_in 171 50
+morocc_in 171 50 morocc_in 171 37
+morocc_in 174 109 morocc_in 174 122
+morocc_in 174 122 morocc_in 174 109
+morocc_in 174 151 morocc_in 174 166
+morocc_in 174 166 morocc_in 174 151
+morocc_in 183 65 morocc 52 259
+nif_in 88 29 nif_in 34 34
+nif_in 34 34 nif_in 88 29
+nif_in 23 11 niflheim 189 210
+nif_fild01 344 322 nif_fild02 22 311
+nif_fild02 373 235 niflheim 19 154
+nif_fild02 22 311 nif_fild01 344 322
+niflheim 189 210 nif_in 23 11
+niflheim 19 154 nif_fild02 378 235
+orcsdun01 32 172 in_orcs01 30 182
+orcsdun01 183 8 orcsdun02 21 188
+orcsdun02 21 188 orcsdun01 183 8
+orcsdun02 180 15 in_orcs01 108 114
+payon 267 89 pay_fild08 17 75
+payon 228 329 pay_arche 81 22
+payon 122 27 pay_fild01 333 356
+payon 16 143 pay_gld 370 149
+payon 141 85 payon_in01 14 51
+payon 151 127 payon_in01 56 53
+payon 136 158 payon_in01 20 129
+payon 130 169 payon_in01 13 139
+payon 189 233 payon_in03 149 39
+payon 187 233 payon_in03 149 39
+payon 270 152 payon_in01 90 9
+pay_arche 36 131 pay_dun00 21 186
+pay_arche 81 17 payon 228 329
+pay_arche 145 165 payon_in02 64 56
+pay_arche 71 156 payon_in02 82 45
+pay_arche 92 170 payon_in02 50 4
+pay_dun00 21 186 pay_arche 36 131
+pay_dun00 184 33 pay_dun01 15 33
+pay_dun01 15 33 pay_dun00 184 33
+pay_dun01 286 25 pay_dun02 16 63
+pay_dun02 16 63 pay_dun01 286 25
+pay_dun02 137 128 pay_dun03 155 161
+pay_dun03 127 62 pay_dun04 202 206
+pay_dun03 127 62 pay_dun04 40 37
+pay_dun03 155 161 pay_dun02 137 128
+pay_dun04 40 37 pay_dun03 127 62
+pay_dun04 202 206 pay_dun03 127 62
+pay_fild01 13 152 moc_fild03 303 170
+pay_fild01 278 14 pay_fild02 83 386
+pay_fild01 353 14 pay_fild02 167 390
+pay_fild01 379 201 pay_fild07 16 200
+pay_fild01 333 361 payon 122 27
+#pay_fild02 16 175 pay_fild11 297 135
+pay_fild02 83 386 pay_fild01 278 14
+pay_fild02 134 16 pay_fild05 127 378
+pay_fild02 167 390 pay_fild01 353 14
+pay_fild02 284 108 pay_fild03 15 110
+pay_fild03 15 110 pay_fild02 284 108
+pay_fild03 172 281 pay_fild07 164 17
+pay_fild03 313 16 pay_fild06 305 375
+pay_fild03 392 63 alberta 15 234
+pay_fild04 17 165 moc_fild01 379 162
+pay_fild04 194 17 moc_fild02 350 339
+pay_fild05 127 378 pay_fild02 134 16
+pay_fild05 271 284 pay_fild06 28 288
+pay_fild06 28 288 pay_fild05 271 284
+pay_fild06 305 375 pay_fild03 313 16
+pay_fild07 16 200 pay_fild01 379 201
+pay_fild07 164 17 pay_fild03 172 281
+pay_fild07 280 382 pay_fild08 160 16
+pay_fild07 382 290 pay_fild10 16 290
+pay_fild08 17 75 payon 265 92
+pay_fild08 160 16 pay_fild07 280 382
+pay_fild08 262 91 pay_fild09 16 91
+pay_fild09 16 91 pay_fild08 262 91
+pay_fild09 112 16 pay_fild10 112 382
+pay_fild10 16 290 pay_fild07 382 290
+pay_fild10 112 382 pay_fild09 112 16
+pay_fild11 38 330 moc_fild03 179 16
+#pay_fild11 297 135 pay_fild02 16 175
+pay_gld 16 276 moc_fild02 378 272
+pay_gld 121 238 payg_cas01 214 44
+pay_gld 140 156 payg_cas04 252 275
+pay_gld 204 270 payg_cas05 62 223
+pay_gld 291 116 payg_cas02 276 61
+pay_gld 321 293 payg_cas03 226 22
+pay_gld 374 149 payon 16 143
+payg_cas01 214 44 pay_gld 121 233
+payg_cas01 201 126 payg_cas01 102 21
+payg_cas01 102 17 payg_cas01 201 121
+payg_cas01 222 130 payg_cas01 130 43
+payg_cas01 134 43 payg_cas01 226 130
+payg_cas01 218 112 payg_cas01 230 94
+payg_cas01 230 98 payg_cas01 222 112
+payg_cas01 213 76 payg_cas01 201 118
+payg_cas01 201 114 payg_cas01 213 72
+payg_cas01 84 15 payg_cas01 15 115
+payg_cas01 11 115 payg_cas01 81 15
+payg_cas01 53 111 payg_cas01 115 147
+payg_cas01 115 151 payg_cas01 53 115
+payg_cas02 276 61 pay_gld 295 116
+payg_cas02 232 72 payg_cas02 28 289
+payg_cas02 28 293 payg_cas02 229 72
+payg_cas02 236 59 payg_cas02 229 72
+payg_cas02 222 26 payg_cas02 80 240
+payg_cas02 84 240 payg_cas02 224 30
+payg_cas02 215 31 payg_cas02 65 288
+payg_cas02 65 292 payg_cas02 215 35
+payg_cas02 47 223 payg_cas02 280 287
+payg_cas02 280 291 payg_cas02 47 227
+payg_cas02 254 239 payg_cas02 13 38
+payg_cas02 13 42 payg_cas02 254 243
+payg_cas03 226 22 pay_gld 317 293
+payg_cas03 255 76 payg_cas03 24 19
+payg_cas03 20 19 payg_cas03 255 72
+payg_cas03 269 79 payg_cas03 53 19
+payg_cas03 57 19 payg_cas03 269 75
+payg_cas03 255 64 payg_cas03 245 37
+payg_cas03 245 41 payg_cas03 255 68
+payg_cas03 262 71 payg_cas03 39 9
+payg_cas03 39 5 payg_cas03 263 66
+payg_cas03 272 68 payg_cas03 261 38
+payg_cas03 261 34 payg_cas03 270 66
+payg_cas03 39 84 payg_cas03 29 249
+payg_cas03 29 245 payg_cas03 39 80
+payg_cas03 29 269 payg_cas03 269 287
+payg_cas03 269 290 payg_cas03 29 273
+payg_cas04 252 275 pay_gld 140 160
+payg_cas04 260 212 payg_cas04 70 240
+payg_cas04 74 240 payg_cas04 256 212
+payg_cas04 232 189 payg_cas04 74 261
+payg_cas04 78 261 payg_cas04 236 189
+payg_cas04 229 208 payg_cas04 70 282
+payg_cas04 74 282 payg_cas04 225 208
+payg_cas04 7 261 payg_cas04 55 30
+payg_cas04 59 30 payg_cas04 11 261
+payg_cas04 28 31 payg_cas04 251 42
+payg_cas04 254 45 payg_cas04 24 31
+payg_cas05 23 283 payg_cas05 237 282
+payg_cas05 237 286 payg_cas05 19 282
+payg_cas05 56 255 payg_cas05 223 256
+payg_cas05 219 256 payg_cas05 52 255
+payg_cas05 39 264 payg_cas05 237 231
+payg_cas05 237 227 payg_cas05 40 260
+payg_cas05 283 256 payg_cas05 286 43
+payg_cas05 290 43 payg_cas05 287 256
+payg_cas05 242 41 payg_cas05 18 18
+payg_cas05 14 14 payg_cas05 246 41
+payg_cas05 62 223 pay_gld 198 264
+payon_in01 17 51 payon 141 85
+payon_in01 10 80 payon_in01 10 59
+payon_in01 10 59 payon_in01 10 83
+payon_in01 10 38 payon_in01 10 80
+payon_in01 10 17 payon_in01 10 38
+payon_in01 56 50 payon 151 127
+payon_in01 23 129 payon 136 158
+payon_in01 13 139 payon 130 172
+payon_in01 86 9 payon 270 152
+payon_in01 22 26 payon_in01 30 81
+payon_in01 26 115 payon_in01 30 126
+payon_in01 26 164 payon_in01 30 151
+payon_in01 30 59 payon_in01 52 35
+payon_in01 30 81 payon_in01 22 26
+payon_in01 30 126 payon_in01 26 115
+payon_in01 30 151 payon_in01 26 164
+payon_in01 52 35 payon_in01 30 59
+payon_in01 60 99 payon_in01 113 77
+payon_in01 60 107 payon_in01 113 107
+payon_in01 60 145 payon_in01 113 143
+payon_in01 60 170 payon_in01 72 159
+payon_in01 70 52 payon_in01 86 37
+payon_in01 70 75 payon_in01 130 36
+payon_in01 72 121 payon_in01 72 134
+payon_in01 72 134 payon_in01 72 121
+payon_in01 72 159 payon_in01 60 170
+payon_in01 83 99 payon_in01 122 77
+payon_in01 83 107 payon_in01 122 107
+payon_in01 83 145 payon_in01 124 143
+payon_in01 86 37 payon_in01 70 52
+payon_in01 111 177 payon_in01 126 177
+payon_in01 113 77 payon_in01 60 99
+payon_in01 113 107 payon_in01 60 107
+payon_in01 113 143 payon_in01 60 145
+payon_in01 122 77 payon_in01 83 99
+payon_in01 122 107 payon_in01 83 107
+payon_in01 124 143 payon_in01 83 145
+payon_in01 126 177 payon_in01 111 177
+payon_in01 130 36 payon_in01 70 75
+payon_in01 143 179 payon_in01 164 179
+payon_in01 164 179 payon_in01 143 179
+payon_in01 167 74 payon_in01 168 53
+payon_in01 168 53 payon_in01 167 74
+payon_in01 170 87 payon_in01 170 100
+payon_in01 170 100 payon_in01 170 87
+payon_in01 170 119 payon_in01 170 132
+payon_in01 170 132 payon_in01 170 119
+payon_in02 10 25 payon_in02 75 67
+payon_in02 35 67 payon_in02 52 67
+payon_in02 50 4 pay_arche 92 170
+payon_in02 52 67 payon_in02 35 67
+payon_in02 61 33 payon_in02 70 33
+payon_in02 64 56 pay_arche 145 165
+payon_in02 70 33 payon_in02 61 33
+payon_in02 75 67 payon_in02 10 25
+payon_in02 82 45 pay_arche 71 156
+payon_in03 172 33 payon_in03 160 14
+payon_in03 160 15 payon_in03 172 35
+payon_in03 147 39 payon 186 233
+payon_in03 158 32 payon 189 233
+payon_in03 130 17 payon_in03 158 32
+payon_in03 172 32 payon_in03 130 17
+payon_in03 160 17 payon_in03 172 32
+payon_in03 186 32 payon_in03 160 17
+payon_in03 190 17 payon_in03 186 32
+payon_in03 146 39 payon 186 233
+prontera 22 203 prt_fild05 373 205
+prontera 42 67 prt_in 47 29
+prontera 45 346 prt_in 80 113
+prontera 73 100 prt_in 208 179
+prontera 74 90 prt_in 248 173
+prontera 84 89 prt_in 282 179
+prontera 107 215 prt_in 240 141
+prontera 120 267 prt_in 183 97
+prontera 132 222 prt_in 135 71
+prontera 133 183 prt_in 53 105
+prontera 156 22 prt_fild08 170 378
+prontera 156 360 prt_castle 102 16
+prontera 177 221 prt_in 168 124
+prontera 179 184 prt_in 60 77
+prontera 192 267 prt_in 181 55
+prontera 204 192 prt_in 68 130
+prontera 208 154 prt_in 172 33
+prontera 237 317 prt_church 100 56
+prontera 289 203 prt_fild06 23 193
+prt_castle 28 121 prt_castle 40 138
+prt_castle 31 113 prt_castle 54 113
+prt_castle 40 138 prt_castle 28 121
+prt_castle 45 145 prt_castle 68 153
+prt_castle 54 113 prt_castle 31 113
+prt_castle 59 29 prt_castle 82 29
+prt_castle 68 153 prt_castle 45 145
+prt_castle 75 107 prt_castle 92 107
+prt_castle 82 29 prt_castle 59 29
+prt_castle 92 107 prt_castle 75 107
+prt_castle 102 16 prontera 156 360
+prt_castle 102 73 prt_castle 102 88
+prt_castle 102 88 prt_castle 102 73
+prt_castle 102 129 prt_castle 102 140
+prt_castle 102 140 prt_castle 102 129
+prt_castle 102 181 prt_gld 159 25
+prt_castle 113 107 prt_castle 130 107
+prt_castle 121 29 prt_castle 144 29
+prt_castle 130 107 prt_castle 113 107
+prt_castle 135 153 prt_castle 164 145
+prt_castle 144 29 prt_castle 121 29
+prt_castle 149 113 prt_castle 172 113
+prt_castle 164 145 prt_castle 135 153
+prt_castle 170 138 prt_castle 176 121
+prt_castle 172 113 prt_castle 149 113
+prt_castle 176 121 prt_castle 170 138
+prt_church 31 19 prt_church 90 81
+prt_church 90 81 prt_church 31 19
+prt_church 100 56 prontera 237 317
+prt_church 109 81 prt_church 168 19
+prt_church 168 19 prt_church 109 81
+prt_fild00 18 129 gef_fild00 381 137
+prt_fild00 159 383 mjolnir_07 156 16
+prt_fild00 165 18 prt_fild04 160 387
+prt_fild00 317 18 prt_fild04 323 387
+prt_fild00 383 249 mjolnir_09 30 249
+prt_fild01 20 292 mjolnir_09 373 288
+prt_fild01 66 373 mjolnir_10 66 15
+prt_fild01 136 373 prt_maze01 176 4
+prt_fild01 199 24 prt_gld 159 298
+prt_fild01 261 373 mjolnir_10 265 13
+prt_fild01 380 243 prt_fild02 17 242
+prt_fild01 382 304 prt_fild02 17 305
+prt_fild01 382 351 prt_fild02 17 350
+prt_fild02 17 242 prt_fild01 380 243
+prt_fild02 17 305 prt_fild01 382 304
+prt_fild02 17 350 prt_fild01 382 351
+prt_fild02 173 382 mjolnir_11 174 20
+prt_fild02 305 17 prt_fild06 277 320
+prt_fild02 380 347 prt_fild03 16 249
+prt_fild03 16 249 prt_fild02 380 347
+prt_fild03 371 255 prt_monk 22 248
+prt_fild04 17 114 gef_fild01 382 111
+prt_fild04 160 387 prt_fild00 165 18
+prt_fild04 323 387 prt_fild00 317 18
+prt_fild04 378 72 prt_fild05 13 63
+prt_fild04 384 155 prt_fild05 14 141
+prt_fild04 384 334 prt_fild05 15 333
+prt_fild05 13 63 prt_fild04 378 72
+prt_fild05 14 141 prt_fild04 384 155
+prt_fild05 15 333 prt_fild04 384 334
+prt_fild05 105 381 mjolnir_09 106 28
+prt_fild05 134 14 prt_fild07 132 381
+prt_fild05 255 14 prt_fild07 248 376
+prt_fild05 292 385 mjolnir_09 300 28
+prt_fild05 373 205 prontera 22 203
+prt_fild06 23 193 prontera 289 203
+prt_fild06 277 320 prt_fild02 305 17
+prt_fild07 13 64 gef_fild02 380 68
+prt_fild07 14 289 gef_fild02 380 289
+prt_fild07 17 145 gef_fild02 380 156
+prt_fild07 84 13 prt_fild09 87 380
+prt_fild07 132 381 prt_fild05 134 14
+prt_fild07 206 12 prt_fild09 224 380
+prt_fild07 248 376 prt_fild05 255 14
+prt_fild07 383 239 prt_fild08 16 239
+prt_fild07 385 186 prt_fild08 16 187
+prt_fild08 16 187 prt_fild07 385 186
+prt_fild08 16 239 prt_fild07 383 239
+prt_fild08 55 21 moc_fild01 56 384
+prt_fild08 170 378 prontera 156 22
+prt_fild08 233 16 moc_fild01 239 382
+prt_fild08 371 212 izlude 30 78
+prt_fild09 14 139 prt_fild10 339 126
+prt_fild09 87 380 prt_fild07 84 13
+prt_fild09 224 380 prt_fild07 206 12
+prt_fild09 383 223 moc_fild01 22 242
+prt_fild10 20 122 prt_fild11 362 111
+prt_fild10 20 196 prt_fild11 361 184
+prt_fild10 227 299 gef_fild02 266 18
+prt_fild10 339 126 prt_fild09 14 139
+prt_fild11 17 281 gef_fild11 377 293
+prt_fild11 302 301 gef_fild03 312 16
+prt_fild11 361 184 prt_fild10 20 196
+prt_fild11 362 111 prt_fild10 20 122
+prt_gld 107 240 prtg_cas04 86 9
+prt_gld 129 65 prtg_cas01 103 32
+prt_gld 153 141 prtg_cas03 168 8
+prt_gld 159 25 prt_castle 102 181
+prt_gld 159 298 prt_fild01 199 24
+prt_gld 212 240 prtg_cas05 17 231
+prt_gld 240 124 prtg_cas02 43 233
+prt_in 37 65 prt_in 48 65
+prt_in 47 29 prontera 42 67
+prt_in 48 65 prt_in 37 65
+prt_in 53 105 prontera 133 183
+prt_in 60 77 prontera 179 184
+prt_in 68 130 prontera 204 192
+prt_in 69 65 prt_in 82 65
+prt_in 70 143 prt_in 70 162
+prt_in 70 162 prt_in 70 143
+prt_in 80 113 prontera 45 346
+prt_in 82 65 prt_in 69 65
+prt_in 135 71 prontera 132 222
+prt_in 168 124 prontera 177 221
+prt_in 172 33 prontera 208 154
+prt_in 181 55 prontera 192 267
+prt_in 183 97 prontera 120 267
+prt_in 208 179 prontera 73 100
+prt_in 217 163 prt_in 234 163
+prt_in 234 163 prt_in 217 163
+prt_in 240 141 prontera 107 215
+prt_in 248 173 prontera 74 90
+prt_in 254 113 prt_in 256 131
+prt_in 256 131 prt_in 254 113
+prt_in 263 163 prt_in 274 163
+prt_in 274 163 prt_in 263 163
+prt_in 282 179 prontera 84 89
+prt_maze01 100 35 prt_maze01 139 47
+prt_maze01 102 165 prt_maze01 98 151
+prt_maze01 105 115 prt_maze01 175 168
+prt_maze01 105 75 prt_maze01 54 8
+prt_maze01 115 145 prt_maze01 8 186
+prt_maze01 115 21 prt_maze01 167 22
+prt_maze01 115 56 prt_maze01 7 57
+prt_maze01 115 96 prt_maze01 128 105
+prt_maze01 124 105 prt_maze01 111 96
+prt_maze01 124 169 prt_maze01 191 139
+prt_maze01 138 124 prt_maze01 142 111
+prt_maze01 139 44 prt_maze01 100 32
+prt_maze01 14 75 prt_maze01 63 128
+prt_maze01 140 75 prt_maze01 96 47
+prt_maze01 142 115 prt_maze01 138 128
+prt_maze01 155 133 prt_maze01 8 140
+prt_maze01 155 181 prt_maze01 88 145
+prt_maze01 155 21 prt_maze01 87 13
+prt_maze01 164 140 prt_maze01 70 68
+prt_maze01 164 22 prt_maze01 112 21
+prt_maze01 164 93 prt_maze01 72 11
+prt_maze01 17 115 prt_maze01 50 48
+prt_maze01 17 34 prt_maze01 23 128
+prt_maze01 175 164 prt_maze01 105 111
+prt_maze01 176 35 prt_maze01 182 88
+prt_maze01 176 4 prt_fild01 136 368
+prt_maze01 176 44 prt_maze01 18 152
+prt_maze01 18 155 prt_maze01 176 47
+prt_maze01 182 84 prt_maze01 177 31
+prt_maze01 19 195 prt_maze02 94 19
+prt_maze01 195 139 prt_maze01 129 174
+prt_maze01 195 15 prt_maze01 47 105
+prt_maze01 195 174 prt_maze01 47 23
+prt_maze01 195 55 prt_maze01 87 97
+prt_maze01 195 93 prt_maze01 88 55
+prt_maze01 22 84 prt_maze01 55 151
+prt_maze01 23 124 prt_maze01 17 30
+prt_maze01 25 5 prt_maze01 65 113
+prt_maze01 4 140 prt_maze01 151 133
+prt_maze01 4 186 prt_maze01 111 145
+prt_maze01 4 57 prt_maze01 112 56
+prt_maze01 44 105 prt_maze01 192 15
+prt_maze01 44 23 prt_maze01 192 174
+prt_maze01 50 44 prt_maze01 17 111
+prt_maze01 51 195 prt_maze01 63 88
+prt_maze01 54 4 prt_maze01 105 71
+prt_maze01 55 155 prt_maze01 22 88
+prt_maze01 63 124 prt_maze01 14 71
+prt_maze01 63 195 prt_maze01 63 88
+prt_maze01 63 84 prt_maze01 58 192
+prt_maze01 65 116 prt_maze01 23 9
+prt_maze01 70 75 prt_maze01 169 140
+prt_maze01 75 11 prt_maze01 167 93
+prt_maze01 75 66 prt_maze01 169 140
+prt_maze01 75 95 prt_maze01 88 173
+prt_maze01 84 10 prt_maze01 152 25
+prt_maze01 84 145 prt_maze01 151 181
+prt_maze01 84 173 prt_maze01 71 95
+prt_maze01 84 55 prt_maze01 191 93
+prt_maze01 84 97 prt_maze01 192 55
+prt_maze01 96 44 prt_maze01 140 72
+prt_maze01 98 155 prt_maze01 102 169
+prt_maze02 103 15 prt_maze01 22 191
+prt_maze02 108 182 prt_maze03 23 8
+prt_maze02 80 182 prt_maze03 23 8
+prt_maze02 84 15 prt_maze01 22 191
+prt_maze03 100 35 prt_maze03 63 88
+prt_maze03 102 164 prt_maze03 143 111
+prt_maze03 104 115 prt_maze03 22 88
+prt_maze03 105 75 prt_maze03 140 47
+prt_maze03 115 145 prt_maze03 88 173
+prt_maze03 115 21 prt_maze03 128 105
+prt_maze03 115 56 prt_maze03 88 145
+prt_maze03 115 96 prt_maze03 167 22
+prt_maze03 124 105 prt_maze03 111 21
+prt_maze03 124 168 prt_maze03 69 69
+prt_maze03 137 124 prt_maze03 177 32
+prt_maze03 14 75 prt_maze03 54 8
+prt_maze03 140 44 prt_maze03 105 72
+prt_maze03 140 75 prt_maze03 97 48
+prt_maze03 143 115 prt_maze03 102 168
+prt_maze03 155 133 prt_maze03 8 186
+prt_maze03 155 181 prt_maze03 88 56
+prt_maze03 155 21 prt_maze03 48 22
+prt_maze03 164 139 prt_maze03 191 16
+prt_maze03 164 22 prt_maze03 111 95
+prt_maze03 17 115 prt_maze03 49 47
+prt_maze03 175 164 prt_maze03 18 30
+prt_maze03 176 35 prt_maze03 137 127
+prt_maze03 176 44 prt_maze03 55 151
+prt_maze03 178 75 prt_maze03 182 88
+prt_maze03 18 155 prt_maze03 63 128
+prt_maze03 18 34 prt_maze03 175 168
+prt_maze03 182 84 prt_maze03 178 71
+prt_maze03 195 139 prt_maze03 167 22
+prt_maze03 195 16 prt_maze03 168 139
+prt_maze03 195 174 prt_maze03 48 105
+prt_maze03 195 54 prt_maze03 88 96
+prt_maze03 22 195 prt_maze03 65 111
+prt_maze03 22 84 prt_maze03 104 111
+prt_maze03 23 124 prt_maze03 98 151
+prt_maze03 25 4 prt_maze02 95 177
+prt_maze03 4 140 prt_maze03 60 192
+prt_maze03 4 186 prt_maze03 151 133
+prt_maze03 4 57 prt_maze03 71 95
+prt_maze03 44 105 prt_maze03 191 174
+prt_maze03 44 22 prt_maze03 151 25
+prt_maze03 49 44 prt_maze03 17 112
+prt_maze03 53 195 prt_maze03 7 140
+prt_maze03 54 4 prt_maze03 14 71
+prt_maze03 55 155 prt_maze03 176 48
+prt_maze03 63 124 prt_maze03 18 151
+prt_maze03 63 195 prt_maze03 7 140
+prt_maze03 63 84 prt_maze03 100 31
+prt_maze03 65 115 prt_maze03 22 191
+prt_maze03 71 75 prt_maze03 127 173
+prt_maze03 75 12 prt_maze03 88 13
+prt_maze03 75 64 prt_maze03 127 173
+prt_maze03 75 95 prt_maze03 8 57
+prt_maze03 84 10 prt_maze03 71 12
+prt_maze03 84 145 prt_maze03 111 56
+prt_maze03 84 173 prt_maze03 111 145
+prt_maze03 84 56 prt_maze03 151 181
+prt_maze03 84 96 prt_maze03 191 54
+prt_maze03 97 44 prt_maze03 140 71
+prt_maze03 98 155 prt_maze03 23 128
+prt_monk 22 248 prt_fild03 371 255
+prt_monk 192 172 monk_test 329 50
+prt_sewb1 135 248 prt_fild05 270 212
+prt_sewb1 188 247 prt_sewb2 19 12
+prt_sewb2 19 12 prt_sewb1 188 247
+prt_sewb2 19 175 prt_sewb2 60 24
+prt_sewb2 60 24 prt_sewb2 19 175
+prt_sewb2 100 176 prt_sewb2 140 24
+prt_sewb2 140 24 prt_sewb2 100 176
+prt_sewb2 180 24 prt_sewb3 180 173
+prt_sewb3 20 185 prt_sewb4 100 96
+prt_sewb3 180 173 prt_sewb2 180 24
+prt_sewb4 100 96 prt_sewb3 20 185
+prtg_cas01 103 32 prt_gld 134 65
+prtg_cas01 109 163 prtg_cas01 202 183
+prtg_cas01 147 120 prtg_cas01 75 187
+prtg_cas01 196 119 prtg_cas01 40 54
+prtg_cas01 196 65 prtg_cas01 75 54
+prtg_cas01 206 183 prtg_cas01 113 163
+prtg_cas01 206 92 prtg_cas01 55 70
+prtg_cas01 37 47 prtg_cas01 45 34
+prtg_cas01 37 54 prtg_cas01 192 119
+prtg_cas01 41 34 prtg_cas01 40 47
+prtg_cas01 51 70 prtg_cas01 202 92
+prtg_cas01 57 19 prtg_cas01 80 49
+prtg_cas01 62 34 prtg_cas01 192 119
+prtg_cas01 71 54 prtg_cas01 192 65
+prtg_cas01 75 183 prtg_cas01 147 116
+prtg_cas01 84 19 prtg_cas01 192 65
+prtg_cas01 84 49 prtg_cas01 61 19
+prtg_cas02 157 135 prtg_cas02 184 40
+prtg_cas02 161 41 prtg_cas02 57 202
+prtg_cas02 184 44 prtg_cas02 157 140
+prtg_cas02 203 21 prtg_cas02 45 25
+prtg_cas02 210 41 prtg_cas02 84 215
+prtg_cas02 35 183 prtg_cas02 71 82
+prtg_cas02 43 233 prt_gld 240 128
+prtg_cas02 45 21 prtg_cas02 203 25
+prtg_cas02 53 202 prtg_cas02 165 41
+prtg_cas02 64 164 prtg_cas02 98 25
+prtg_cas02 71 86 prtg_cas02 35 187
+prtg_cas02 88 215 prtg_cas02 206 41
+prtg_cas02 98 21 prtg_cas02 64 168
+prtg_cas03 164 173 prtg_cas03 45 117
+prtg_cas03 165 59 prtg_cas03 45 47
+prtg_cas03 168 8 prt_gld 153 137
+prtg_cas03 169 235 prtg_cas03 11 200
+prtg_cas03 172 44 prtg_cas03 10 78
+prtg_cas03 178 85 prtg_cas03 82 73
+prtg_cas03 191 55 prtg_cas03 190 233
+prtg_cas03 194 233 prtg_cas03 191 59
+prtg_cas03 45 120 prtg_cas03 164 177
+prtg_cas03 45 43 prtg_cas03 165 54
+prtg_cas03 6 78 prtg_cas03 176 44
+prtg_cas03 7 200 prtg_cas03 169 231
+prtg_cas03 86 73 prtg_cas03 178 81
+prtg_cas04 10 229 prtg_cas04 48 44
+prtg_cas04 238 257 prtg_cas04 34 286
+prtg_cas04 247 258 prtg_cas04 255 14
+prtg_cas04 251 14 prtg_cas04 247 254
+prtg_cas04 32 28 prtg_cas04 11 254
+prtg_cas04 34 225 prtg_cas04 63 26
+prtg_cas04 34 290 prtg_cas04 238 261
+prtg_cas04 42 13 prtg_cas04 56 254
+prtg_cas04 48 48 prtg_cas04 10 233
+prtg_cas04 54 25 prtg_cas04 56 233
+prtg_cas04 56 229 prtg_cas04 54 29
+prtg_cas04 60 254 prtg_cas04 42 17
+prtg_cas04 63 30 prtg_cas04 34 229
+prtg_cas04 7 254 prtg_cas04 32 32
+prtg_cas04 86 9 prt_gld 111 240
+prtg_cas05 17 231 prt_gld 208 240
+prtg_cas05 195 13 prtg_cas05 55 248
+prtg_cas05 228 96 prtg_cas05 26 7
+prtg_cas05 244 3 prtg_cas05 35 247
+prtg_cas05 253 294 prtg_cas05 58 11
+prtg_cas05 26 3 prtg_cas05 228 92
+prtg_cas05 260 96 prtg_cas05 66 229
+prtg_cas05 292 13 prtg_cas05 76 246
+prtg_cas05 38 250 prtg_cas05 244 7
+prtg_cas05 53 246 prtg_cas05 199 13
+prtg_cas05 58 7 prtg_cas05 253 290
+prtg_cas05 66 225 prtg_cas05 260 92
+prtg_cas05 76 242 prtg_cas05 288 13
+treasure01 27 164 treasure01 38 164
+treasure01 38 164 treasure01 27 164
+treasure01 41 37 treasure01 58 37
+treasure01 41 111 treasure01 61 111
+treasure01 58 37 treasure01 41 37
+treasure01 61 111 treasure01 41 111
+treasure01 69 22 alb2trea 88 111
+treasure01 69 75 treasure01 69 102
+treasure01 69 102 treasure01 69 75
+treasure01 69 125 treasure01 69 140
+treasure01 69 140 treasure01 69 125
+treasure01 69 177 treasure02 102 24
+treasure01 76 111 treasure01 98 111
+treasure01 79 37 treasure01 96 37
+treasure01 96 37 treasure01 79 37
+treasure01 98 111 treasure01 76 111
+treasure01 99 164 treasure01 112 164
+treasure01 112 164 treasure01 99 164
+treasure01 125 161 treasure01 142 161
+treasure01 142 161 treasure01 125 161
+treasure01 164 91 treasure01 164 114
+treasure01 164 114 treasure01 164 91
+treasure02 49 99 treasure02 49 128
+treasure02 49 128 treasure02 49 99
+treasure02 65 72 treasure02 80 72
+treasure02 80 72 treasure02 65 72
+treasure02 102 24 treasure01 69 177
+treasure02 102 103 treasure02 102 118
+treasure02 102 118 treasure02 102 103
+treasure02 123 72 treasure02 138 72
+treasure02 138 72 treasure02 123 72
+treasure02 155 99 treasure02 155 128
+treasure02 155 128 treasure02 155 99
+tur_dun01 154 241 tur_dun02 148 268
+tur_dun03 132 193 tur_dun02 167 19
+tur_dun02 148 268 tur_dun01 154 241
+tur_dun02 167 19 tur_dun03 132 193
+tur_dun03 217 71 tur_dun04 100 196
+tur_dun04 100 196 tur_dun03 217 71
+umbala 130 79 um_fild04 215 339
+umbala 129 78 um_fild04 215 340
+umbala 106 285 um_dun01 42 27
+umbala 107 130 um_in 99 63
+umbala 138 129 um_in 99 114
+umbala 125 157 um_in 155 111
+umbala 94 186 um_in 141 39
+umbala 100 203 um_in 163 69
+umbala 107 118 um_in 15 20
+# bungee jump
+#umbala 140 197 nif_in 68 14
+um_dun01 42 27 umbala 106 285
+um_dun01 149 198 um_dun02 52 22
+um_dun02 52 22 um_dun01 149 198
+um_dun02 126 162 yggdrasil01 38 63
+um_fild01 31 374 beach_dun2 258 244
+um_fild01 369 277 um_fild02 22 272
+um_fild01 31 274 beach_dun2 258 244
+um_fild02 188 374 um_fild04 182 13
+um_fild02 373 148 um_fild03 32 145
+um_fild02 373 329 um_fild03 19 334
+um_fild02 22 272 um_fild01 369 277
+um_fild02 373 148 um_fild03 32 145
+um_fild03 19 334 um_fild02 373 329
+um_fild03 32 145 um_fild02 373 148
+um_fild03 114 50 cmd_fild01 77 366
+um_fild03 243 26 cmd_fild01 178 370
+um_fild04 182 13 um_fild02 188 374
+um_fild04 215 339 umbala 130 79
+um_fild04 215 340 umbala 129 78
+um_in 155 111 umbala 125 157
+um_in 99 111 umbala 136 127
+um_in 99 63 umbala 107 130
+um_in 141 39 umbala 94 183
+um_in 11 18 umbala 107 118
+um_in 166 69 umbala 100 203
+yggdrasil01 27 195 yggdrasil01 270 52
+yggdrasil01 270 52 yggdrasil01 27 195
+yggdrasil01 248 259 nif_fild01 316 67
+yuno 48 105 yuno_in01 40 176
+yuno 48 151 yuno_in01 34 100
+yuno 87 321 yuno_in02 172 61
+yuno 117 135 yuno_in01 116 40
+yuno 158 13 yuno_fild04 231 288
+yuno 196 138 yuno_in01 32 36
+yuno 245 147 yuno_in01 101 85
+yuno 264 87 yuno_in01 168 104
+yuno 278 293 yuno_in03 25 11
+yuno 284 366 yuno_in03 224 19
+yuno 323 284 yuno_in03 167 19
+yuno 342 203 yuno_in04 29 58
+yuno_fild01 208 18 aldebaran 140 243
+yuno_fild01 27 247 yuno_fild12 366 244
+yuno_fild01 70 377 yuno_fild09 70 21
+yuno_fild01 287 367 yuno_fild09 280 32
+yuno_fild02 19 340 yuno_fild03 382 331
+yuno_fild02 117 375 hu_fild04 122 35
+yuno_fild02 69 23 yuno_fild08 75 375
+yuno_fild02 287 16 yuno_fild08 285 385
+yuno_fild03 20 79 yuno_fild04 374 82
+yuno_fild03 20 162 yuno_fild04 374 149
+yuno_fild03 33 140 mag_dun01 125 67
+yuno_fild03 382 331 yuno_fild02 19 340
+yuno_fild03 179 16 yuno_fild07 179 352
+yuno_fild03 178 15 yuno_fild07 179 351
+yuno_fild03 21 162 yuno_fild04 371 147
+yuno_fild04 231 288 yuno 158 13
+yuno_fild04 374 82 yuno_fild03 20 79
+yuno_fild04 374 149 yuno_fild03 21 162
+yuno_fild04 42 370 yuno_fild05 61 33
+yuno_fild04 249 22 ein_fild06 255 358
+yuno_fild05 61 29 yuno_fild04 42 366
+yuno_fild07 73 220 ein_fild06 332 176
+yuno_fild07 179 353 yuno_fild03 179 17
+yuno_fild07 352 292 yuno_fild08 27 275
+yuno_fild07 360 72 yuno_fild08 35 61
+yuno_fild07 57 79 ein_fild06 352 95
+yuno_fild07 92 28 yuno_fild11 91 369
+yuno_fild07 208 175 jupe_cave 143 52
+yuno_fild07 179 354 yuno_fild03 178 15
+yuno_fild08 31 58 yuno_fild07 357 75
+yuno_fild08 24 275 yuno_fild07 348 288
+yuno_fild08 134 29 yuno_fild12 197 371
+yuno_fild08 75 375 yuno_fild02 72 28
+yuno_fild08 285 385 yuno_fild02 290 20
+yuno_fild08 375 194 yuno_fild09 23 193
+yuno_fild09 280 29 yuno_fild01 287 364
+yuno_fild09 70 18 yuno_fild01 70 374
+yuno_fild09 20 193 yuno_fild08 372 194
+yuno_fild11 368 361 yuno_fild12 27 336
+yuno_fild11 28 266 ein_fild07 378 264
+yuno_fild11 91 372 yuno_fild07 92 31
+yuno_fild11 368 361 yuno_fild12 25 338
+yuno_fild12 193 372 yuno_fild08 134 33
+yuno_fild12 23 339 yuno_fild11 364 356
+yuno_fild12 369 244 yuno_fild01 27 247
+yuno_fild12 23 338 yuno_fild11 366 361
+yuno_in01 32 36 yuno 196 138
+yuno_in01 32 182 yuno_in01 82 164
+yuno_in01 34 100 yuno 48 151
+yuno_in01 40 176 yuno 48 105
+yuno_in01 82 164 yuno_in01 32 182
+yuno_in01 88 36 yuno_in01 176 34
+yuno_in01 101 85 yuno 245 147
+yuno_in01 116 40 yuno 117 135
+yuno_in01 168 104 yuno 264 87
+yuno_in01 176 34 yuno_in01 88 36
+yuno_in02 82 14 yuno_in05 196 194
+yuno_in02 172 61 yuno 87 321
+yuno_in03 25 11 yuno 278 293
+yuno_in03 25 56 yuno_in03 32 89
+yuno_in03 32 89 yuno_in03 25 56
+yuno_in03 66 186 yuno_in03 153 134
+yuno_in03 96 62 yuno_in03 223 167
+yuno_in03 104 115 yuno_in03 219 50
+yuno_in03 111 192 yuno_in03 162 129
+yuno_in03 124 178 yuno_in03 173 118
+yuno_in03 153 134 yuno_in03 66 186
+yuno_in03 161 174 yuno_in03 186 119
+yuno_in03 161 187 yuno_in03 186 131
+yuno_in03 162 129 yuno_in03 111 192
+yuno_in03 167 19 yuno 323 284
+yuno_in03 167 72 yuno_in03 179 109
+yuno_in03 173 118 yuno_in03 124 178
+yuno_in03 179 109 yuno_in03 167 72
+yuno_in03 186 119 yuno_in03 161 174
+yuno_in03 186 131 yuno_in03 161 187
+yuno_in03 219 50 yuno_in03 104 115
+yuno_in03 223 167 yuno_in03 96 62
+yuno_in03 224 19 yuno 284 366
+yuno_in03 231 62 yuno_in03 239 141
+yuno_in03 235 91 yuno_in03 244 52
+yuno_in03 239 141 yuno_in03 231 62
+yuno_in03 244 52 yuno_in03 235 91
+yuno_in04 29 58 yuno 342 203
+yuno_in04 95 58 yuno_in04 52 58
+yuno_in04 52 58 yuno_in04 95 58
+yuno_in04 103 22 yuno_in04 115 51
+yuno_in04 103 51 yuno_in04 115 22
+yuno_in04 103 64 yuno_in04 103 93
+yuno_in04 103 93 yuno_in04 103 64
+yuno_in04 115 22 yuno_in04 115 51
+yuno_in04 115 51 yuno_in04 115 22
+yuno_in04 115 64 yuno_in04 103 93
+yuno_in04 115 93 yuno_in04 103 64
+yuno_in04 122 57 yuno_in04 161 110
+yuno_in04 161 110 yuno_in04 122 57
+yuno_in05 16 188 yuno_in05 137 71
+yuno_in05 31 167 yuno_in05 50 88
+yuno_in05 50 88 yuno_in02 82 14
+yuno_in05 137 71 yuno_in05 16 188
+yuno_in05 148 83 yuno_in05 165 103
+yuno_in05 153 142 yuno_in05 196 103
+yuno_in05 165 103 yuno_in05 148 83
+yuno_in05 177 9 yuno_in05 181 116
+yuno_in05 177 52 yuno_in05 181 91
+yuno_in05 181 91 yuno_in05 177 52
+yuno_in05 181 116 yuno_in05 177 9
+yuno_in05 196 103 yuno_in05 153 142
+yuno_in05 196 194 yuno_in02 82 14
+xmas 104 289 xmas_in 30 161
+xmas 119 162 xmas_in 38 89
+xmas 120 131 xmas_in 46 33
+xmas 142 239 xmas_in 94 83
+xmas 142 258 xmas_in 94 117
+xmas 143 314 xmas_dun01 205 13
+xmas 149 41 xmas_fild01 69 252
+xmas 149 239 xmas_in 104 83
+xmas 149 258 xmas_in 104 117
+xmas 173 160 xmas_in 163 93
+xmas 174 131 xmas_in 153 32
+xmas 181 169 xmas_in 179 109
+xmas 189 278 xmas_in 168 160
+xmas_dun01 129 130 xmas_dun02 129 130
+xmas_dun01 205 13 xmas 143 314
+xmas_dun02 129 130 xmas_dun01 129 130
+xmas_fild01 69 252 xmas 149 44
+xmas_fild01 90 252 xmas 149 44
+xmas_fild01 84 48 aldebaran 140 234
+xmas_in 30 161 xmas 104 289
+xmas_in 38 89 xmas 119 162
+xmas_in 46 33 xmas 120 131
+xmas_in 94 83 xmas 142 239
+xmas_in 94 117 xmas 142 258
+xmas_in 104 83 xmas 149 239
+xmas_in 104 117 xmas 149 258
+xmas_in 153 32 xmas 174 131
+xmas_in 163 93 xmas 173 160
+xmas_in 168 160 xmas 189 278
+xmas_in 179 109 xmas 181 169
+rachel 150 249 ra_temple 120 30
+rachel 81 33 ra_in01 237 198
+rachel 61 33 ra_in01 181 198
+rachel 217 55 ra_in01 250 34
+rachel 179 220 ra_in01 295 352
+rachel 103 240 ra_in01 343 193
+rachel 216 160 ra_in01 135 282
+rachel 42 87 ra_in01 171 359
+rachel 42 109 ra_in01 171 388
+rachel 83 78 ra_in01 249 266
+rachel 115 149 ra_in01 386 43
+rachel 90 189 ra_in01 192 148
+rachel 108 200 ra_in01 213 83
+ra_in01 188 189 ra_in01 263 144
+ra_in01 296 144 ra_in01 235 189
+ra_in01 175 189 ra_in01 132 189
+ra_in01 244 189 ra_in01 291 189
+ra_in01 235 21 ra_in01 187 31
+ra_in01 312 374 ra_in01 359 374
+ra_in01 291 371 ra_in01 225 380
+ra_in01 381 200 ra_in01 377 268
+ra_in01 367 255 ra_in01 326 296
+ra_in01 319 303 ra_in01 381 320
+ra_in01 178 370 ra_in01 113 385
+ra_in01 165 369 ra_in01 122 334
+ra_in01 241 299 ra_in01 193 312
+ra_in01 185 303 ra_in01 194 249
+ra_in01 357 61 ra_in01 310 62
+ra_in01 297 59 ra_in01 339 116
+ra_temin 28 319 ra_san01 139 139
+ra_temin 130 93 ra_temin 239 258
+ra_temin 206 93 ra_temin 312 258
+ra_temin 275 332 ra_temin 27 305
+ra_temin 275 226 ra_temsky 99 11
+ra_temsky 99 118 ra_temsky 99 140
+ra_temsky 112 143 ra_temsky 141 139
+ra_temsky 87 143 ra_temsky 58 139
+ra_temple 120 22 rachel 150 243
+ra_temple 119 180 ra_temin 169 23
+ra_in01 237 202 rachel 81 38
+ra_in01 181 202 rachel 61 38
+ra_in01 250 38 rachel 217 60
+ra_in01 295 348 rachel 179 215
+ra_in01 339 193 rachel 98 238
+ra_in01 135 286 rachel 216 164
+ra_in01 171 355 rachel 42 82
+ra_in01 172 392 rachel 42 114
+ra_in01 249 262 rachel 83 73
+ra_in01 386 39 rachel 115 144
+ra_in01 192 152 rachel 90 193
+ra_in01 213 79 rachel 108 195
+ra_in01 259 144 ra_in01 184 189
+ra_in01 231 189 ra_in01 292 144
+ra_in01 136 189 ra_in01 179 189
+ra_in01 287 189 ra_in01 240 189
+ra_in01 183 31 ra_in01 239 21
+ra_in01 355 374 ra_in01 308 374
+ra_in01 221 380 ra_in01 287 371
+ra_in01 381 268 ra_in01 387 200
+ra_in01 330 296 ra_in01 371 255
+ra_in01 381 324 ra_in01 319 299
+ra_in01 109 385 ra_in01 174 370
+ra_in01 126 334 ra_in01 169 369
+ra_in01 197 312 ra_in01 245 299
+ra_in01 194 245 ra_in01 190 302
+ra_in01 314 62 ra_in01 361 61
+ra_in01 339 120 ra_in01 297 63
+ra_temin 169 18 ra_temple 119 175
+ra_temin 239 253 ra_temin 130 88
+ra_temin 312 253 ra_temin 206 88
+ra_temin 27 299 ra_temin 275 328
+ra_temsky 99 8 ra_temin 275 231
+ra_temsky 99 135 ra_temsky 99 113
+ra_temsky 137 139 ra_temsky 109 143
+ra_temsky 62 139 ra_temsky 91 143
+rachel 25 125 ra_fild11 353 226
+rachel 275 125 ra_fild12 40 226
+rachel 130 21 ve_fild02 195 377
+que_rachel 130 93 que_rachel 239 258
+que_rachel 206 93 que_rachel 312 258
+que_rachel 275 332 que_rachel 27 305
+que_rachel 239 253 que_rachel 130 88
+que_rachel 312 253 que_rachel 206 88
+que_rachel 27 299 que_rachel 275 328
+ra_in01 309 70 rachel 108 175
+rachel 105 171 ra_in01 309 65
+ra_in01 375 109 rachel 116 154
+rachel 116 158 ra_in01 375 114
+ra_temin 275 243 ra_temin 131 131
+ra_fild01 233 333 ice_dun01 157 15
+ra_fild01 306 38 ra_fild04 322 371
+ra_fild04 322 378 ra_fild01 306 43
+ra_fild04 362 351 ra_fild05 39 353
+ra_fild05 33 353 ra_fild04 356 351
+ra_fild05 27 13 ra_fild09 30 337
+ra_fild09 29 343 ra_fild05 31 17
+ra_fild04 263 54 ra_fild08 287 365
+ra_fild08 287 370 ra_fild04 263 60
+ra_fild09 27 238 ra_fild08 360 234
+ra_fild08 368 234 ra_fild09 35 238
+ra_fild04 23 176 ra_fild03 370 172
+ra_fild03 374 168 ra_fild04 29 176
+ra_fild05 348 274 ra_fild06 24 277
+ra_fild06 19 277 ra_fild05 341 273
+ra_fild06 294 21 lhz_fild01 296 376
+lhz_fild01 296 382 ra_fild06 298 25
+ra_fild12 36 225 rachel 270 125
+ra_fild08 165 29 ra_fild12 149 369
+ra_fild12 149 374 ra_fild08 165 36
+ra_fild12 303 27 ra_fild13 295 341
+ra_fild13 295 346 ra_fild12 303 33
+ra_fild11 360 226 rachel 30 125
+ra_fild11 21 290 ra_fild10 379 283
+ra_fild10 384 287 ra_fild11 28 290
+ra_fild11 202 335 ra_fild07 215 32
+ra_fild07 215 27 ra_fild11 201 329
+ra_fild07 168 353 ra_fild02 171 45
+ra_fild02 168 36 ra_fild07 168 349
+ra_fild02 373 275 ra_fild03 28 294
+ra_fild03 23 294 ra_fild02 367 270
+ra_san02 213 280 ra_san01 140 19
+ra_san03 123 283 ra_san01 140 19
+ra_san04 119 104 ra_san01 140 19
+ra_san03 279 21 ra_san05 282 149
+ra_san03 85 15 ra_san04 203 216
+ra_san04 203 221 ra_san03 85 20
+ra_san04 120 48 ra_san05 150 282
+ra_san05 150 7 ra_temple 119 153
+ra_san02 289 149 ra_san03 10 149
+ra_san03 5 149 ra_san02 284 149
+ra_san02 213 4 ra_san04 35 216
+ra_san04 35 221 ra_san02 213 9
+ra_san02 30 21 ra_san05 14 149
+ra_san01 139 139 ra_temin 27 314
+tha_scene01 144 198 tha_t01 149 38
+tha_t01 149 33 hu_fild01 140 158
+tha_t01 150 150 tha_t02 149 130
+tha_t02 149 125 tha_t01 150 145
+tha_t03 217 165 tha_t02 227 157
+tha_t03 59 140 tha_t04 60 142
+tha_t04 60 137 tha_t03 59 135
+tha_t04 81 36 tha_t05 62 8
+tha_t05 62 157 tha_t05 213 97
+tha_t05 208 97 tha_t05 62 162
+tha_t05 185 235 tha_t06 206 11
+thana_step 174 288 tha_t08 28 43
+thana_step 173 372 tha_t07 30 166
+tha_t07 114 166 thana_step 69 287
+tha_t08 114 43 thana_step 30 223
+thana_step 32 166 tha_t09 20 96
+tha_t09 92 146 thana_step 180 223
+thana_step 182 166 tha_t10 155 100
+tha_t10 170 138 thana_step 14 73
+thana_step 15 15 tha_t11 50 17
+tha_t11 92 36 thana_step 180 73
+thana_step 181 15 tha_t12 115 16
+ve_fild03 168 240 thor_v01 21 229
+thor_v01 21 224 ve_fild03 168 235
+thor_v01 201 37 thor_v02 78 203
+thor_v02 192 60 thor_v03 35 262
+thor_v02 73 203 thor_v01 196 37
+thor_v03 30 262 thor_v02 187 58
+veins 230 166 ve_in 251 287
+ve_in 251 283 veins 230 161
+ve_in 261 315 ve_in 177 297
+ve_in 177 293 ve_in 261 311
+veins 150 179 ve_in 349 223
+ve_in 349 219 veins 150 175
+ve_in 347 250 ve_in 282 223
+ve_in 286 223 ve_in 352 250
+veins 114 278 ve_in 183 207
+ve_in 183 203 veins 110 278
+veins 128 270 ve_in 201 211
+ve_in 206 211 veins 128 266
+veins 130 238 ve_in 99 219
+ve_in 99 215 veins 127 235
+ve_in 76 229 ve_in 75 160
+ve_in 71 160 ve_in 72 229
+veins 148 220 ve_in 252 127
+ve_in 256 127 veins 150 215
+ve_in 224 115 ve_in 313 114
+ve_in 309 114 ve_in 220 115
+veins 197 260 ve_in 351 321
+ve_in 351 317 veins 197 255
+veins 88 173 ve_in 77 295
+ve_in 77 291 veins 88 168
+ve_in 98 299 ve_in 124 372
+ve_in 128 372 ve_in 102 299
+veins 337 231 ve_in 194 374
+ve_in 194 369 veins 331 231
+veins 267 230 ve_in02 17 19
+ve_in02 13 19 veins 269 225
+veins 143 25 ve_fild07 147 366
+ve_fild07 147 371 veins 146 28
+veins 218 361 ve_fild06 148 225
+ve_fild06 153 220 veins 218 355
+ve_fild01 366 267 ve_fild02 36 263
+ve_fild01 184 20 ve_fild04 174 334
+ra_fild11 233 27 ve_fild01 243 363
+ve_fild01 243 368 ra_fild11 232 32
+ve_fild01 350 92 ve_fild02 78 133
+ra_fild13 29 308 ve_fild02 380 308
+ve_fild02 385 308 ra_fild13 34 308
+ve_fild02 195 382 rachel 130 25
+ve_fild02 31 263 ve_fild01 361 267
+ve_fild02 73 133 ve_fild01 345 92
+ve_fild03 355 223 ve_fild04 49 249
+ve_fild03 222 43 ve_fild05 200 325
+ve_fild04 174 339 ve_fild01 184 25
+ve_fild04 44 249 ve_fild03 350 220
+ve_fild04 115 50 ve_fild06 80 183
+ve_fild05 200 330 ve_fild03 222 48
+ve_fild05 359 192 ve_fild06 80 183
+ve_fild06 153 220 veins 218 355
+ve_fild06 81 177 ve_fild04 115 55
+ve_fild06 81 177 ve_fild05 354 191
+ve_fild07 147 371 veins 146 28
+yuno_fild06 369 136 hu_fild04 28 126
+hu_fild04 26 126 yuno_fild06 367 136
+yuno_fild06 149 369 hu_fild01 139 37
+hu_fild01 139 35 yuno_fild06 151 369
+hu_fild04 381 187 hu_fild05 34 202
+hu_fild05 32 202 hu_fild04 379 187
+hu_fild05 91 42 hu_fild07 80 369
+hu_fild07 80 371 hu_fild05 91 44
+hu_fild07 35 351 yuno_fild02 384 338
+yuno_fild02 384 340 hu_fild07 37 351
+hu_fild07 56 36 yuno_fild09 47 375
+yuno_fild09 47 377 hu_fild07 56 38
+hu_fild07 226 36 yuno_fild09 220 372
+yuno_fild09 220 374 hu_fild07 226 38
+abbey01 51 9 nameless_n 160 184
+abbey01 87 122 abbey01 13 201
+abbey01 13 204 abbey01 88 118
+abbey01 321 102 abbey02 149 11
+abbey02 149 8 abbey01 321 99
+abbey02 149 290 abbey03 119 8
+abbey03 119 5 abbey02 149 287
+abyss_01 267 274 hu_fild05 192 207
+abyss_01 26 23 abyss_02 275 270
+abyss_02 278 270 abyss_01 26 26
+abyss_02 145 281 abyss_03 116 27
+abyss_03 116 24 abyss_02 145 278
+einbroch 92 280 airplane 224 64
+einbroch 64 234 airport 138 51
+airport 142 61 einbroch 62 246
+airport 124 13 airport 19 21
+airport 19 18 airport 122 16
+airport 161 13 airport 47 21
+airport 47 18 airport 163 16
+airport 143 14 einbroch 64 204
+einbroch 64 207 airport 143 17
+lhz_airport 125 14 lhz_airport 19 20
+lhz_airport 19 18 lhz_airport 123 14
+lhz_airport 160 14 lhz_airport 48 20
+lhz_airport 48 18 lhz_airport 162 14
+lighthalzen 267 76 lhz_airport 143 15
+lhz_airport 143 13 lighthalzen 265 76
+lhz_airport 143 63 lighthalzen 296 76
+lighthalzen 294 76 lhz_airport 143 60
+lighthalzen 308 76 airplane 224 64
+y_airport 125 14 y_airport 19 20
+y_airport 19 18 y_airport 123 14
+y_airport 160 14 y_airport 48 20
+y_airport 48 18 y_airport 162 14
+yuno 53 214 y_airport 143 23
+y_airport 143 16 yuno 52 207
+yuno 47 240 y_airport 143 54
+yuno 59 240 y_airport 143 54
+airplane 208 53 airplane 239 160
+airplane 245 160 airplane 214 54
+airplane_01 254 54 airplane_01 91 67
+airplane_01 87 67 airplane_01 250 54
+airplane_01 208 53 airplane_01 239 160
+airplane_01 245 160 airplane_01 214 54
+airplane_01 104 199 airplane_01 105 72
+airplane_01 103 72 airplane_01 102 199
+airplane_01 104 176 airplane_01 105 52
+airplane_01 103 52 airplane_01 102 176
+ein_in01 265 104 einbech 141 112
+einbech 256 109 ein_in01 148 153
+ein_in01 144 153 einbech 253 109
+einbroch 132 79 ein_in01 17 213
+ein_in01 13 213 einbroch 129 79
+ein_in01 81 198 einbroch 179 70
+einbroch 179 73 ein_in01 81 203
+einbroch 214 263 einbroch 233 315
+einbroch 233 312 einbroch 214 260
+einbroch 250 263 einbroch 269 315
+einbroch 269 312 einbroch 250 260
+einbroch 216 214 ein_in01 108 17
+ein_in01 108 13 einbroch 216 211
+einbroch 257 199 ein_in01 198 224
+ein_in01 195 224 einbroch 254 199
+ein_in01 211 216 ein_in01 274 218
+ein_in01 271 218 ein_in01 208 216
+ein_in01 211 232 ein_in01 274 232
+ein_in01 271 232 ein_in01 208 232
+ein_in01 274 246 ein_in01 273 276
+ein_in01 273 273 ein_in01 274 243
+ein_in01 264 246 ein_in01 231 276
+ein_in01 231 273 ein_in01 264 243
+ein_in01 274 203 ein_in01 274 173
+ein_in01 274 176 ein_in01 274 206
+ein_in01 264 203 ein_in01 232 173
+ein_in01 232 176 ein_in01 264 206
+ein_in01 284 224 ein_in01 177 277
+ein_in01 180 277 ein_in01 280 224
+einbroch 278 233 ein_in01 107 95
+ein_in01 103 95 einbroch 275 233
+ein_in01 126 88 ein_in01 100 139
+ein_in01 100 142 ein_in01 123 85
+einbroch 290 222 ein_in01 121 80
+ein_in01 121 77 einbroch 290 219
+einbroch 129 229 ein_in01 14 147
+ein_in01 11 147 einbroch 126 229
+ein_in01 286 25 einbroch 54 52
+einbroch 255 107 ein_in01 14 17
+ein_in01 14 14 einbroch 255 110
+ein_in01 39 36 ein_in01 35 83
+ein_in01 39 85 ein_in01 36 36
+ein_fild07 382 263 yuno_fild11 30 266
+ein_fild04 20 251 ein_fild03 361 257
+ein_fild03 363 257 ein_fild04 22 251
+ein_fild04 14 215 ein_fild03 359 219
+ein_fild03 361 219 ein_fild04 16 215
+ein_fild04 14 205 ein_fild03 359 204
+ein_fild03 361 204 ein_fild04 16 205
+ein_fild03 142 32 lhz_fild02 166 365
+lhz_fild02 166 367 ein_fild03 142 34
+lhz_fild02 164 37 lhz_fild03 158 347
+lhz_fild03 158 349 lhz_fild02 164 39
+lhz_fild03 363 283 ein_fild08 25 275
+ein_fild08 23 275 lhz_fild03 361 283
+yuno 23 127 sch_gld 260 92
+sch_gld 355 89 yuno 26 127
+sch_gld 293 91 schg_cas01 276 243
+schg_cas01 276 241 sch_gld 293 95
+sch_gld 288 256 schg_cas02 340 73
+schg_cas02 340 69 sch_gld 288 253
+sch_gld 98 182 schg_cas03 338 332
+schg_cas03 338 335 sch_gld 98 187
+sch_gld 138 96 schg_cas04 276 243
+schg_cas04 276 241 sch_gld 138 93
+sch_gld 63 315 schg_cas05 276 243
+schg_cas05 276 241 sch_gld 69 315
+hugel 95 33 hu_fild06 200 367
+hugel 155 114 hu_in01 211 177
+hu_in01 211 173 hugel 159 114
+hu_in01 162 228 hu_in01 199 219
+hu_in01 195 219 hu_in01 159 228
+hu_in01 162 168 hu_in01 200 192
+hu_in01 195 192 hu_in01 158 168
+hugel 153 153 hu_in01 287 231
+hu_in01 287 227 hugel 153 149
+hu_in01 263 252 hu_in01 360 253
+hu_in01 365 253 hu_in01 268 252
+hugel 92 167 hu_in01 246 363
+hu_in01 246 359 hugel 92 163
+hu_in01 244 315 hu_in01 243 388
+hu_in01 248 388 hu_in01 250 315
+hu_in01 229 313 hu_in01 164 315
+hu_in01 168 315 hu_in01 234 313
+hu_in01 168 307 hu_in01 167 376
+hu_in01 168 379 hu_in01 168 311
+hugel 85 181 hu_in01 231 303
+hu_in01 231 301 hugel 83 181
+hugel 70 157 hu_in01 110 373
+hu_in01 110 369 hugel 73 155
+hu_in01 108 390 hu_in01 107 322
+hu_in01 114 322 hu_in01 113 389
+hugel 91 104 hu_in01 30 304
+hu_in01 30 299 hugel 95 103
+hu_in01 34 318 hu_in01 34 251
+hu_in01 34 246 hu_in01 34 313
+hugel 104 79 hu_in01 235 107
+hu_in01 231 107 hugel 101 77
+hu_in01 268 123 hu_in01 265 36
+hu_in01 265 42 hu_in01 262 123
+hu_in01 37 90 hugel 52 95
+hu_in01 15 70 hu_in01 15 25
+hu_in01 15 29 hu_in01 15 74
+hu_in01 15 151 hu_in01 15 104
+hugel 206 228 hu_in01 381 368
+hu_in01 381 363 hugel 209 224
+hu_in01 380 319 hu_in01 382 388
+hu_in01 388 388 hu_in01 385 319
+hu_in01 177 90 hugel 52 95
+hu_in01 107 90 hugel 52 95
+hu_in01 85 108 hu_in01 85 155
+hu_in01 85 151 hu_in01 85 104
+hu_in01 85 70 hu_in01 85 25
+hu_in01 85 29 hu_in01 85 74
+hugel 129 66 hu_in01 350 107
+hu_in01 345 107 hugel 126 64
+hu_in01 381 118 hu_in01 379 173
+hu_in01 379 178 hu_in01 376 118
+hugel 153 216 hu_in01 305 379
+hu_in01 301 379 hugel 147 216
+hu_in01 314 386 hu_in01 312 322
+hu_in01 307 322 hu_in01 310 386
+hugel 80 230 hu_in01 24 363
+hu_in01 24 361 hugel 82 230
+hugel 55 208 que_bingo 49 9
+que_bingo 49 7 hugel 57 207
+que_bingo 39 34 que_bingo 34 109
+que_bingo 34 105 que_bingo 38 28
+que_bingo 53 34 que_bingo 49 71
+que_bingo 48 66 que_bingo 53 29
+hugel 209 109 odin_tem01 100 146 800 c r1 n
+odin_temp01 93 146 hugel 206 109 c r1 n
+ein_fild04 343 293 ein_fild05 80 294
+ein_fild05 76 294 ein_fild04 336 292
+ein_fild05 376 183 ein_fild06 47 166
+ein_fild06 42 171 ein_fild05 371 183
+ein_fild02 357 251 yuno_fild04 38 280
+yuno_fild04 33 279 ein_fild02 350 250
+ein_fild01 349 369 yuno_fild05 43 346
+yuno_fild05 41 350 ein_fild01 345 367
+ein_fild01 106 34 ein_fild02 109 358
+ein_fild02 108 364 ein_fild01 106 40
+ein_fild01 234 34 ein_fild02 258 343
+ein_fild02 257 350 ein_fild01 231 40
+ein_fild02 170 29 ein_fild05 172 366
+ein_fild05 172 371 ein_fild02 170 37
+hu_fild01 366 185 hu_fild02 22 168
+hu_fild02 17 168 hu_fild01 361 189
+hu_fild04 47 372 hu_fild02 40 27
+hu_fild02 40 22 hu_fild04 48 368
+hu_fild04 294 379 hu_fild02 280 31
+hu_fild02 283 28 hu_fild04 289 376
+hu_fild05 284 356 hu_fild03 288 26
+hu_fild03 288 19 hu_fild05 276 346
+hu_fild02 374 339 hu_fild03 24 337
+hu_fild03 20 338 hu_fild02 370 339
+hu_fild02 378 162 hu_fild03 30 163
+hu_fild03 25 163 hu_fild02 373 160
+yuno_fild09 377 184 yuno_fild10 44 183
+yuno_fild10 39 183 yuno_fild09 371 184
+ice_dun01 157 10 ra_fild01 233 327
+ice_dun01 146 161 ice_dun02 151 139
+ice_dun02 151 145 ice_dun01 146 157
+ice_dun02 150 285 ice_dun03 149 24
+ice_dun03 149 19 ice_dun02 150 280
+ice_dun04 33 140 ice_dun03 149 130
+kh_dun01 3 234 yuno_fild08 74 174
+kh_dun01 232 226 kh_dun01 13 12
+kh_dun01 63 7 kh_dun01 227 176
+kh_dun01 232 176 kh_dun01 63 12
+kh_school 76 156 yuno_fild08 155 189
+kh_school 30 125 kh_school 67 14
+kh_school 71 14 kh_school 36 125
+kh_school 35 133 kh_school 148 16
+kh_school 153 16 kh_school 39 136
+kh_school 30 155 kh_school 182 116
+kh_school 186 117 kh_school 35 155
+kh_school 35 176 kh_school 148 56
+kh_school 153 56 kh_school 40 176
+kh_school 30 185 kh_school 67 74
+kh_school 71 74 kh_school 35 184
+kh_vila 79 11 yuno_fild02 92 208
+kh_vila 71 38 kh_vila 42 38
+kh_vila 46 38 kh_vila 75 38
+kh_vila 71 54 kh_vila 42 54
+kh_vila 46 54 kh_vila 75 54
+kh_vila 34 66 kh_vila 20 108
+kh_vila 20 103 kh_vila 34 61
+kh_vila 84 66 kh_vila 44 107
+kh_vila 44 103 kh_vila 84 62
+kh_vila 32 128 kh_vila 23 171
+kh_vila 22 167 kh_vila 32 123
+kh_vila 90 47 kh_vila 119 47
+kh_vila 115 47 kh_vila 85 47
+kh_vila 126 75 kh_vila 180 176
+kh_vila 180 171 kh_vila 126 70
+kh_vila 175 71 kh_vila 136 64
+kh_vila 191 19 yuno_fild02 74 215
+lighthalzen 188 204 kh_mansion 84 49
+kh_mansion 88 50 lighthalzen 188 199
+kh_mansion 21 11 kh_mansion 72 49
+kh_rossi 15 92 yuno 270 139
+kh_rossi 35 87 kh_rossi 27 37
+kh_rossi 27 42 kh_rossi 35 91
+kh_rossi 63 87 kh_rossi 99 38
+kh_rossi 99 42 kh_rossi 63 91
+kh_rossi 90 87 kh_rossi 168 30
+kh_rossi 168 34 kh_rossi 90 90
+kh_rossi 35 98 kh_rossi 27 147
+kh_rossi 27 143 kh_rossi 35 94
+kh_rossi 90 101 kh_rossi 282 64
+kh_rossi 42 26 kh_rossi 92 25
+kh_rossi 87 25 kh_rossi 36 26
+kh_rossi 282 60 kh_rossi 90 96
+kh_rossi 222 68 kh_rossi 22 277
+kh_rossi 22 273 kh_rossi 222 64
+kh_rossi 248 68 kh_rossi 88 277
+kh_rossi 88 273 kh_rossi 248 64
+kh_rossi 222 25 kh_rossi 22 219
+kh_rossi 22 222 kh_rossi 222 29
+kh_rossi 248 25 kh_rossi 88 217
+kh_rossi 88 222 kh_rossi 248 29
+kh_rossi 259 46 kh_rossi 224 234
+kh_rossi 228 234 kh_rossi 263 46
+kh_rossi 220 231 kh_rossi 260 186
+kh_rossi 260 190 kh_rossi 220 234
+kh_rossi 204 231 kh_rossi 204 186
+kh_rossi 204 190 kh_rossi 204 234
+kh_rossi 188 231 kh_rossi 148 186
+kh_rossi 148 190 kh_rossi 188 234
+kh_rossi 188 238 kh_rossi 148 283
+kh_rossi 148 279 kh_rossi 188 235
+kh_rossi 204 238 kh_rossi 204 283
+kh_rossi 204 279 kh_rossi 204 235
+kh_rossi 220 238 kh_rossi 261 283
+kh_rossi 260 279 kh_rossi 220 235
+lhz_fild01 210 18 lighthalzen 214 324
+lighthalzen 214 329 lhz_fild01 210 23
+lhz_fild01 367 222 lhz_fild02 36 221
+lhz_fild02 29 219 lhz_fild01 361 222
+mosk_fild02 190 256 mosk_dun01 190 46
+mosk_dun01 190 43 mosk_fild02 190 253
+mosk_dun01 200 272 mosk_dun02 163 31
+mosk_dun02 165 28 mosk_dun01 200 269
+mosk_dun02 266 117 mosk_dun03 33 136
+mosk_dun03 30 133 mosk_dun02 263 118
+nameless_n 157 184 abbey01 51 12
+nameless_i 168 257 nameless_in 12 43
+nameless_in 12 40 nameless_i 168 254
+nameless_i 252 130 nameless_in 26 128
+nameless_in 23 128 nameless_i 249 130
+nameless_i 79 256 nameless_in 12 172
+nameless_in 12 169 nameless_i 82 256
+nameless_i 78 94 nameless_in 96 180
+nameless_in 96 177 nameless_i 81 96
+odin_tem01 378 182 odin_tem02 28 180
+odin_tem02 21 180 odin_tem01 373 182
+odin_tem01 383 334 odin_tem02 27 334
+odin_tem02 21 334 odin_tem01 379 334
+odin_tem02 153 349 odin_tem03 120 54
+odin_tem03 121 49 odin_tem02 154 345
+odin_tem02 261 377 odin_tem03 247 40
+odin_tem03 247 34 odin_tem02 263 372
+prontera 263 279 prt_in 227 18
+prt_in 227 15 prontera 263 275
+prt_church 115 122 prt_church 168 106
+prt_church 166 106 prt_church 112 122
+alberta 245 66 moscovia 162 56 10000 c r1 c r0 n
+moscovia 166 53 alberta 243 67 0 c r0 n
+alberta 189 151 izlude 176 182 500 c r1
+izlude 201 181 alberta 188 169 500 c r1
+hu_fild06 200 372 hugel 95 37
+hugel 95 33 hu_fild06 200 367
+hu_fild06 28 119 hu_fild05 347 130
+hu_fild05 353 126 hu_fild06 34 119
+airplane 254 54 airplane 91 67
+airplane 87 67 airplane 250 54
+yuno 96 261 airplane 244 58
+yuno 6 261 airplane_01 244 58
+izlude 149 39 izlude 182 56
+izlude 176 56 izlude 145 40
+moscovia 205 98 mosk_in 214 255
+moscovia 203 171 mosk_in 86 180
+mosk_in 222 128 mosk_in 288 118
+moscovia 223 174 mosk_in 14 246
+mosk_in 11 246 moscovia 222 176
+moscovia 229 208 mosk_in 142 178
+mosk_in 142 175 moscovia 227 207
+mosk_in 150 192 mosk_in 204 188
+mosk_in 202 188 mosk_in 148 192
+mosk_in 220 273 mosk_in 152 280
+mosk_in 21 113 mosk_in 99 123
+izlude 128 226 arena_room 100 30
+arena_room 99 24 izlude 128 220
+mosk_in 93 61 moscovia 255 140
+mosk_in 93 91 moscovia 224 232
+mosk_in 13 179 moscovia 188 193
+mosk_in 215 37 moscovia 194 78
+mosk_in 211 111 moscovia 253 179
+mosk_in 288 116 mosk_in 222 126
+mosk_in 214 252 moscovia 203 96
+mosk_in 152 272 mosk_in 220 270
+mosk_in 99 126 mosk_in 21 116
+moscovia 256 138 mosk_in 96 61
+moscovia 256 179 mosk_in 211 114
+mosk_in 89 180 moscovia 204 169
+
+# Atelier
+prontera 272 108 s_atelier 13 119
+s_atelier 10 119 prontera 268 109
+s_atelier 76 128 s_atelier 31 128
+s_atelier 31 128 s_atelier 76 125
+s_atelier 166 72 s_atelier 117 71
+s_atelier 117 71 s_atelier 171 72
+rachel 180 115 s_atelier 130 70
+s_atelier 131 75 rachel 180 118
+s_atelier 159 130 s_atelier 108 129
+s_atelier 108 129 s_atelier 159 125
+yuno 278 67 s_atelier 109 123
+s_atelier 105 123 yuno 275 67
+s_atelier 80 66 s_atelier 32 64
+s_atelier 32 64 s_atelier 80 63
+lighthalzen 41 52 s_atelier 18 75
+s_atelier 18 79 lighthalzen 41 56
+
+# Einbroch tower
+einbroch 218 198 einbroch 181 196 10 c c c c r0
+einbroch 173 229 einbroch 179 204 10 c c c c r0
+einbroch 176 172 einbroch 181 196 10 c c c c r0
+# 175 196 have several destinations, all in einbroch
+einbroch 175 196 einbroch 216 188 0 c c r0
+
+einbroch 137 199 que_ng 138 167
+que_ng 130 166 einbroch 130 197
+que_ng 178 162 que_ng 176 86
+que_ng 170 85 que_ng 182 161
+que_ng 165 137 que_ng 177 41
+que_ng 172 42 que_ng 160 139
+
+# Yuno airport
+y_airport 143 43 y_airport 148 51 1200 c r0 c r0
+y_airport 143 49 y_airport 142 40 0 c r0 c r0
+y_airport 140 63 yuno 47 244 0 c r0
+y_airport 145 63 yuno 59 244 0 c r0
+
+# Lighthalzen airport
+lhz_airport 143 43 lhz_airport 148 51 1200 c r0 c r0
+lhz_airport 143 49 lhz_airport 142 40 0 c r0 c r0
+
+# Izlude airship
+izlude 206 55 airplane_01 244 58 1200 c r0 c r0
+
+# Rachel airship
+#(portal with dialog) ra_fild12 295 208 airplane_01 245 60 1200 c r0
+
+prt_fild03 371 256 prt_monk 25 248
+prt_monk 245 137 monk_in 98 183
+monk_in 98 186 prt_monk 245 139
+monk_in 99 141 monk_in 99 100
+monk_in 99 102 monk_in 99 143
+monk_in 128 84 monk_in 161 90
+monk_in 159 90 monk_in 126 84
+monk_in 69 84 monk_in 38 92
+monk_in 40 92 monk_in 71 84
+monk_in 128 46 monk_in 161 38
+monk_in 159 38 monk_in 126 46
+monk_in 69 46 monk_in 38 38
+monk_in 40 38 monk_in 71 46
+monk_in 98 27 prt_monk 245 104
+prt_monk 245 106 monk_in 98 30
+job_monk 225 180 prt_monk 194 168 0 c
+monk_test 329 76 monk_test 259 118
+monk_test 259 115 monk_test 329 71
+monk_test 272 125 monk_test 301 127
+monk_test 298 127 monk_test 268 125
+monk_test 166 278 prt_monk 196 168
+monk_test 329 47 prt_monk 193 166
+
+# Aldebaran - alchemist guild
+aldebaran 65 53 alde_alche 20 175
+alde_alche 13 184 alde_alche 88 113
+alde_alche 88 117 alde_alche 13 181
+alde_alche 46 104 alde_alche 157 17
+alde_alche 160 17 alde_alche 50 103
+alde_alche 133 103 alde_alche 164 164
+alde_alche 158 163 alde_alche 129 103
+alde_alche 46 77 alde_alche 88 17
+alde_alche 93 17 alde_alche 50 77
+alde_alche 133 77 alde_alche 162 107
+alde_alche 158 107 alde_alche 129 77
+alde_alche 89 62 alde_alche 17 23
+alde_alche 17 29 alde_alche 89 67
+aldebaran 53 65 alde_alche 42 175
+alde_alche 42 171 aldebaran 56 68
+alde_alche 41 186 alde_alche 113 178
+alde_alche 114 183 alde_alche 42 182
+
+lhz_airport 142 13 lighthalzen 262 75
+
+# Lighthalzen Rekenber HQ - entrance
+lighthalzen 106 248 lhz_in01 116 126
+lhz_in01 116 121 lighthalzen 106 243
+
+# Lighthalzen Rekenber HQ - alchemist area entrance
+lhz_in01 35 226 lhz_in01 37 225 0 n
+lhz_in01 40 224 lhz_in01 19 129
+lhz_in01 15 129 lhz_in01 34 224
+
+lhz_in01 191 127 lhz_in01 53 129
+lhz_in01 43 114 lhz_in01 277 130
+lhz_in01 278 132 lhz_in01 43 120
+lhz_in01 43 144 lhz_in01 278 161
+lhz_in01 278 157 lhz_in01 43 139
+lighthalzen 159 133 lhz_in02 232 265
+lhz_in02 232 261 lighthalzen 158 129
+lhz_in02 250 278 lhz_in02 265 278
+lhz_in02 261 278 lhz_in02 246 278
+lhz_in01 58 129 lhz_in01 196 127
+lighthalzen 236 276 lhz_in02 133 199
+lhz_in02 129 199 lighthalzen 232 275
+lighthalzen 198 257 lhz_in02 39 28
+lhz_in02 44 28 lighthalzen 203 257
+lighthalzen 251 299 lhz_in03 97 21
+lhz_in03 93 21 lighthalzen 247 299
+
+# Rogue Guild
+
+cmd_fild07 193 117 in_rogue 379 46
+in_rogue 375 46 cmd_fild07 196 117
+in_rogue 375 33 in_rogue 380 125
+in_rogue 375 125 in_rogue 379 33
+
+#(portal with dialog) cmd_fild09 335 143 in_rogue 169 34 0 c r0 r2 r4 r0 c
+in_rogue 172 34 cmd_fild09 341 143
+# maze entrance
+#in_rogue 160 34 in_rogue x y 0 c c c c c c r0
+
+# maze exit
+in_rogue 370 320 in_rogue 378 113
+
+# Louyang Tower
+louyang 133 245 lou_in01 25 19
+lou_in01 28 19 louyang 136 245
+# bug: Kore can't use this portal properly lou_in01 25 23 lou_in01 17 19 500 c c r1 c
+
+# Mushroom Farm
+moc_ruins 141 125 job_thief1 133 333 0 c # random endpoint
+job_thief1 180 15 moc_ruins 145 117
+
+# Hugel - Lighthalzen Airship (needs additional configuration)
+#airplane 243 73 einbroch 92 278
+#airplane 243 73 hugel 181 146
+#airplane 243 73 lighthalzen 302 75
+#airplane 243 73 yuno 92 260
+new_zone01 148 112 new_zone02 100 9
+new_zone02 126 106 new_zone02 160 171
+new_zone02 73 106 new_zone02 41 172
+pay_fild07 163 17 pay_fild03 177 275
+alde_alche 19 171 aldebaran 68 56
+airplane 243 73 lighthalzen 302 75
+airport 142 13 lighthalzen 262 75
+lighthalzen 196 46 lhz_in02 282 83
+lhz_in02 274 82 lhz_in02 270 14
+lhz_in02 288 30 lighthalzen 194 35
+lighthalzen 197 36 lhz_in02 284 30
+lhz_in02 265 14 lhz_in02 269 82
+lhz_in02 282 79 lighthalzen 194 48
+
+# Eden HQ Entrace
+prontera 124 76 moc_para01 31 14 c c r0
+prontera 38 212 moc_para01 31 14 c c r0
+prontera 162 326 moc_para01 31 14 c c r0
+prontera 271 213 moc_para01 31 14 c c r0
+morocc 161 97 moc_para01 31 14 c c r0
+moc_ruins 68 164 moc_para01 31 14 c c r0
+moc_prydb1 53 126 moc_para01 31 14 c c r0
+amatsu 102 152 moc_para01 31 14 c c r0
+brasilis 194 221 moc_para01 31 14 c c r0
+geffen 132 66 moc_para01 31 14 c c r0
+geffen 196 147 moc_para01 31 14 c c r0
+payon 177 111 moc_para01 31 14 c c r0
+aldebaran 133 119 moc_para01 31 14 c c r0
+einbroch 244 200 moc_para01 31 14 c c r0
+moscovia 220 192 moc_para01 31 14 c c r0
+einbroch 55 202 moc_para01 31 14 c c r0
+yuno 144 189 moc_para01 31 14 c c r0
+lighthalzen 167 102 moc_para01 31 14 c c r0
+alberta 124 67 moc_para01 31 14 c c r0
+dewata 194 168 moc_para01 31 14 c c r0
+comodo 191 153 moc_para01 31 14 c c r0
+cmd_fild07 139 134 moc_para01 31 14 c c r0
+gonryun 162 122 moc_para01 31 14 c c r0
+umbala 96 160 moc_para01 31 14 c c r0
+ayothaya 209 169 moc_para01 31 14 c c r0
+hugel 99 167 moc_para01 31 14 c c r0
+rachel 125 144 moc_para01 31 14 c c r0
+veins 214 122 moc_para01 31 14 c c r0
+alberta_in 75 39 moc_para01 31 14 c c r0
+alberta 27 238 moc_para01 31 14 c c r0
+geffen_in 160 104 moc_para01 31 14 c c r0
+payon_in02 58 58 moc_para01 31 14 c c r0
+izlude 134 97 moc_para01 31 14 c c r0
+izlude_in 68 162 moc_para01 31 14 c c r0
+dicastes01 186 206 moc_para01 31 14 c r0 n
+mora 41 133 moc_para01 31 14 c r0 n
+mora 108 117 moc_para01 31 14 c r0 n
+harboro1 90 221 moc_para01 31 14 c r0 n
+
+# Eden HQ
+moc_para01 47 39 moc_para01 106 14 c r0
+moc_para01 107 12 moc_para01 47 37
+moc_para01 100 27 moc_para01 47 85
+moc_para01 49 86 moc_para01 103 27
+moc_para01 113 32 moc_para01 105 92
+moc_para01 102 92 moc_para01 111 33
+moc_para01 57 27 moc_para01 162 26
+moc_para01 158 26 moc_para01 55 27
+#moc_para01 48 16 moc_para01 48 164
+moc_para01 48 16 moc_paraup 48 164
+#moc_para01 47 161 moc_para01 47 18
+moc_paraup 47 161 moc_para01 47 18
+#moc_para01 41 187 moc_para01 179 93
+moc_paraup 41 187 moc_paraup 179 93
+#moc_para01 179 90 moc_para01 41 185
+moc_paraup 179 90 moc_paraup 41 185
+
+# Port Malaya
+alberta 237 71 malaya 271 55 10000 c r1 n
+ma_fild01 37 272 malaya 370 277
+ma_in01 105 92 malaya 309 70
+ma_in01 126 17 malaya 261 240
+ma_in01 24 77 malaya 178 211
+ma_in01 33 152 malaya 300 211
+ma_in01 86 16 malaya 112 212
+ma_in01 9 24 malaya 299 167
+malaya 112 212 ma_in01 83 16
+malaya 178 211 ma_in01 24 80
+malaya 238 206 moc_para01 31 14 0 c r0
+malaya 261 240 ma_in01 126 20
+malaya 276 55 alberta 239 68 0 c r0 n
+malaya 299 167 ma_in01 12 24
+malaya 300 211 ma_in01 36 152
+malaya 309 70 ma_in01 108 92
+malaya 370 277 ma_fild01 40 272
+ma_fild02 248 33 ma_fild01 266 359
+ma_fild01 266 359 ma_fild02 248 36
+ma_scene01 140 80 ma_fild01 288 52
+ma_fild01 288 52 ma_scene01 142 78
+#Need to finish nurse quest to get access to the hospital
+malaya 48 76 ma_dun01 33 110 0 r0 n
+ma_dun01 35 108 malaya 58 76 0 c r0 n
+
+# Malangdo
+mal_in01 18 161 malangdo 112 167
+malangdo 112 167 mal_in01 17 163
+mal_in01 75 174 mal_in01 18 173
+mal_in01 18 173 mal_in01 72 173
+mal_in01 124 175 mal_in01 73 170
+mal_in01 73 170 mal_in01 124 172
+mal_in01 30 119 malangdo 113 151
+malangdo 113 151 mal_in01 28 118
+mal_in01 67 118 mal_in01 20 119
+mal_in01 20 119 mal_in01 65 117
+mal_in01 38 217 malangdo 119 137
+malangdo 119 137 mal_in01 36 216
+mal_in01 75 222 mal_in01 11 218
+mal_in01 11 218 mal_in01 76 220
+mal_in01 140 213 mal_in01 79 219
+mal_in01 79 219 mal_in01 140 216
+mal_in01 18 78 malangdo 135 109
+malangdo 135 109 mal_in01 19 76
+mal_in01 67 66 mal_in01 18 67
+mal_in01 18 67 mal_in01 65 65
+mal_dun01 30 230 malangdo 73 239
+malangdo 73 239 mal_dun01 33 230
+mal_in01 163 13 malangdo 135 276
+malangdo 135 276 mal_in01 164 15
+mal_in01 9 16 malangdo 240 150
+malangdo 240 150 mal_in01 11 17
+mal_in01 67 12 mal_in01 20 15
+mal_in01 20 15 mal_in01 65 11
+mal_in02 60 61 malangdo 162 163
+malangdo 162 163 mal_in02 58 61
+mal_in02 34 60 mal_in02 51 60
+mal_in02 51 60 mal_in02 31 60
+mal_in02 64 87 mal_in02 63 66
+mal_in02 63 66 mal_in02 63 89
+mal_in02 63 35 mal_in02 63 53
+mal_in02 63 53 mal_in02 63 33
+mal_in02 102 87 mal_in02 101 66
+mal_in02 101 66 mal_in02 101 89
+mal_in02 101 35 mal_in02 101 53
+mal_in02 101 53 mal_in02 101 33
+mal_in02 140 87 mal_in02 137 66
+mal_in02 137 66 mal_in02 139 89
+mal_in02 139 35 mal_in02 137 53
+mal_in02 137 53 mal_in02 139 33
+mal_in02 159 61 mal_in02 142 60
+mal_in02 142 60 mal_in02 162 61
+
+# following is a single warp, depends of entrance npc used
+# currently unsupported, do not enable that
+#moc_para01 30 10 prontera 116 72
+
+#------------------------------
+xmas 139 307 evt_xmas 129 129 0 c r1
+
+#EP-14.2
+# mora <-> bif_fild02
+mora 182 74 bif_fild02 286 327
+bif_fild02 285 332 mora 179 74 0 c r0 n 
+
+#  bif_fild02 <-> ecl_fild01
+bif_fild02 292 351 ecl_fild01 205 76
+ecl_fild01 207 72 bif_fild02 294 350
+
+# ecl_fild01 <-> ecl_tdun0.*
+ecl_fild01 182 82 ecl_tdun01 60 13
+ecl_tdun01 61 11 ecl_fild01 182 85
+ecl_tdun01 67 106 ecl_tdun02 60 88
+ecl_tdun02 60 90 ecl_tdun01 70 105
+ecl_tdun02 52 9 ecl_tdun03 47 13
+ecl_tdun03 49 11 ecl_tdun02 50 11
+ecl_tdun03 50 46 ecl_tdun04 26 24
+ecl_tdun04 26 26 ecl_tdun03 50 44
+ecl_tdun04 34 17 ecl_fild01 183 73
+ecl_fild01 183 70 ecl_tdun04 33 19
+
+# eclage <-> ecl_fild01
+eclage 98 26 ecl_fild01 99 317
+ecl_fild01 97 322 eclage 100 28
+
+# eclage <-> ecl_in01
+eclage 299 309 ecl_in01 47 11
+ecl_in01 47 8 eclage 297 307
+
+aethra 71 132 aethra_in 127 126
+aethra 90 168 aethra_in 199 176
+aethra_in 127 122 aethra 71 132
+aethra_in 199 172 aethra 90 168
+
+ashroom 24 78 pallet 41 68
+ashroom 37 27 ashroom 90 63
+ashroom 81 56 pallet 24 44
+ashroom 90 66 ashroom 37 27
+
+pallet 24 44 ashroom 81 58
+pallet 41 68 ashroom 22 94
+pallet 51 28 ashroom 24 78
+pallet 53 49 plt_in 35 55
+
+plt_in 19 62 plt_in 114 61
+plt_in 35 52 pallet 53 49
+plt_in 111 61 plt_in 19 62
+plt_in 131 69 saladuelo 44 17
+
+saladuelo 44 17 plt_in 127 68
+
+caspen 96 205 ayo_in02 100 151
+caspen 104 265 casp_in01 174 190
+caspen 117 232 cmd_in02 178 132
+caspen 136 198 casp_auct02 40 36
+caspen 137 237 casp_in01 178 269
+caspen 151 198 casp_auct02 40 32
+caspen 170 236 ayo_in01 13 94
+caspen 181 228 casp_in01 58 182
+caspen 267 277 casp_dun01 28 43
+casp_in01 54 240 caspen 136 198
+casp_in01 58 179 caspen 181 228
+casp_in01 77 187 caspen 181 228
+casp_in01 82 187 casp_in01 73 188
+casp_in01 110 240 caspen 136 201
+casp_in01 159 205 caspen 104 265
+casp_in01 174 180 casp_in01 262 203
+casp_in01 178 264 caspen 137 237
+casp_in01 191 205 casp_in01 262 203
+casp_in01 231 203 casp_in01 159 205
+casp_in01 262 203 casp_in01 191 201
+casp_auct02 40 36 caspen 151 198
+casp_dun01 23 38 caspen 267 277
+
+#Museum
+brasilis 146 162 bra_in01 17 137
+bra_in01 17 134  brasilis 148 161
+bra_in01 50 145  bra_in01 81 143
+bra_in01 79 142  bra_in01 47 144
+bra_in01 50 171  bra_in01 82 168
+bra_in01 79 169  bra_in01 46 170
+bra_in01 138 174 bra_in01 12 183
+bra_in01 206 98  bra_in01 138 176
+
+#Inn
+brasilis 274 153 bra_in01 38 9
+bra_in01 39 7 brasilis 273 151
+bra_in01 52 27 bra_in01 85 26
+bra_in01 83 27 bra_in01 50 27
+bra_in01 9 67  bra_in01 154 22
+bra_in01 156 23 bra_in01 11 65
+bra_in01 52 67  bra_in01 87 66
+bra_in01 85 67  bra_in01 50 66
+bra_in01 31 29  bra_in01 23 70
+bra_in01 25 70  bra_in01 32 26
+bra_in01 31 74  bra_in01 148 59
+bra_in01 148 57 bra_in01 31 72
+
+#Dungeon
+bra_dun01 199 35 bra_dun02 261 263
+bra_dun02 261 265 bra_dun01 199 37
+
+#Dungeon Access
+bra_in01 144 187 bra_in01 0 206 102 c r0 n
+bra_in01 206 188 bra_dun01 87 47 0 n
+bra_dun01 87 43 bra_in01 206 185 0 n
+
+# dewata 
+dewata 44 252 dew_fild01 373 212
+dew_fild01 375 212 dewata 46 256
+dew_fild01 57 273 dew_in01 15 33
+dew_fild01 48 65 dew_dun02 302 30
+dew_dun02 305 30 dew_fild01 50 65
+
+# Lasagna
+izlude 195 213 lasagna 206 297 2000 c c r0 n
+lasagna 205 325 lasagna 193 209 2000 c c r1 n
+lasagna 205 325 malangdo 193 209 2000 c c r2 n
+lasa_fild02 348 244 lasa_dun01 24 143
+lasa_dun01 18 143 lasa_fild02 344 243
+lasa_dun_q 190 14 lasa_dun01 152 98
+lasa_dun01 157 98 lasa_dun02 22 171
+lasa_dun02 18 171 lasa_dun01 153 98
+lasa_dun02 146 58 lasa_dun03 190 18
+lasa_dun03,190,15 lasa_dun02,146 54
+lasa_fild01 134 381 lasagna 153 58
+lasagna 150 54 lasa_fild01 131 378
+lasa_fild01 341 375 lasagna 327 56
+lasagna 327 51 lasa_fild01 344 371
+lasagna 358 91 lasa_fild02 20 98
+lasa_fild02 16 98 lasagna 355 92
+lasa_in01 159 61 lasagna 68 202
+conch_in 60 61 lasagna 206 323
+conch_in 51 60 conch_in 31 60
+conch_in 34 60 conch_in 53 59
+conch_in 63 53 conch_in 63 33
+conch_in 63 35 conch_in 64 55
+conch_in 64 66 conch_in 63 89
+conch_in 63 87 conch_in 63 64
+conch_in 101 53 conch_in 101 33
+conch_in 101 35 conch_in 102 55
+conch_in 101 66 conch_in 101 89
+conch_in 102 87 conch_in 101 64
+conch_in 137 53 conch_in 139 33
+conch_in 139 35 conch_in 138 55
+conch_in 137 66 conch_in 139 89
+conch_in 140 87 conch_in 137 64
+conch_in 142 60 conch_in 162 61
+conch_in 159 61 conch_in 140 59
+
+# Rock Ridge
+alberta 240 103 harboro1 70 215 10000 c r0 n
+harboro1 60 215 alberta 172 131 c r0 n
+harboro1 241 218 har_in01 18 18
+harboro1 362 206 rockrdg1 37 246
+rockmi1 247 16 rockrdg2 304 350
+rockrdg2 304 350 rockmi1 247 19
+harboro1 312 193 har_in01 26 87
+har_in01 26 90 harboro1 312 193
+har_in01 18 15 harboro1 241 218
+har_in01 34 28 harboro1 241 218
+har_in01 99 30 har_in01 34 31
+har_in01 34 28 har_in01 99 27
+rockrdg1 33 246 harboro1 362 206
+rockrdg1 371 206 rockrdg2 31 207
+rockrdg2 27 207 rockrdg1 371 206


### PR DESCRIPTION
Prontera kafra lady is not at 29 207 anymore.
Her location is 35 208, check the following error log.
```
Location: Prontera City, Capitol of Rune-Midgarts (prontera) : (baseName: prontera) : 40, 196
NPC Exists: Kafra Employee (35, 208) (ID 51166) - (0)
Player Merchance (5) uses effect: Magiccircle
Portal Exists: Unknown #50844 (25, 203) - (0)
NPC Exists: Eden Teleport Officer#3 (38, 212) (ID 51823) - (2)
Failed to teleport using NPC at prontera (29,207).
NPC error: Could not find an NPC at location (29,207)..
Retrying for the 1 time...
Failed to teleport using NPC at prontera (29,207).
NPC error: Could not find an NPC at location (29,207)..
Retrying for the 2 time...
Failed to teleport using NPC at prontera (29,207).
NPC error: Could not find an NPC at location (29,207)..
Retrying for the 3 time...
Failed to teleport using NPC at prontera (29,207).
NPC error: Could not find an NPC at location (29,207)..
Retrying for the 4 time...
Failed to teleport using NPC at prontera (29,207).
NPC error: Could not find an NPC at location (29,207)..
Failed to teleport using NPC at prontera (29,207) after 5 tries, ignoring NPC and recalculating route.
```