### PR TITLE
fix party leader

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -3684,19 +3684,17 @@ sub cmdParty {
 				}
 			}
 		} elsif ($arg1 eq "leader") {
+			my $found;
 			if ($arg2 eq "") {
 				error T("Syntax Error in function 'party leader' (Change Party Leader)\n" .
 					"Usage: party leader <party member>\n");
 			} elsif ($arg2 =~ /\D/ || $args =~ /".*"/) {
-				my $found;
 				foreach (@partyUsersID) {
 					if ($char->{'party'}{'users'}{$_}{'name'} eq $arg2) {
-						$messageSender->sendPartyLeader($_);
-						$found = 1;
+						$found = $_;
 						last;
 					}
 				}
-				
 				if (!$found) {
 					error TF("Error in function 'party leader' (Change Party Leader)\n" .
 						"Can't change party leader - member %s doesn't exist.\n", $arg2);
@@ -3706,8 +3704,13 @@ sub cmdParty {
 					error TF("Error in function 'party leader' (Change Party Leader)\n" .
 						"Can't change party leader - member %s doesn't exist.\n", $arg2);
 				} else {
-					$messageSender->sendPartyLeader($partyUsersID[$arg2]);
+					$found = $partyUsersID[$arg2];
 				}
+			}
+			if ($found && $found eq $accountID) {
+				warning T("Can't change party leader - you are already a party leader.\n");
+			} else {
+				$messageSender->sendPartyLeader($found);
 			}
 		}
 	} else {

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -5895,12 +5895,12 @@ sub party_exp {
 sub party_leader {
 	my ($self, $args) = @_;
 	for (my $i = 0; $i < @partyUsersID; $i++) {
+		if (unpack("V",$partyUsersID[$i]) eq $args->{old}) {
+			$char->{party}{users}{$partyUsersID[$i]}{admin} = '';
+		}
 		if (unpack("V",$partyUsersID[$i]) eq $args->{new}) {
 			$char->{party}{users}{$partyUsersID[$i]}{admin} = 1;
 			message TF("New party leader: %s\n", $char->{party}{users}{$partyUsersID[$i]}{name}), "party", 1;
-		}
-		if (unpack("V",$partyUsersID[$i]) eq $args->{old}) {
-			$char->{party}{users}{$partyUsersID[$i]}{admin} = '';
 		}
 	}
 }


### PR DESCRIPTION
1. We should not send a package 'party_leader' if we are already party leader
2. In the 'party_leader' function, we must designate the party leader at the end of the function. Otherwise, an error occurs when the party leader re-designates himself as the leader.