### PR TITLE
reorder a few lines from sub openShop

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -4700,10 +4700,10 @@ sub openShop {
 	@shopnames = split(/;;/, $shop{title_line});
 	$shop{title} = $shopnames[int rand($#shopnames + 1)];
 	$shop{title} = ($config{shopTitleOversize}) ? $shop{title} : substr($shop{title},0,36);
-	Plugins::callHook ('open_shop', {title => $shop{title}, items => \@items});
-	$messageSender->sendOpenShop($shop{title}, \@items);
 	message T("Trying to set up shop...\n"), "vending";
+	$messageSender->sendOpenShop($shop{title}, \@items);
 	$shopstarted = 1;
+	Plugins::callHook ('open_shop', {title => $shop{title}, items => \@items});
 }
 
 sub closeShop {


### PR DESCRIPTION
The idea here is:

- show message on console `Trying to set up shop...` before the `sendOpenShop()`, since it didn't happen yet;
- define $shopstarted to 1 BEFORE calling hook, because since it was defining after, any plugin that was hooking on it was getting the old value instead of the updated value

the rest keep the same
