### PR TITLE
Cerroected char_delete2_accept packet

### DIFF
--- a/src/Network/Send/idRO.pm
+++ b/src/Network/Send/idRO.pm
@@ -36,6 +36,7 @@ sub new {
 		skill_use_location 0366
 		party_setting 07D7
 		buy_bulk_vender 0801
+		char_delete2_accept 098F
 	);
 	$self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
 	


### PR DESCRIPTION
Fixed cannot delete character on idRO, it's using `098F` packet handle for `char_delete2_accept`

---
it was like that since #97