### PR TITLE
xConf update

### DIFF
--- a/plugins/xConf/xConf.pl
+++ b/plugins/xConf/xConf.pl
@@ -137,14 +137,14 @@ sub xConf {
 			$key_with_underscore =~ s/ /_/;
 			for (my $i; $i < values %{$inf_hash}; $i++) {
 				if (lc($key) eq lc($inf_hash->{$i}) || lc($key_with_underscore) eq lc($inf_hash->{$i})) {
-					$key = (defined $options ? $key . ' ' . $options : $key);
-					$name = $key;
 					$id = $i;
 					$found = 1;
 					debug "$type '$name' found in file '$tables_file'.\n";
 					last;
 				}
 			}
+			$key = (defined $options ? $key . ' ' . $options : $key);
+			$name = $key;
 		}
 
 		debug "Id: '$id', name: '$name', value: $value\n";

--- a/plugins/xConf/xConf.pl
+++ b/plugins/xConf/xConf.pl
@@ -46,7 +46,7 @@ sub xConf {
 	my ($cmd, $args) = @_;
 	my ($file,$tables_file,$found,$key,$oldval,$shopname,$type,$value, $name, $inf_hash, $ctrl_hash, $id, $needQuotes);
 	
-	($key, $value) = $args =~ /([\s\S]+?)\s([\-\d\.]+[\s\S]*)/ if !$shopname;
+	($key, $value) = $args =~ /([\s\S]+?)\s([\-\d\.]+[\s\S]*)/;
 	
 	if ($cmd eq 'sconf') {
 		($key, $value) = $args =~ /(name)\s(.*)/;
@@ -64,11 +64,6 @@ sub xConf {
 		$file = 'items_control.txt';
 		$tables_file = 'tables\..\items.txt';
 		$type = 'Item';
-		
-		#syntax checking for items with number in name buy whithout quotes to surrond it
-		if ($key =~ /[a-zA-Z][0-9]/ && $key !~ /"/) {
-			warning ("$key has number in name, we recommend surround it with quotes");
-		}
 		
 		if ($key =~ /"/) {
 			$needQuotes = 1; #first remove quotes to do all check and after in the end put it back
@@ -92,6 +87,10 @@ sub xConf {
 	
 	$key = $args if !$key;
 	$key =~ s/^\s+|\s+$//g;
+	#syntax checking for items with number in name buy whithout quotes to surrond it
+	if ($key !~ /^\d+$/ && $key =~ /\d/ && $key !~/^".+"$/) {
+		warning ("$key has number in name, so it's recommend to surround it with quotes\n");
+	}
 	$key =~ s/"(.+)"/\1/; #remove quotes
 	debug "extracted from args: KEY: $key, VALUE: $value\n";
 	if (!$key) {


### PR DESCRIPTION
### Whats new:
- now it gives support for you to use quotes on item name.
- if someone don't use quotes on an item that needs it, show a warning
- item that have slots or options didn't work , now it does.

#### the rest is refactoration


### Tests:
i've used the following commands: 
```
do iconf Diamond Ring 0 0 1
do iconf Diver Goggles 0 0 1
do iconf Eye Patch 0 0 1
do iconf Flower Ring 0 0 1
do iconf Flu Mask 0 0 1
do iconf Full Plate 0 0 1
do iconf Gemmed Sallet 0 0 1
do iconf "Hood [1]" 0 0 1
do iconf 505 0 1 0 # Blue Potion
do iconf 545 50 1 0 # Condensed Red Potion
do iconf 547 50 1 0 # Condensed White Potion
do iconf 546 50 1 0 # Condensed Yellow Potion
do iconf 506 0 1 0 # Green Potion
do iconf 501 25 1 0 # Red Potion
do iconf 502 25 1 0 # Orange Potion
do iconf 504 25 1 0 # White Potion
do iconf 503 25 1 0 # Yellow potion
```

#### Output when first configures:
![image](https://user-images.githubusercontent.com/11494727/54204560-37f2bb00-44b3-11e9-9b55-83b395267bd0.png)

#### if you have already configured the items on items_control.txt:
![image](https://user-images.githubusercontent.com/11494727/54204478-11348480-44b3-11e9-918b-6270f15f59db.png)

#### tested mconf and it works fine