### PR TITLE
Add sanity check on cmdmove

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -3835,26 +3835,17 @@ sub cmdMove {
 				my $file = $map_or_portal.'.fld';
 				$file = File::Spec->catfile($Settings::fields_folder, $file) if ($Settings::fields_folder);
 				$file .= ".gz" if (! -f $file); # compressed file
-				if ($maps_lut{"${map_or_portal}.rsw"}) {
-					if ($dist) {
-						message TF("Calculating route to: %s(%s): %s, %s (Distance: %s)\n",
-							$maps_lut{$map_or_portal.'.rsw'}, $map_or_portal, $x, $y, $dist), "route";
-					} elsif ($x ne "") {
-						message TF("Calculating route to: %s(%s): %s, %s\n",
-							$maps_lut{$map_or_portal.'.rsw'}, $map_or_portal, $x, $y), "route";
-					} else {
-						message TF("Calculating route to: %s(%s)\n",
-							$maps_lut{$map_or_portal.'.rsw'}, $map_or_portal), "route";
+				if ($maps_lut{"${map_or_portal}.rsw"} || -f $file) {
+					my $move_field = new Field(name => $map_or_portal);
+					if ($move_field->isOffMap($x, $y)) {
+						error TF("Coordinates %s %s are off the map %s\n",$x, $y, $map_or_portal);
+						return;
 					}
-					main::ai_route($map_or_portal, $x, $y,
-						attackOnRoute => 1,
-						noSitAuto => 1,
-						notifyUponArrival => 1,
-						distFromGoal => $dist);
-				} elsif (-f $file) {
-					# valid map
-					my $map_name = $maps_lut{"${map_or_portal}.rsw"}?$maps_lut{"${map_or_portal}.rsw"}:
-						T('Unknown Map');
+					if (!$move_field->isWalkable($x, $y)) {
+						error TF("Coordinates %s %s are not walkable on the map %s\n",$x, $y, $map_or_portal);
+						return;
+					}
+					my $map_name = $maps_lut{"${map_or_portal}.rsw"} ? $maps_lut{"${map_or_portal}.rsw"} : T('Unknown Map');
 					if ($dist) {
 						message TF("Calculating route to: %s(%s): %s, %s (Distance: %s)\n",
 							$map_name, $map_or_portal, $x, $y, $dist), "route";


### PR DESCRIPTION
cmdMove lets the user start Task::MapRoute on an obviously impossible trajectory, either because the destination is not walkable or because it is off the map. These checks fix that.