### PR TITLE
Add batchSize to getAuto logic

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -738,6 +738,7 @@ npcWrongStepsMethod 0
 getAuto {
 	minAmount
 	maxAmount
+	batchSize
 	passive
 	disabled 0
 }


### PR DESCRIPTION
Problem:
If getAuto is set to get a non-stackable item and the diference between the minAmount and maxAmount is greater than 1 openkore will try to get more than 1 of the item at the same time. This is not possible. In some servers it will just not work, on others it will disconnect the char, in some it may even get you banned.

Proof:
config:
![](https://i.gyazo.com/d23a9fb10662c248f253aaee62621c9f.png)

result:
![](https://i.gyazo.com/cec8fe40953d8643980201e18acf3db0.png)


Solution:
I added batchSize logic from buyAuto to getAuto, it should now work if properly set up.

Proof:
config:
![](https://i.gyazo.com/a53ce204d2e2a06668ce6ae1e9b0623a.png)

result:
![](https://i.gyazo.com/37594a7464a157e8733074eeb6402c76.png)



Tested on RMS renewall test server.