### PR TITLE
Add self_interruptible automacro parameter

### DIFF
--- a/plugins/eventMacro/eventMacro.pl
+++ b/plugins/eventMacro/eventMacro.pl
@@ -589,13 +589,15 @@ sub commandHandler {
 		
 		$eventMacro->{Macro_Runner} = new eventMacro::Runner(
 			$arg,
+			'command',
 			defined $opt->{repeat} ? $opt->{repeat} : 1,
 			defined $opt->{exclusive} ? $opt->{exclusive} ? 0 : 1 : undef,
+			0, # is self_interruptible? (in this case is always negative)
 			defined $opt->{overrideAI} ? $opt->{overrideAI} : undef,
 			defined $opt->{orphan} ? $opt->{orphan} : undef,
 			undef,
 			defined $opt->{macro_delay} ? $opt->{macro_delay} : undef,
-			0
+			0 # is subcall? (in this case is always negative)
 		);
 
 		if ( defined $eventMacro->{Macro_Runner} ) {

--- a/plugins/eventMacro/eventMacro/Automacro.pm
+++ b/plugins/eventMacro/eventMacro/Automacro.pm
@@ -129,6 +129,9 @@ sub set_parameters {
 	if (!defined $self->{parameters}{'exclusive'}) {
 		$self->{parameters}{'exclusive'} = 0;
 	}
+	if (!defined $self->{parameters}{'self_interruptible'}) {
+		$self->{parameters}{'self_interruptible'} = 0;
+	}
 	if (!defined $self->{parameters}{'repeat'}) {
 		$self->{parameters}{'repeat'} = 1;
 	}

--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -271,6 +271,11 @@ sub create_automacro_list {
 				error "[eventMacro] Ignoring automacro '$name' (exclusive parameter should be '0' or '1')\n";
 				next AUTOMACRO;
 			
+			###Parameter: self_interruptible
+			} elsif ($parameter->{'key'} eq "self_interruptible" && $parameter->{'value'} !~ /[01]/) {
+				error "[eventMacro] Ignoring automacro '$name' (self_interruptible parameter should be '0' or '1')\n";
+				next AUTOMACRO;
+			
 			###Parameter: priority
 			} elsif ($parameter->{'key'} eq "priority" && $parameter->{'value'} !~ /\d+/) {
 				error "[eventMacro] Ignoring automacro '$name' (priority parameter should be a number)\n";
@@ -1475,7 +1480,12 @@ sub AI_start_checker {
 		
 		my $automacro = $self->{Automacro_List}->get($array_member->{index});
 		
-		next unless $automacro->is_timed_out;	
+		next unless $automacro->is_timed_out;
+		
+		if (!$automacro->get_parameter('self_interruptible') && defined $self->{Macro_Runner} && !$self->{Macro_Runner}->self_interruptible && $self->{Macro_Runner}->get_caller_name eq $automacro->get_name()) {
+			next;
+		}
+		
 		message "[eventMacro] Conditions met for automacro '".$automacro->get_name()."', calling macro '".$automacro->get_parameter('call')."'\n", "system";
 		
 		$self->call_macro($automacro);
@@ -1547,8 +1557,10 @@ sub call_macro {
 	
 	$self->{Macro_Runner} = new eventMacro::Runner(
 		$automacro->get_parameter('call'),
+		$automacro->get_name,
 		$automacro->get_parameter('repeat'),
 		$automacro->get_parameter('exclusive') ? 0 : 1,
+		$automacro->get_parameter('self_interruptible'),
 		$automacro->get_parameter('overrideAI'),
 		$automacro->get_parameter('orphan'),
 		$automacro->get_parameter('delay'),

--- a/plugins/eventMacro/eventMacro/Data.pm
+++ b/plugins/eventMacro/eventMacro/Data.pm
@@ -38,18 +38,19 @@ use constant {
 };
 
 our %parameters = (
-	'timeout' => 1,      # setting: re-check timeout
-	'delay' => 1,        # option: delay before the macro starts
-	'run-once' => 1,     # option: run automacro only once
-	'disabled' => 1,     # option: automacro disabled
-	'call' => 1,         # setting: macro to be called
-	'overrideAI' => 1,   # option: override AI
-	'orphan' => 1,       # option: orphan handling
-	'macro_delay' => 1,  # option: default macro delay
-	'priority' => 1,     # option: automacro priority
-	'exclusive' => 1,    # option: is macro interruptible
-	'repeat' => 1,       # option: the number of times the called macro will repeat itself
-	'CheckOnAI' => 1,    # option: on which AI state the automacro will be checked
+	'timeout' => 1,               # setting: re-check timeout
+	'delay' => 1,                 # option: delay before the macro starts
+	'run-once' => 1,              # option: run automacro only once
+	'disabled' => 1,              # option: automacro disabled
+	'call' => 1,                  # setting: macro to be called
+	'overrideAI' => 1,            # option: override AI
+	'orphan' => 1,                # option: orphan handling
+	'macro_delay' => 1,           # option: default macro delay
+	'priority' => 1,              # option: automacro priority
+	'exclusive' => 1,             # option: is macro interruptible by other automacros
+	'self_interruptible' => 1,    # option: is macro interruptible by its own caller automacro
+	'repeat' => 1,                # option: the number of times the called macro will repeat itself
+	'CheckOnAI' => 1,             # option: on which AI state the automacro will be checked
 );
 
 our $macroKeywords = join '|', qw(

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -24,13 +24,14 @@ use eventMacro::Automacro;
 
 # Creates the object
 sub new {
-	my ($class, $name, $repeat, $interruptible, $overrideAI, $orphan, $delay, $macro_delay, $is_submacro) = @_;
+	my ($class, $name, $caller_name, $repeat, $interruptible, $self_interruptible, $overrideAI, $orphan, $delay, $macro_delay, $is_submacro) = @_;
 
 	return undef unless ($eventMacro->{Macro_List}->getByName($name));
 	
 	my $self = bless {}, $class;
 	
 	$self->{name} = $name;
+	$self->{caller_name} = $caller_name;
 	$self->{Paused} = 0;
 	$self->{registered} = 0;
 	$self->{finished} = 0;
@@ -71,6 +72,12 @@ sub new {
 		$self->interruptible($interruptible);
 	} else {
 		$self->interruptible(1);
+	}
+	
+	if (defined $self_interruptible && $self_interruptible =~ /^[01]$/) {
+		$self->self_interruptible($self_interruptible);
+	} else {
+		$self->self_interruptible(0);
 	}
 	
 	if (defined $overrideAI && $overrideAI =~ /^[01]$/) {
@@ -156,6 +163,23 @@ sub interruptible {
 		
 	}
 	return $self->{interruptible};
+}
+
+# Sets/Gets the current self_interruptible flag
+sub self_interruptible {
+	my ($self, $self_interruptible) = @_;
+	
+	if (defined $self_interruptible) {
+		
+		if (defined $self->{self_interruptible} && $self->{self_interruptible} == $self_interruptible) {
+			debug "[eventMacro] Macro '".$self->{name}."' self_interruptible state is already '".$self_interruptible."'.\n", "eventMacro", 2;
+		} else {
+			debug "[eventMacro] Now macro '".$self->{name}."' self_interruptible state is '".$self_interruptible."'.\n", "eventMacro", 2;
+			$self->{self_interruptible} = $self_interruptible;
+		}
+		
+	}
+	return $self->{self_interruptible};
 }
 
 # Makes sure the automacro checking state is compatible with this macro interruptible
@@ -340,6 +364,12 @@ sub get_name {
 	return $self->{name};
 }
 
+# Returns the name of the automacro that called this macro
+sub get_caller_name {
+	my ($self) = @_;
+	return $self->{caller_name};
+}
+
 # Deletes the subcall object
 sub clear_subcall {
 	my ($self) = @_;
@@ -369,7 +399,7 @@ sub clear_subcall {
 sub create_subcall {
 	my ($self, $name, $repeat) = @_;
 	debug "[eventMacro] Creating submacro '".$name."' on macro '".$self->{name}."'.\n", "eventMacro", 2;
-	$self->{subcall} = new eventMacro::Runner($name, $repeat, $self->interruptible, $self->overrideAI, $self->orphan, undef, $self->macro_delay, 1);
+	$self->{subcall} = new eventMacro::Runner($name, $self->get_caller_name, $repeat, $self->interruptible, $self->self_interruptible, $self->overrideAI, $self->orphan, undef, $self->macro_delay, 1);
 }
 
 # destructor
@@ -1647,6 +1677,12 @@ sub parse_set {
 			$self->error("exclusive parameter should be '0' or '1'. Given value: '$new_value'");
 		} else {
 			$self->interruptible($new_value?0:1);
+		}
+	} elsif ($parameter eq 'self_interruptible') {
+		if ($new_value !~ /^[01]$/) {
+			$self->error("self_interruptible parameter should be '0' or '1'. Given value: '$new_value'");
+		} else {
+			$self->self_interruptible($new_value);
 		}
 	} elsif ($parameter eq 'orphan') {
 		if ($new_value !~ /(terminate|terminate_last_call|reregister|reregister_safe)/) {

--- a/plugins/eventMacro/test/RunnerParseCommandTest.pm
+++ b/plugins/eventMacro/test/RunnerParseCommandTest.pm
@@ -16,7 +16,9 @@ sub start {
 	
 	$eventMacro->{Macro_Runner} = new eventMacro::Runner(
 			'testmacro1',
+			'auto_name',
 			1,
+			undef,
 			undef,
 			undef,
 			undef,

--- a/plugins/eventMacro/test/RunnerStatementTest.pm
+++ b/plugins/eventMacro/test/RunnerStatementTest.pm
@@ -16,7 +16,9 @@ sub start {
 	
 	$eventMacro->{Macro_Runner} = new eventMacro::Runner(
 			'testmacro1',
+			'auto_name',
 			1,
+			undef,
 			undef,
 			undef,
 			undef,


### PR DESCRIPTION
This new parameter defines if the macro should be interruptible by the automacro that called it.

exclusive 1: Cannot be interrupted by any automacro, self_interruptible does not matter.
![](https://i.gyazo.com/526ab5de84a71e355c08d1c757c4cb56.png)
![](https://i.gyazo.com/46d36cd3056594a390ec68be49620dc3.png)


exclusive 0 & self_interruptible 0: Cannot be interrupted by itself, can be interrupted by any other automacro.
![](https://i.gyazo.com/b099523a49deb522e1345b255f02c6e3.png)
![](https://i.gyazo.com/43cd4d0c23b7bed07d0872abd5cc01e4.png)


exclusive 0 & self_interruptible 1: Can be interrupted by itself and by any other automacro.
![](https://i.gyazo.com/0c6e34cdc46f122ad3f88b44ef0afc68.png)


Current master default behaviour: exclusive 0 & self_interruptible 1
New default behaviour with these changes: exclusive 0 & self_interruptible 0