### PR TITLE
[FIX] avoid crash when no item

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -1900,7 +1900,11 @@ sub inventoryItemRemoved {
 			delete $char->{equipment}{arrow};
 			delete $char->{arrow};
 		}
-		$char->inventory->remove($item);
+		if( defined $item->{'name'}) {
+			$char->inventory->remove($item);
+		} else {
+			warning "Server sended item_removed but we not have this item anymore. binID: ".$binID."\n";
+		}
 	}
 	$itemChange{$item->{name}} -= $amount;
 	Plugins::callHook('inventory_item_removed', {item => $item, index => $binID, amount => $amount, remaining => ($item->{amount} <= 0 ? 0 : $item->{amount})});


### PR DESCRIPTION
Sometimes the server sends the item_removed packet after teleport, but after teleport openkore has already cleared the list of items.

this currently causes an openkore error causing the user to close and reopen the software.

this fixes #2458 

