### PR TITLE
added destination check to Task::Move

### DIFF
--- a/src/Task/Move.pm
+++ b/src/Task/Move.pm
@@ -137,7 +137,7 @@ sub iterate {
 		$self->setDone();
 
 	# Stop if we've moved.
-	} elsif ($self->{actor}{time_move} > $self->{start_time} && $self->{actor}{pos_to}{x} == $self->{x} && $self->{actor}{pos_to}{y} == $self->{y})) {
+	} elsif ($self->{actor}{time_move} > $self->{start_time} && $self->{actor}{pos_to}{x} == $self->{x} && $self->{actor}{pos_to}{y} == $self->{y}) {
 		debug "Move $self->{actor} - done\n", "move";
 		$self->setDone();
 

--- a/src/Task/Move.pm
+++ b/src/Task/Move.pm
@@ -137,7 +137,7 @@ sub iterate {
 		$self->setDone();
 
 	# Stop if we've moved.
-	} elsif ($self->{actor}{time_move} > $self->{start_time}) {
+	} elsif ($self->{actor}{time_move} > $self->{start_time} && $self->{actor}{pos_to}{x} == $self->{x} && $self->{actor}{pos_to}{y} == $self->{y})) {
 		debug "Move $self->{actor} - done\n", "move";
 		$self->setDone();
 


### PR DESCRIPTION
Sometimes openkore will receive a character_moves packet during a Task::Move which is from a previous Task::Move, this causes the current Task to be ended. This check ensures the Task only ends when it receives the move packet of the same coordinates it sent.

Exemple:
![](https://i.gyazo.com/fc2be877b58f5a58bdb6103a8f87cedf.png)

In this picture we receive a movement packet to the cell 204 188, but the current Task::Move and the last move packet sent by it have has the destination 208 188.
In this exemple already with this PR changes Task::Move didn't end after the first character_moves packet because it didn't have the right destination coordinates, which would would happened without this change.
