### PR TITLE
Fix homunculus map change in RMS server

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2426,7 +2426,7 @@ sub homunculus_info {
 	if ($args->{state} == HO_PRE_INIT) {
 		my $state = $char->{homunculus}{state}
 			if ($char->{homunculus} && $char->{homunculus}{ID} && $char->{homunculus}{ID} ne $args->{ID});
-		$char->{homunculus} = Actor::get($args->{ID}) if ($char->{homunculus}{ID} ne $args->{ID});
+		$char->{homunculus} = Actor::get($args->{ID});
 		$char->{homunculus}{state} = $state if (defined $state);
 		$char->{homunculus}{map} = $field->baseName;
 		unless ($char->{slaves}{$char->{homunculus}{ID}}) {


### PR DESCRIPTION
As the title states once you change maps in RMS restart the homunculus actor won't be destroyed because a reference to it will be kept in `$char->{homunculus}`, but `$char->{slaves}` is always cleared in map changes, which causes the homunculus to be added again in `AI::SlaveManager` via `AI::SlaveManager::addSlave`.

The problem happens when in `AI::SlaveManager::addSlave` the class of the homunculus is changed from `Actor::Slave::Homunculus` to `AI::Slave::Homunculus`. If the actor is then added again without being deleted first its class will actually be `Actor::Slave::Homunculus`, preventing it from being identified as a homunculus, and being added as a `AI::Slave`.