### PR TITLE
[talknpc] fix buy item after npc close conversation

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -5397,6 +5397,8 @@ sub npc_talk_close {
 	my ($self, $args) = @_;
 	# 00b6: long ID
 	# "Close" icon appreared on the NPC message dialog
+	return if($ai_v{'npc_talk'}{'talk'} eq 'buy_or_sell');
+
 	my $ID = $args->{ID};
 	my $name = getNPCName($ID);
 


### PR DESCRIPTION
in some cases server send to us close conversation packet after the buy/sell list.

current openkore is destroying the task and is not possible to buy/sell

before:
![image](https://user-images.githubusercontent.com/10372732/57648646-76345580-759c-11e9-8e22-38722e00cdc3.png)

after this pull:
![image](https://user-images.githubusercontent.com/10372732/57648609-556c0000-759c-11e9-97de-0dd1618ccbc1.png)


this pull fixes #2759 
this pull fixes #1682 
