### PR TITLE
[Receive.pm] fix missing lenght in search_store_result

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -6856,7 +6856,7 @@ sub search_store_result {
 	my @universalCatalogPage;
 
 	for (my $i = 0; $i < length($args->{storeInfo}); $i += $step) {
-		my ($storeID, $accountID, $shopName, $nameID, $itemType, $price, $amount, $refine, $cards, $unknown) = unpack($unpackString, substr($args->{storeInfo}, $i));
+		my ($storeID, $accountID, $shopName, $nameID, $itemType, $price, $amount, $refine, $cards, $unknown) = unpack($unpackString, substr($args->{storeInfo}, $i, $step));
 
 		my @cards = unpack "v4", $cards;
 


### PR DESCRIPTION
hook "search_store" was called everytime with same content
before:
![image](https://user-images.githubusercontent.com/10372732/56154287-8bfb2e80-5f8e-11e9-9793-0ec41e3c6ed1.png)

after:
![image](https://user-images.githubusercontent.com/10372732/56154311-9a494a80-5f8e-11e9-9388-2637a203debc.png)

