### PR TITLE
Strip mid-line comments in most control files

### DIFF
--- a/src/FileParsers.pm
+++ b/src/FileParsers.pm
@@ -228,6 +228,13 @@ sub parseConfigFile {
 		$line =~ s/[\r\n]//g;	# Remove line endings
 		$line =~ s/^[\t\s]*//;	# Remove leading tabs and whitespace
 		$line =~ s/\s+$//g;	# Remove trailing whitespace
+		
+		if (index($line, '#') != -1) {
+			warning T("Mid-line comments are not allowed in this file and therefore might cause problems.\n"), "parseConfigFile", 5;
+			warning T("If the '#' found is not a comment, this can be ignored.\n"), "parseConfigFile", 5;
+			warning TF("HERE: %s", $line), "parseConfigFile", 5;
+		}
+		
 		next if ($line eq "");
 
 		if (!defined $commentBlock && $line =~ /^\/\*/) {
@@ -343,6 +350,8 @@ sub parseDataFile {
 		next if ($line =~ /^#/);
 		$line =~ s/[\r\n]//g;
 		$line =~ s/\s+$//g;
+		$line =~ s/#.*// if ($file eq "routeweights.txt");
+		next unless length $line;
 		($key, $value) = $line =~ /([\s\S]*) ([\s\S]*?)$/;
 		if ($key ne "" && $value ne "") {
 			$$r_hash{$key} = $value;
@@ -363,6 +372,8 @@ sub parseDataFile_lc {
 		next if ($line =~ /^#/);
 		$line =~ s/[\r\n]//g;
 		$line =~ s/\s+$//g;
+		$line =~ s/#.*// if ($file eq "pickupitems.txt" or $file eq "arrowcraft.txt");
+		next unless length $line;
 		($key, $value) = $line =~ /([\s\S]*) ([\s\S]*?)$/;
 		if ($key ne "" && $value ne "") {
 			$$r_hash{lc($key)} = $value;
@@ -447,6 +458,10 @@ sub parseShopControl {
 			$shop->{title_line} = $line;
 			next;
 		}
+		
+		# Strip mid-line comments after parsing the shop title, so shops can use '#' in their titles
+		$line =~ s/#.*//;
+		next unless length $line;
 
 		my ($name, $price, $amount) = split(/\t+/, $line);
 		$price =~ s/^\s+//g;
@@ -505,7 +520,8 @@ sub parseItemsControl {
 		}
 		
 		next if $key =~ /^$/;
-		$args_text =~ s/\s*#.*//;
+		$args_text =~ s/\s+//;
+		$args_text =~ s/#.*//;
 		my @args = split /\s+/, $args_text;
 		# Cache similar entries to save memory.
 		$r_hash->{$key} = $cache{$args_text} ||= { map {$_ => shift @args} qw(keep storage sell cart_add cart_get) };
@@ -546,6 +562,8 @@ sub parseMonControl {
 		next if ($line =~ /^#/);
 		$line =~ s/[\r\n]//g;
 		$line =~ s/\s+$//g;
+		$line =~ s/#.*//;
+		next unless length $line;
 
 		if ($line =~ /\t/) {
 			($key, $args) = split /\t+/, lc($line);
@@ -655,6 +673,8 @@ sub parsePriority {
 		s/\x{FEFF}//g;
 		next if (/^#/);
 		s/[\r\n]//g;
+		s/#.*//;
+		next unless length;
 		$$r_hash{lc($_)} = $pri + 1;
 		$pri--;
 	}
@@ -891,6 +911,8 @@ sub parseTimeouts {
 		$line =~ s/\x{FEFF}//g;
 		next if ($line =~ /^#/);
 		$line =~ s/[\r\n]//g;
+		$line =~ s/#.*//;
+		next unless length $line;
 
 		my ($key, $value) = $line =~ /([\s\S]+?) ([\s\S]*?)$/;
 		my @args = split (/ /, $value);

--- a/src/FileParsers.pm
+++ b/src/FileParsers.pm
@@ -350,7 +350,7 @@ sub parseDataFile {
 		next if ($line =~ /^#/);
 		$line =~ s/[\r\n]//g;
 		$line =~ s/\s+$//g;
-		$line =~ s/#.*// if ($file eq "routeweights.txt");
+		$line =~ s/\s*#.*// if ($file eq "routeweights.txt");
 		next unless length $line;
 		($key, $value) = $line =~ /([\s\S]*) ([\s\S]*?)$/;
 		if ($key ne "" && $value ne "") {
@@ -372,7 +372,7 @@ sub parseDataFile_lc {
 		next if ($line =~ /^#/);
 		$line =~ s/[\r\n]//g;
 		$line =~ s/\s+$//g;
-		$line =~ s/#.*// if ($file eq "pickupitems.txt" or $file eq "arrowcraft.txt");
+		$line =~ s/\s*#.*// if ($file eq "pickupitems.txt" or $file eq "arrowcraft.txt");
 		next unless length $line;
 		($key, $value) = $line =~ /([\s\S]*) ([\s\S]*?)$/;
 		if ($key ne "" && $value ne "") {
@@ -460,7 +460,7 @@ sub parseShopControl {
 		}
 		
 		# Strip mid-line comments after parsing the shop title, so shops can use '#' in their titles
-		$line =~ s/#.*//;
+		$line =~ s/\s*#.*//;
 		next unless length $line;
 
 		my ($name, $price, $amount) = split(/\t+/, $line);
@@ -520,8 +520,7 @@ sub parseItemsControl {
 		}
 		
 		next if $key =~ /^$/;
-		$args_text =~ s/\s+//;
-		$args_text =~ s/#.*//;
+		$args_text =~ s/\s*#.*//;
 		my @args = split /\s+/, $args_text;
 		# Cache similar entries to save memory.
 		$r_hash->{$key} = $cache{$args_text} ||= { map {$_ => shift @args} qw(keep storage sell cart_add cart_get) };
@@ -562,7 +561,7 @@ sub parseMonControl {
 		next if ($line =~ /^#/);
 		$line =~ s/[\r\n]//g;
 		$line =~ s/\s+$//g;
-		$line =~ s/#.*//;
+		$line =~ s/\s*#.*//;
 		next unless length $line;
 
 		if ($line =~ /\t/) {
@@ -673,7 +672,7 @@ sub parsePriority {
 		s/\x{FEFF}//g;
 		next if (/^#/);
 		s/[\r\n]//g;
-		s/#.*//;
+		s/\s*#.*//;
 		next unless length;
 		$$r_hash{lc($_)} = $pri + 1;
 		$pri--;
@@ -911,7 +910,7 @@ sub parseTimeouts {
 		$line =~ s/\x{FEFF}//g;
 		next if ($line =~ /^#/);
 		$line =~ s/[\r\n]//g;
-		$line =~ s/#.*//;
+		$line =~ s/\s*#.*//;
 		next unless length $line;
 
 		my ($key, $value) = $line =~ /([\s\S]+?) ([\s\S]*?)$/;


### PR DESCRIPTION
Fixes incorrect parsing in most control files (as described by #2518)

| File | Stripped |
|---|---|
| arrowcraft.txt | Yes |
| avoid.txt | No |
| buyer_shop.txt | Yes* |
| chat_resp.txt | No |
| config.txt | No** |
| consolecolors.txt | No |
| items_control.txt | Yes |
| mon_control.txt | Yes |
| overallAuth.txt | No |
| pickupitems.txt | Yes |
| poseidon.txt | No |
| priority.txt | Yes |
| responses.txt | No |
| routeweights.txt | Yes |
| shop.txt | Yes* |
| sys.txt | No |
| timeouts.txt | Yes |

*Except for shop titles
**User warned, not strippable due to player names
