### PR TITLE
add gameGuard 0 line in config.txt

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -754,3 +754,4 @@ logToFile_Errors
 logToFile_Messages
 logToFile_Warnings
 history_max 50
+gameGuard 0


### PR DESCRIPTION
in my opinion, if poseidon is a built-in tool on openkore, then we should let the config built-in on config.txt too

but since only 1 server (that i know) will use this config, make disabled by default