### PR TITLE
fix eventMacro 'orphan' parameter

### DIFF
--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -282,8 +282,8 @@ sub create_automacro_list {
 				next AUTOMACRO;
 			
 			###Parameter: orphan
-			} elsif ($parameter->{'key'} eq "orphan" && $parameter->{'value'} !~ /(terminate|terminate_last_call|reregister|reregister_safe)/) {
-				error "[eventMacro] Ignoring automacro '$name' (orphan parameter should be 'terminate', 'terminate_last_call', 'reregister' or 'reregister_safe')\n";
+			} elsif ($parameter->{'key'} eq "orphan" && $parameter->{'value'} !~ /^(terminate|terminate_last_call|reregister|reregister_safe)$/) {
+				error "[eventMacro] Ignoring automacro '$name' (orphan parameter should be 'terminate', 'terminate_last_call', 'reregister' or 'reregister_safe'. Given value: '$parameter->{'value'}')\n";
 				next AUTOMACRO;
 			###Parameter: repeat
 			} elsif ($parameter->{'key'} eq "repeat" && $parameter->{'value'} !~ /\d+/) {

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -1649,7 +1649,7 @@ sub parse_set {
 			$self->interruptible($new_value?0:1);
 		}
 	} elsif ($parameter eq 'orphan') {
-		if ($new_value !~ /(terminate|terminate_last_call|reregister|reregister_safe)/) {
+		if ($new_value !~ /^(terminate|terminate_last_call|reregister|reregister_safe)$/) {
 			$self->error("orphan parameter should be 'terminate', 'terminate_last_call', 'reregister' or 'reregister_safe'. Given value: '$new_value'");
 		} else {
 			$self->orphan($new_value);


### PR DESCRIPTION
if i use this automacro, then the OpeKore does not swear on syntax `orphan`:

```
automacro test {
	disabled 0
	JobID 0
	run-once 1
	orphan terminateZZZ
	call {
		log test
	}
}
```

After this patch we get an error:
`[eventMacro] Ignoring automacro 'test' (orphan parameter should be 'terminate', 'terminate_last_call', 'reregister' or 'reregister_safe'. Given value: 'terminateZZZ')`

Maybe we should do it with other options too?