### PR TITLE
Fix help for commands added through Commands::register

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -351,8 +351,10 @@ sub register {
 
 	foreach my $cmd (@_) {
 		my $name = $cmd->[0];
+		my $desc = (ref($cmd->[1]) eq 'ARRAY') ? $cmd->[1] : [$cmd->[1]];
+		
 		my %item = (
-			desc => $cmd->[1],
+			desc => $desc,
 			callback => $cmd->[2]
 		);
 		$customCommands{$name} = \%item;


### PR DESCRIPTION
Right now, the help command cannot retrieve scalar info from commands registered through Commands::register, such as plugin commands