### PR TITLE
Fix for burrowed npc autotalk

### DIFF
--- a/src/Task/TalkNPC.pm
+++ b/src/Task/TalkNPC.pm
@@ -814,7 +814,7 @@ sub findTarget {
 	my ($self, $actorList) = @_;
 	if ($self->{nameID}) {
 		my ($actor) = grep { $self->{nameID} eq $_->{nameID} } @{$actorList->getItems};
-		if ($actor && $actor->{statuses}->{EFFECTSTATE_BURROW}) {
+		if ($actor && $actor->{statuses}->{EFFECTSTATE_BURROW} && $self->{type} ne 'autotalk') {
 			$self->setError(NPC_NOT_FOUND, T("Talk with a hidden NPC prevented."));
 			return;
 		}


### PR DESCRIPTION
When a burrowed npc auto starts a conversation with a player, and the server requires a npc_talk_cancel, openkore twill not be able to send it because Task::TalkNPC::findTarget won't find the npc because it is burrowed. This fixes it.