### PR TITLE
[eventMacro] Make Validator::NumericComparison properly support vars

### DIFF
--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -761,6 +761,12 @@ sub get_split_var {
 sub get_var {
 	my ($self, $type, $variable_name, $complement) = @_;
 	
+	if (ref($type) eq 'HASH') {
+		$variable_name = $type->{real_name};
+		$complement = $type->{complement};
+		$type = $type->{type};
+	}
+	
 	if ($type eq 'scalar') {
 		return ($self->get_scalar_var($variable_name));
 		

--- a/plugins/eventMacro/eventMacro/Validator/NumericComparison.pm
+++ b/plugins/eventMacro/eventMacro/Validator/NumericComparison.pm
@@ -2,14 +2,17 @@ package eventMacro::Validator::NumericComparison;
 
 use strict;
 use base 'eventMacro::Validator';
-use eventMacro::Data qw( $general_wider_variable_qr );
+use eventMacro::Data qw( $general_wider_variable_qr $eventMacro);
 use eventMacro::Utilities qw( find_variable );
 
 my $number_qr = qr/-?\d+(?:\.\d+)?/;
 
 sub parse {
 	my ( $self, $str ) = @_;
-	$self->{parsed} = $str =~ /^\s*(<|<=|=|==|!=|!|>=|>|)\s*($number_qr%?|$general_wider_variable_qr)(?:\s*\.\.\s*($number_qr%?|$general_wider_variable_qr))?\s*$/o;
+	
+	my @matches = $str =~ /^\s*(<|<=|=|==|!=|!|>=|>|)\s*($number_qr%?|$general_wider_variable_qr)(?:\s*\.\.\s*($number_qr%?|$general_wider_variable_qr))?\s*$/o;
+	$self->{parsed} = scalar @matches;
+	
 	if (!$self->{parsed}) {
 		$self->{error} = "There were found no numeric comparison in the condition code";
 		return;
@@ -18,34 +21,34 @@ sub parse {
 	$self->{var_name_min} = undef;
 	$self->{var_name_max} = undef;
 	
-	$self->{op}  = $1 || '==';
+	$self->{op} = $matches[0] || '==';
 	
-	if (my $var = find_variable($2)) {
+	if (my $var = find_variable($matches[1])) {
 		$self->{min} = undef;
 		$self->{var_name_min} = $var->{display_name};
 		$self->{min_is_pct} = 0;
 		$self->{min_is_var} = 1;
 		push(@{$self->{var}}, $var);
 	} else {
-		$self->{min} = $2;
+		$self->{min} = $matches[1];
 		$self->{min_is_pct} = $self->{min} =~ s/%$//;
 		$self->{min_is_var} = 0;
 	}
 	
-	if ( !defined $3 ) {
+	if ( !defined $matches[2] ) {
 		$self->{max}        = $self->{min};
 		$self->{max_is_var} = $self->{min_is_var};
 		$self->{max_is_pct} = $self->{min_is_pct};
 		$self->{var_name_max} = $self->{var_name_min};
 	} else {
-		if (my $var = find_variable($3)) {
+		if (my $var = find_variable($matches[2])) {
 			$self->{max} = undef;
 			$self->{var_name_max} = $var->{display_name};
 			$self->{max_is_pct} = 0;
 			$self->{max_is_var} = 1;
 			push(@{$self->{var}}, $var) unless ($var->{display_name} eq $self->{var_name_min});
 		} else {
-			$self->{max} = $3;
+			$self->{max} = $matches[2];
 			$self->{max_is_pct} = $self->{max} =~ s/%$//;
 			$self->{max_is_var} = 0;
 		}
@@ -78,9 +81,35 @@ sub update_vars {
 
 sub validate {
 	my ( $self, $value, $ref_value ) = @_;
+	
+	my ($min, $max);
 
-	my $min = $self->{min_is_pct} ? $self->{min} * $ref_value / 100 : $self->{min};
-	my $max = $self->{max_is_pct} ? $self->{max} * $ref_value / 100 : $self->{max};
+	if ($self->{min_is_var}) {
+		return 0 if scalar @{$self->{var}} <= 0;
+		
+		$min = $eventMacro->get_var($self->{var}->[0]);
+		$min ||= 0;
+		
+		if ($self->{max_is_var}) {
+			$max = (scalar @{$self->{var}} > 1) ? $eventMacro->get_var($self->{var}->[1]) : $eventMacro->get_var($self->{var}->[0]);
+			$max ||= 0;
+		} else {
+			$max = $self->{max};
+		}
+	} elsif ($self->{max_is_var}) {
+		return 0 if scalar @{$self->{var}} <= 0;
+		
+		$max = $eventMacro->get_var($self->{var}->[0]);
+		$max ||= 0;
+		
+		$min = $self->{min};
+	} else {
+		$min = $self->{min};
+		$max = $self->{max};
+	}
+	
+	$min = $self->{min_is_pct} ? $min * $ref_value / 100 : $min;
+	$max = $self->{max_is_pct} ? $max * $ref_value / 100 : $max;
 	
 	return 0 unless (defined $min && defined $max);
 	


### PR DESCRIPTION
Vars would get parsed correctly, but their valued wouldn't be actually retrieved.
Closes #2736 
Needs to be tested with accessed arrays and hashes, scalars and direct values seem fine.