### PR TITLE
Slave AI cleaning

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -361,6 +361,7 @@ mercenary_attackAuto_notInTown 1
 mercenary_attackAuto_onlyWhenSafe 0
 mercenary_attackDistance 1.5
 mercenary_attackMaxDistance 2.5
+mercenary_attackDistanceAuto 0
 mercenary_attackMaxRouteTime 4
 mercenary_attackCanSnipe 0
 mercenary_attackCheckLOS 0
@@ -394,6 +395,7 @@ homunculus_attackAuto_notInTown 1
 homunculus_attackAuto_onlyWhenSafe 0
 homunculus_attackDistance 1.5
 homunculus_attackMaxDistance 2.5
+homunculus_attackDistanceAuto 0
 homunculus_attackMaxRouteTime 4
 homunculus_attackCanSnipe 0
 homunculus_attackCheckLOS 0

--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -29,6 +29,9 @@ ai 2
 ai_move_retry 0.25
 ai_move_giveup 1.5
 
+ai_homunculus_standby 2
+ai_mercenary_standby 2
+
 # Send the attack packet every x seconds, if it hasn't been send already
 ai_attack 1
 ai_homunculus_attack 1

--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -32,9 +32,12 @@ ai_move_giveup 1.5
 # Send the attack packet every x seconds, if it hasn't been send already
 ai_attack 1
 ai_homunculus_attack 1
+ai_mercenary_attack 1
 
 # Check for monsters to attack every x seconds
 ai_attack_auto 0.5
+ai_homunculus_attack_auto 0.5
+ai_mercenary_attack_auto 0.5
 
 # Give up attacking a monster if it can't be reached within x seconds
 ai_attack_giveup 12

