### PR TITLE
[CoreLogic] autostorage wait before action

### DIFF
--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -154,6 +154,7 @@ ai_sellAuto_wait_after_packet_giveup 15
 ai_storageAuto 2
 ai_storageAuto_giveup 15
 ai_storageAuto_useItem 2
+ai_storageAuto_wait_before_action 2
 # delay between sending cart item add/get packets
 ai_cartAuto 0.15
 

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1258,6 +1258,7 @@ sub processAutoStorage {
 		# Autostorage finished; trigger sellAuto unless autostorage was already triggered by it
 		my $forcedBySell = AI::args->{forcedBySell};
 		my $forcedByBuy = AI::args->{forcedByBuy};
+		undef $timeout{ai_storageAuto_wait_before_action}{time};
 		AI::dequeue;
 		if ($config{sellAuto} && ai_sellAutoCheck()) {
 			if ($forcedByBuy) {
@@ -1401,6 +1402,13 @@ sub processAutoStorage {
 			my %pluginArgs;
 			Plugins::callHook("AI_storage_open", \%pluginArgs); # we can hook here to perform actions BEFORE any storage function
 			return if ($pluginArgs{return});
+
+			if(!$timeout{ai_storageAuto_wait_before_action}{time}) {
+				$timeout{ai_storageAuto_wait_before_action}{time} = time;
+				return;
+			} elsif(!timeOut($timeout{ai_storageAuto_wait_before_action})) {
+				return;
+			}
 
 			if (!$args->{getStart}) {
 				$args->{done} = 1;


### PR DESCRIPTION
sometimes openkore try to get or add item to storage faster then server send the item list to openkore, so sometimes server disconnect us

this pull fixe this