### PR TITLE
Add inParty and notInParty self conditions

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -4343,6 +4343,14 @@ sub checkSelfCondition {
 
 		return 0 unless inRange($amountInRange, $config{$prefix."_whenPartyMembersNear"});
 	}
+	
+	if ($config{$prefix . "_inParty"}) {
+		return 0 unless $char->{party}{joined};
+	}
+	
+	if ($config{$prefix . "_notInParty"}) {
+		return 0 if $char->{party}{joined};
+	}
 
 	my %hookArgs;
 	$hookArgs{prefix} = $prefix;


### PR DESCRIPTION
inParty triggers whenever we're in a party
notInParty triggers whenever we're not in a party

Test blocks:
![image](https://user-images.githubusercontent.com/17522256/51068369-2ea8b780-1604-11e9-9e18-7a4d404027e6.png)

Results:
![image](https://user-images.githubusercontent.com/17522256/51068371-39fbe300-1604-11e9-8167-cff6d4829455.png)
