### PR TITLE
Fixed homunculus and mercenary timeouts

### DIFF
--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -32,9 +32,12 @@ ai_move_giveup 1.5
 # Send the attack packet every x seconds, if it hasn't been send already
 ai_attack 1
 ai_homunculus_attack 1
+ai_mercenary_attack 1
 
 # Check for monsters to attack every x seconds
 ai_attack_auto 0.5
+ai_homunculus_attack_auto 0.5
+ai_mercenary_attack_auto 0.5
 
 # Give up attacking a monster if it can't be reached within x seconds
 ai_attack_giveup 12

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -324,7 +324,7 @@ sub processAttack {
 
 	} elsif ($slave->action eq "attack" && !$monsters{$slave->args->{ID}} && (!$players{$slave->args->{ID}} || $players{$slave->args->{ID}}{dead})) {
 		# Monster died or disappeared
-		$timeout{'ai_homunculus_attack'}{'time'} -= $timeout{'ai_homunculus_attack'}{'timeout'};
+		$timeout{$slave->{ai_attack_timeout}}{time} -= $timeout{$slave->{ai_attack_timeout}}{timeout};
 		my $ID = $slave->args->{ID};
 		$slave->dequeue;
 
@@ -606,10 +606,9 @@ sub processAttack {
 				$args->{unstuck}{count}++;
 			}
 
-			if ($args->{attackMethod}{type} eq "weapon" && timeOut($timeout{ai_homunculus_attack})) {
-				$slave->sendAttack ($ID);#,
-					#($config{homunculus_tankMode}) ? 0 : 7);
-				$timeout{ai_homunculus_attack}{time} = time;
+			if ($args->{attackMethod}{type} eq "weapon" && timeOut($timeout{$slave->{ai_attack_timeout}})) {
+				$slave->sendAttack ($ID);
+				$timeout{$slave->{ai_attack_timeout}}{time} = time;
 				delete $args->{attackMethod};
 			}
 
@@ -725,7 +724,7 @@ sub processAutoAttack {
 
 	if ((($slave->isIdle || $slave->action eq 'route') && (AI::isIdle || AI::is(qw(follow sitAuto take items_gather items_take attack skill_use))))
 	     # Don't auto-attack monsters while taking loot, and itemsTake/GatherAuto >= 2
-	  && timeOut($timeout{ai_homunculus_attack_auto})
+	  && timeOut($timeout{$slave->{ai_attack_auto_timeout}})
 	  && (!$config{$slave->{configPrefix}.'attackAuto_notInTown'} || !$field->isCity)) {
 
 		# If we're in tanking mode, only attack something if the person we're tanking for is on screen.
@@ -937,7 +936,7 @@ sub processAutoAttack {
 			$slave->setSuspend(0);
 			$slave->attack($attackTarget, $priorityAttack);
 		} else {
-			$timeout{'ai_homunculus_attack_auto'}{'time'} = time;
+			$timeout{$slave->{ai_attack_auto_timeout}}{time} = time;
 		}
 	}
 

--- a/src/AI/SlaveManager.pm
+++ b/src/AI/SlaveManager.pm
@@ -22,10 +22,14 @@ sub addSlave {
 
 	if ($actor->isa("Actor::Slave::Homunculus")) {
 		$actor->{configPrefix} = 'homunculus_';
+		$actor->{ai_attack_timeout} = 'ai_homunculus_attack';
+		$actor->{ai_attack_auto_timeout} = 'ai_homunculus_attack_auto';
 		bless $actor, 'AI::Slave::Homunculus';
 		
 	} elsif ($actor->isa("Actor::Slave::Mercenary")) {
 		$actor->{configPrefix} = 'mercenary_';
+		$actor->{ai_attack_timeout} = 'ai_mercenary_attack';
+		$actor->{ai_attack_auto_timeout} = 'ai_mercenary_attack_auto';
 		bless $actor, 'AI::Slave::Mercenary';
 		
 	} else {


### PR DESCRIPTION
At the moment `AI::Slave` uses a single timeout key for all slaves attacks, this makes it so that if you have a homunculus and a mercenary at the same time they won't be able to attack at the same time. This PR fixes that and also adds the missing timeouts.