--- a/src/AI.pm
+++ b/src/AI.pm
@@ -385,7 +385,7 @@ sub ai_slave_getAggressives {
 
 		if ((($type && ($control->{attack_auto} == 2)) ||
 			(($monster->{dmgToPlayer}{$slave->{ID}} || $monster->{missedToPlayer}{$slave->{ID}} || $monster->{dmgFromPlayer}{$slave->{ID}} || $monster->{missedFromPlayer}{$slave->{ID}}) && Misc::checkMonsterCleanness($ID))) &&
-			timeOut($monster->{homunculus_attack_failed}, $timeout{ai_attack_unfail}{timeout}))
+			timeOut($monster->{$slave->{ai_attack_failed_timeout}}, $timeout{ai_attack_unfail}{timeout}))
 		{
 			my $myPos = calcPosition($slave);
 			my $pos = calcPosition($monster);

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -324,7 +324,7 @@ sub processAttack {
 
 	} elsif ($slave->action eq "attack" && !$monsters{$slave->args->{ID}} && (!$players{$slave->args->{ID}} || $players{$slave->args->{ID}}{dead})) {
 		# Monster died or disappeared
-		$timeout{'ai_homunculus_attack'}{'time'} -= $timeout{'ai_homunculus_attack'}{'timeout'};
+		$timeout{$slave->{ai_attack_timeout}}{time} -= $timeout{$slave->{ai_attack_timeout}}{timeout};
 		my $ID = $slave->args->{ID};
 		$slave->dequeue;
 
@@ -606,10 +606,9 @@ sub processAttack {
 				$args->{unstuck}{count}++;
 			}
 
-			if ($args->{attackMethod}{type} eq "weapon" && timeOut($timeout{ai_homunculus_attack})) {
-				$slave->sendAttack ($ID);#,
-					#($config{homunculus_tankMode}) ? 0 : 7);
-				$timeout{ai_homunculus_attack}{time} = time;
+			if ($args->{attackMethod}{type} eq "weapon" && timeOut($timeout{$slave->{ai_attack_timeout}})) {
+				$slave->sendAttack ($ID);
+				$timeout{$slave->{ai_attack_timeout}}{time} = time;
 				delete $args->{attackMethod};
 			}
 
@@ -725,7 +724,7 @@ sub processAutoAttack {
 
 	if ((($slave->isIdle || $slave->action eq 'route') && (AI::isIdle || AI::is(qw(follow sitAuto take items_gather items_take attack skill_use))))
 	     # Don't auto-attack monsters while taking loot, and itemsTake/GatherAuto >= 2
-	  && timeOut($timeout{ai_homunculus_attack_auto})
+	  && timeOut($timeout{$slave->{ai_attack_auto_timeout}})
 	  && (!$config{$slave->{configPrefix}.'attackAuto_notInTown'} || !$field->isCity)) {
 
 		# If we're in tanking mode, only attack something if the person we're tanking for is on screen.
@@ -937,7 +936,7 @@ sub processAutoAttack {
 			$slave->setSuspend(0);
 			$slave->attack($attackTarget, $priorityAttack);
 		} else {
-			$timeout{'ai_homunculus_attack_auto'}{'time'} = time;
+			$timeout{$slave->{ai_attack_auto_timeout}}{time} = time;
 		}
 	}
 

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -734,7 +734,7 @@ sub processAutoAttack {
 			my $myPos = calcPosition($slave);
 
 			# List aggressive monsters
-			@aggressives = AI::ai_slave_getAggressives($slave->{ID}, 1) if ($config{$slave->{configPrefix}.'attackAuto'} && $attackOnRoute);
+			@aggressives = AI::ai_slave_getAggressives($slave, 1) if ($config{$slave->{configPrefix}.'attackAuto'} && $attackOnRoute);
 
 			# There are two types of non-aggressive monsters. We generate two lists:
 			foreach (@monstersID) {
@@ -742,9 +742,6 @@ sub processAutoAttack {
 				my $monster = $monsters{$_};
 				next if !$field->isWalkable($monster->{pos}{x}, $monster->{pos}{y}); # this should NEVER happen
 				next if !checkLineWalkable($myPos, $monster->{pos}); # ignore unrecheable monster. there's a bug in bRO's gef_fild06 where a lot of petites are bugged in some unrecheable cells
-
-				# Never attack monsters that we failed to get LOS with
-				next if (!timeOut($monster->{attack_failedLOS}, $timeout{ai_attack_failedLOS}{timeout}));
 
 				my $pos = calcPosition($monster);
 

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -167,10 +167,10 @@ sub iterate {
 				# We do this every 0.5 secs
 				$slave->{move_retry} = time;
 				# NOTE:
-				# The default LUA uses sendHomunculusStandBy() for the follow AI
+				# The default LUA uses sendSlaveStandBy() for the follow AI
 				# however, the server-side routing is very inefficient
 				# (e.g. can't route properly around obstacles and corners)
-				# so we make use of the sendHomunculusMove() to make up for a more efficient routing
+				# so we make use of the sendSlaveMove() to make up for a more efficient routing
 				$slave->sendMove ($char->{pos_to}{x}, $char->{pos_to}{y});
 				debug sprintf("Slave follow move (distance: %.2f)\n", $slave->distance()), 'homunculus';
 			}
@@ -817,17 +817,17 @@ sub processAutoAttack {
 
 sub sendAttack {
 	my ($slave, $targetID) = @_;
-	$messageSender->sendHomunculusAttack ($slave->{ID}, $targetID);
+	$messageSender->sendSlaveAttack ($slave->{ID}, $targetID);
 }
 
 sub sendMove {
 	my ($slave, $x, $y) = @_;
-	$messageSender->sendHomunculusMove ($slave->{ID}, $x, $y);
+	$messageSender->sendSlaveMove ($slave->{ID}, $x, $y);
 }
 
 sub sendStandBy {
 	my ($slave) = @_;
-	$messageSender->sendHomunculusStandBy ($slave->{ID});
+	$messageSender->sendSlaveStandBy ($slave->{ID});
 }
 
 1;

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -797,9 +797,7 @@ sub processAutoAttack {
 
 			# We define whether we should attack only monsters in LOS or not
 			my $nonLOSNotAllowed = !$config{$slave->{configPrefix}.'attackCheckLOS'};
-			$attackTarget = getBestTarget(\@aggressives, $nonLOSNotAllowed) ||
-			                getBestTarget(\@partyMonsters, $nonLOSNotAllowed}) ||
-			                getBestTarget(\@cleanMonsters, $nonLOSNotAllowed);
+			$attackTarget = getBestTarget(\@aggressives, $nonLOSNotAllowed) || getBestTarget(\@partyMonsters, $nonLOSNotAllowed) || getBestTarget(\@cleanMonsters, $nonLOSNotAllowed);
 		}
 
 		# If an appropriate monster's found, attack it. If not, wait ai_attack_auto secs before searching again.

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -144,7 +144,7 @@ sub iterate {
 			$slave->clear('move', 'route');
 			$slave->sendStandBy;
 			$timeout{$slave->{ai_standby_timeout}}{time} = time;
-			debug sprintf("Slave standby (distance: %.2f)\n", $slave_dist), 'slave';
+			debug sprintf("Slave standby (distance: %d)\n", $slave_dist), 'slave';
 
 		# auto-follow
 		} elsif (
@@ -153,14 +153,13 @@ sub iterate {
 			&& !$char->{sitting}
 			&& !AI::args->{mapChanged}
 			&& $slave_dist < MAX_DISTANCE
-			&& ($slave->isIdle
-				|| blockDistance(AI::args->{move_to}, $slave->{pos_to}) >= MAX_DISTANCE)
+			&& ($slave->isIdle || blockDistance(AI::args->{move_to}, $slave->{pos_to}) >= MAX_DISTANCE)
 			&& (!defined $slave->findAction('route') || !$slave->args($slave->findAction('route'))->{isFollow})
 		) {
 			$slave->clear('move', 'route');
 			if (!checkLineWalkable($slave->{pos_to}, $char->{pos_to})) {
 				$slave->route(undef, @{$char->{pos_to}}{qw(x y)}, isFollow => 1);
-				debug sprintf("Slave follow route (distance: %.2f)\n", $slave->distance()), 'slave';
+				debug sprintf("Slave follow route (distance: %d)\n", $slave_dist), 'slave';
 	
 			} elsif (timeOut($slave->{move_retry}, 0.5)) {
 				# No update yet, send move request again.
@@ -172,7 +171,7 @@ sub iterate {
 				# (e.g. can't route properly around obstacles and corners)
 				# so we make use of the sendSlaveMove() to make up for a more efficient routing
 				$slave->sendMove ($char->{pos_to}{x}, $char->{pos_to}{y});
-				debug sprintf("Slave follow move (distance: %.2f)\n", $slave->distance()), 'slave';
+				debug sprintf("Slave follow move (distance: %d)\n", $slave_dist), 'slave';
 			}
 
 		# if your slave is idle, make it move near you
@@ -185,7 +184,7 @@ sub iterate {
 		) {
 			$slave->sendStandBy;
 			$timeout{$slave->{ai_standby_timeout}}{time} = time;
-			debug sprintf("Slave standby (distance: %.2f)\n", $slave_dist), 'slave';
+			debug sprintf("Slave standby (distance: %d)\n", $slave_dist), 'slave';
 
 		# if you are idle, move near the slave
 		} elsif (
@@ -195,7 +194,7 @@ sub iterate {
 			&& $slave_dist > $config{$slave->{configPrefix}.'followDistanceMax'}
 		) {
 			main::ai_route($field->baseName, $slave->{pos_to}{x}, $slave->{pos_to}{y}, distFromGoal => ($config{$slave->{configPrefix}.'followDistanceMin'} || 3), attackOnRoute => 1, noSitAuto => 1);
-			message TF("%s moves too far (distance: %.2f) - Moving near\n", $slave, $slave->distance), 'slave';
+			message TF("%s moves too far (distance: %d) - Moving near\n", $slave, $slave_dist), 'slave';
 
 		# Main slave AI
 		} else {

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -188,7 +188,7 @@ sub iterate {
 
 		# if you are idle, move near the slave
 		} elsif (
-			$slave->isa("Actor::Slave::Homunculus") &&
+			$slave->isa("AI::Slave::Homunculus") &&
 			AI::state == AI::AUTO && AI::isIdle && !$slave->isIdle
 			&& $config{$slave->{configPrefix}.'followDistanceMax'}
 			&& $slave_dist > $config{$slave->{configPrefix}.'followDistanceMax'}

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -785,8 +785,7 @@ sub processAutoAttack {
 				my $control = mon_control($monster->{name}, $monster->{nameID});
 				if ($config{$slave->{configPrefix}.'attackAuto'} >= 2
 				 && ($control->{attack_auto} == 1 || $control->{attack_auto} == 3)
-				 && $safe
-				 && $attackOnRoute >= 2
+				 && $attackOnRoute >= 2 && $safe
 				 && !positionNearPlayer($pos, $playerDist) && !positionNearPortal($pos, $portalDist)
 				 && !$monster->{dmgFromYou}
 				 && timeOut($monster->{$slave->{ai_attack_failed_timeout}}, $timeout{ai_attack_unfail}{timeout})) {
@@ -798,9 +797,9 @@ sub processAutoAttack {
 
 			# We define whether we should attack only monsters in LOS or not
 			my $nonLOSNotAllowed = !$config{$slave->{configPrefix}.'attackCheckLOS'};
-			$attackTarget = getBestTarget(\@aggressives, $nonLOSNotAllowed, $config{$slave->{configPrefix}.'attackCanSnipe'}) ||
-			                getBestTarget(\@partyMonsters, $nonLOSNotAllowed, $config{$slave->{configPrefix}.'attackCanSnipe'}) ||
-			                getBestTarget(\@cleanMonsters, $nonLOSNotAllowed, $config{$slave->{configPrefix}.'attackCanSnipe'});
+			$attackTarget = getBestTarget(\@aggressives, $nonLOSNotAllowed) ||
+			                getBestTarget(\@partyMonsters, $nonLOSNotAllowed}) ||
+			                getBestTarget(\@cleanMonsters, $nonLOSNotAllowed);
 		}
 
 		# If an appropriate monster's found, attack it. If not, wait ai_attack_auto secs before searching again.

--- a/src/AI/SlaveManager.pm
+++ b/src/AI/SlaveManager.pm
@@ -22,10 +22,14 @@ sub addSlave {
 
 	if ($actor->isa("Actor::Slave::Homunculus")) {
 		$actor->{configPrefix} = 'homunculus_';
+		$actor->{ai_attack_timeout} = 'ai_homunculus_attack';
+		$actor->{ai_attack_auto_timeout} = 'ai_homunculus_attack_auto';
 		bless $actor, 'AI::Slave::Homunculus';
 		
 	} elsif ($actor->isa("Actor::Slave::Mercenary")) {
 		$actor->{configPrefix} = 'mercenary_';
+		$actor->{ai_attack_timeout} = 'ai_mercenary_attack';
+		$actor->{ai_attack_auto_timeout} = 'ai_mercenary_attack_auto';
 		bless $actor, 'AI::Slave::Mercenary';
 		
 	} else {

--- a/src/AI/SlaveManager.pm
+++ b/src/AI/SlaveManager.pm
@@ -25,6 +25,7 @@ sub addSlave {
 		$actor->{ai_attack_timeout} = 'ai_homunculus_attack';
 		$actor->{ai_attack_auto_timeout} = 'ai_homunculus_attack_auto';
 		$actor->{ai_standby_timeout} = 'ai_homunculus_standby';
+		$actor->{ai_attack_failed_timeout} = 'homunculus_attack_failed';
 		bless $actor, 'AI::Slave::Homunculus';
 		
 	} elsif ($actor->isa("Actor::Slave::Mercenary")) {
@@ -32,6 +33,7 @@ sub addSlave {
 		$actor->{ai_attack_timeout} = 'ai_mercenary_attack';
 		$actor->{ai_attack_auto_timeout} = 'ai_mercenary_attack_auto';
 		$actor->{ai_standby_timeout} = 'ai_mercenary_standby';
+		$actor->{ai_attack_failed_timeout} = 'mercenary_attack_failed';
 		bless $actor, 'AI::Slave::Mercenary';
 		
 	} else {

--- a/src/AI/SlaveManager.pm
+++ b/src/AI/SlaveManager.pm
@@ -24,12 +24,14 @@ sub addSlave {
 		$actor->{configPrefix} = 'homunculus_';
 		$actor->{ai_attack_timeout} = 'ai_homunculus_attack';
 		$actor->{ai_attack_auto_timeout} = 'ai_homunculus_attack_auto';
+		$actor->{ai_standby_timeout} = 'ai_homunculus_standby';
 		bless $actor, 'AI::Slave::Homunculus';
 		
 	} elsif ($actor->isa("Actor::Slave::Mercenary")) {
 		$actor->{configPrefix} = 'mercenary_';
 		$actor->{ai_attack_timeout} = 'ai_mercenary_attack';
 		$actor->{ai_attack_auto_timeout} = 'ai_mercenary_attack_auto';
+		$actor->{ai_standby_timeout} = 'ai_mercenary_standby';
 		bless $actor, 'AI::Slave::Mercenary';
 		
 	} else {

--- a/src/Actor.pm
+++ b/src/Actor.pm
@@ -778,7 +778,7 @@ sub route {
 	} else {
 		$task = new Task::Route(@params);
 	}
-	$task->{$_} = $args{$_} for qw(attackID attackOnRoute noSitAuto LOSSubRoute isRandomWalk);
+	$task->{$_} = $args{$_} for qw(attackID attackOnRoute noSitAuto LOSSubRoute isRandomWalk isFollow);
 	
 	$self->queue('route', $task);
 }

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -2736,7 +2736,7 @@ sub cmdSlave {
 			return;
 		} else {
 			# max distance that homunculus can follow: 17
-			$messageSender->sendHomunculusMove($slave->{ID}, $args[1], $args[2]);
+			$messageSender->sendSlaveMove($slave->{ID}, $args[1], $args[2]);
 		}
 
 	} elsif ($subcmd eq "standby") {
@@ -2744,7 +2744,7 @@ sub cmdSlave {
 			error TF("You must be logged in the game to use this command '%s'\n", $cmd .' ' .$subcmd);
 			return;
 		}
-		$messageSender->sendHomunculusStandBy($slave->{ID});
+		$messageSender->sendSlaveStandBy($slave->{ID});
 
 	} elsif ($args[0] eq 'ai') {
 		if ($args[1] eq 'clear') {

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -2634,11 +2634,11 @@ sub cmdSlave {
 	if (!$slave || !$slave->{appear_time}) {
 		error T("Error: No slave detected.\n");
 
-	} elsif ($slave->{state} & 2 && $slave->isa("Actor::Slave::Homunculus")) {
+	} elsif ($slave->{state} & 2 && $slave->isa("AI::Slave::Homunculus")) {
 			my $skill = new Skill(handle => 'AM_CALLHOMUN');
 			error TF("Homunculus is in rest, use skills '%s' (ss %d).\n", $skill->getName, $skill->getIDN);
 
-	} elsif ($slave->{state} & 4 && $slave->isa("Actor::Slave::Homunculus")) {
+	} elsif ($slave->{state} & 4 && $slave->isa("AI::Slave::Homunculus")) {
 			my $skill = new Skill(handle => 'AM_RESURRECTHOMUN');
 			error TF("Homunculus is dead, use skills '%s' (ss %d).\n", $skill->getName, $skill->getIDN);
 
@@ -2720,9 +2720,9 @@ sub cmdSlave {
 			error TF("You must be logged in the game to use this command '%s'\n", $cmd .' ' .$subcmd);
 			return;
 		}
-		if ($slave->isa("Actor::Slave::Mercenary")) {
+		if ($slave->isa("AI::Slave::Mercenary")) {
 			$messageSender->sendMercenaryCommand (2);
-		} elsif ($slave->isa("Actor::Slave::Homunculus")) {
+		} elsif ($slave->isa("AI::Slave::Homunculus")) {
 			$messageSender->sendHomunculusCommand (2);
 		}
 	} elsif ($args[0] eq "move") {

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2426,7 +2426,7 @@ sub homunculus_info {
 	if ($args->{state} == HO_PRE_INIT) {
 		my $state = $char->{homunculus}{state}
 			if ($char->{homunculus} && $char->{homunculus}{ID} && $char->{homunculus}{ID} ne $args->{ID});
-		$char->{homunculus} = Actor::get($args->{ID}) if ($char->{homunculus}{ID} ne $args->{ID});
+		$char->{homunculus} = Actor::get($args->{ID});
 		$char->{homunculus}{state} = $state if (defined $state);
 		$char->{homunculus}{map} = $field->baseName;
 		unless ($char->{slaves}{$char->{homunculus}{ID}}) {

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -979,8 +979,7 @@ sub reconstruct_actor_move {
 	$args->{coords} = getCoordString(@{$args}{qw(x y)}, $args->{no_padding});
 }
 
-# should be called sendSlaveMove...
-sub sendHomunculusMove {
+sub sendSlaveMove {
 	my ($self, $ID, $x, $y) = @_;
 	
 	$self->sendToServer($self->reconstruct({
@@ -1151,8 +1150,7 @@ sub sendShowEquipTickbox {
 	debug "Sent Show Equip Tickbox: flag.\n", "sendPacket", 2;
 }
 
-# should be sendSlaveAttack...
-sub sendHomunculusAttack {
+sub sendSlaveAttack {
 	my $self = shift;
 	my $slaveID = shift;
 	my $targetID = shift;
@@ -1168,8 +1166,7 @@ sub sendHomunculusAttack {
 	debug "Sent Slave attack: ".getHex($targetID)."\n", "sendPacket", 2;
 }
 
-# should be sendSlaveStandBy...
-sub sendHomunculusStandBy {
+sub sendSlaveStandBy {
 	my $self = shift;
 	my $slaveID = shift;
 	$self->sendToServer($self->reconstruct({

--- a/src/Network/Send/ServerType21.pm
+++ b/src/Network/Send/ServerType21.pm
@@ -44,7 +44,7 @@ sub sendMove {
 	debug "Sent move to: $x, $y\n", "sendPacket", 2;
 }
 
-sub sendHomunculusMove {
+sub sendSlaveMove {
 	my ($self, $homunID, $x, $y) = @_;
 	
 	$self->sendToServer($self->reconstruct({

--- a/src/Network/Send/ServerType8.pm
+++ b/src/Network/Send/ServerType8.pm
@@ -256,7 +256,7 @@ sub sendTake {
 	debug "Sent take\n", "sendPacket", 2;
 }
 
-sub sendHomunculusMove {
+sub sendSlaveMove {
 	my $self = shift;
 	my $homunID = shift;
 	my $x = int scalar shift;


### PR DESCRIPTION
This PR:
1 - adds a few timeouts for the slaves.
2 - changes most (I believe all) of the wrong messages in the slave AI referring slaves as homunculus.
3 - adds a new sub for selecting the slave target based on the one used for the player.
4 - changed a few sub names to better reflect what they do.
5 - added a "teleport to master" logic to recall the slave when it gets lost.
6 - Fixes the merc and homun command, which did not work because of wrong class check
7 - Fixes the "move near homun if idle" logic which also did not work because of wrong class check
