### PR TITLE
[xKore 1] workaround to recognize the right char data

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -6193,6 +6193,16 @@ sub received_character_ID_and_Map {
 		$map_port = $args->{mapPort};
 	}
 
+	# Workaround. Current xKore 1 is not able to define the $char
+	if($config{XKore} == 1) {
+		foreach my $character (@chars) {
+			if (getHex($charID) eq getHex($character->{charID})) {
+				configModify("char", $character->{slot});
+				$char = $chars[$character->{slot}];
+			}                                                 
+		}
+	}
+
 	message TF("----------Game Info----------\n" .
 		"Char ID: %s (%s)\n" .
 		"MAP Name: %s\n" .


### PR DESCRIPTION
if you use xKore 1 and select chars in highests slots, openkore is not able to define the correct char data.
this pull fixes this