### PR TITLE
Rework runFromTarget

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -213,7 +213,8 @@ route_reAddMissingPortals 1
 
 runFromTarget 0
 runFromTarget_dist 5
-runFromTarget_step 7
+runFromTarget_minStep 7
+runFromTarget_maxStep 9
 
 saveMap
 saveMap_warpToBuyOrSell 1
@@ -371,7 +372,8 @@ mercenary_attackChangeTarget 1
 
 mercenary_runFromTarget 0
 mercenary_runFromTarget_dist 5
-mercenary_runFromTarget_step 7
+mercenary_runFromTarget_minStep 7
+mercenary_runFromTarget_maxStep 9
 
 mercenary_followDistanceMax 10
 mercenary_followDistanceMin 3
@@ -417,7 +419,8 @@ homunculus_tankModeTarget
 
 homunculus_runFromTarget 0
 homunculus_runFromTarget_dist 5
-homunculus_runFromTarget_step 7
+homunculus_runFromTarget_minStep 7
+homunculus_runFromTarget_maxStep 9
 
 homunculus_StandByAuto 0
 homunculus_teleportAuto_hp 10

--- a/control/config.txt
+++ b/control/config.txt
@@ -212,7 +212,8 @@ route_tryToGuessMissingPortalByDistance 1
 route_reAddMissingPortals 1
 
 runFromTarget 0
-runFromTarget_dist 6
+runFromTarget_dist 5
+runFromTarget_step 7
 
 saveMap
 saveMap_warpToBuyOrSell 1
@@ -368,6 +369,10 @@ mercenary_attackCheckLOS 0
 mercenary_attackNoGiveup 0
 mercenary_attackChangeTarget 1
 
+mercenary_runFromTarget 0
+mercenary_runFromTarget_dist 5
+mercenary_runFromTarget_step 7
+
 mercenary_followDistanceMax 10
 mercenary_followDistanceMin 3
 
@@ -411,7 +416,8 @@ homunculus_tankMode 0
 homunculus_tankModeTarget
 
 homunculus_runFromTarget 0
-homunculus_runFromTarget_dist 6
+homunculus_runFromTarget_dist 5
+homunculus_runFromTarget_step 7
 
 homunculus_StandByAuto 0
 homunculus_teleportAuto_hp 10

--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -460,7 +460,7 @@ sub main {
 		}
 
 	} elsif ($config{'runFromTarget'} && ($realMonsterDist < $config{'runFromTarget_dist'} || $hitYou)) {
-		my $cell = get_kite_position($field, $char, $target, $config{'runFromTarget_dist'}, $config{'runFromTarget_step'});
+		my $cell = get_kite_position($field, $char, $target, $config{'runFromTarget_dist'}, $config{'runFromTarget_minStep'}, $config{'runFromTarget_maxStep'});
 		if ($cell) {
 			$args->{avoiding} = 1;
 			$char->move($cell->{x}, $cell->{y}, $ID);

--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -460,7 +460,7 @@ sub main {
 		}
 
 	} elsif ($config{'runFromTarget'} && ($realMonsterDist < $config{'runFromTarget_dist'} || $hitYou)) {
-		my $cell = get_kite_position($field, $char, $target, $config{'runFromTarget_dist'}, $config{'runFromTarget_minStep'}, $config{'runFromTarget_maxStep'});
+		my $cell = get_kite_position($field, $char, $target, $config{'runFromTarget_dist'}, ($config{'runFromTarget_minStep'} || 7), ($config{'runFromTarget_maxStep'} || 9));
 		if ($cell) {
 			$args->{avoiding} = 1;
 			$char->move($cell->{x}, $cell->{y}, $ID);

--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -462,8 +462,11 @@ sub main {
 	} elsif ($config{'runFromTarget'} && ($realMonsterDist < $config{'runFromTarget_dist'} || $hitYou)) {
 		my $cell = get_kite_position($field, $char, $target, $config{'runFromTarget_dist'}, ($config{'runFromTarget_minStep'} || 7), ($config{'runFromTarget_maxStep'} || 9));
 		if ($cell) {
+			debug TF("%s kiteing from (%d %d) to (%d %d), mob at (%d %d).\n", $char, $realMyPos->{x}, $realMyPos->{y}, $cell->{x}, $cell->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'ai_attack';
 			$args->{avoiding} = 1;
 			$char->move($cell->{x}, $cell->{y}, $ID);
+		} else {
+			debug TF("%s no acceptable place to kite from (%d %d), mob at (%d %d).\n", $char, $realMyPos->{x}, $realMyPos->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'ai_attack';
 		}
 
 	} elsif ($realMonsterDist > $args->{attackMethod}{maxDistance}

--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -460,61 +460,11 @@ sub main {
 		}
 
 	} elsif ($config{'runFromTarget'} && ($realMonsterDist < $config{'runFromTarget_dist'} || $hitYou)) {
-		#my $begin = time;
-		# Get a list of blocks that we can run to
-		my @blocks = calcRectArea($myPos->{x}, $myPos->{y},
-			# If the monster hit you while you're running, then your recorded
-			# location may be out of date. So we use a smaller distance so we can still move.
-			($hitYou) ? $config{'runFromTarget_dist'} / 2 : $config{'runFromTarget_dist'});
-
-		# Find the distance value of the block that's farthest away from a wall
-		my $highest;
-		foreach (@blocks) {
-			my $dist = ord(substr($field->{dstMap}, $_->{y} * $field->width + $_->{x}));
-			if (!defined $highest || $dist > $highest) {
-				$highest = $dist;
-			}
+		my $cell = get_kite_position($field, $char, $target, $config{'runFromTarget_dist'}, $config{'runFromTarget_step'});
+		if ($cell) {
+			$args->{avoiding} = 1;
+			$char->move($cell->{x}, $cell->{y}, $ID);
 		}
-
-		# Get rid of rediculously large route distances (such as spots that are on a hill)
-		# Get rid of blocks that are near a wall
-		my $pathfinding = new PathFinding;
-		use constant AVOID_WALLS => 4;
-		for (my $i = 0; $i < @blocks; $i++) {
-			# We want to avoid walls (so we don't get cornered), if possible
-			my $dist = ord(substr($field->{dstMap}, $blocks[$i]{y} * $field->width + $blocks[$i]{x}));
-			if ($highest >= AVOID_WALLS && $dist < AVOID_WALLS) {
-				delete $blocks[$i];
-				next;
-			}
-
-			$pathfinding->reset(
-				field => $field,
-				start => $myPos,
-				dest => $blocks[$i]);
-			my $ret = $pathfinding->runcount;
-			if ($ret <= 0 || $ret > $config{'runFromTarget_dist'} * 2) {
-				delete $blocks[$i];
-				next;
-			}
-		}
-
-		# Find the block that's farthest to us
-		my $largestDist;
-		my $bestBlock;
-		foreach (@blocks) {
-			next unless defined $_;
-			my $dist = distance($monsterPos, $_);
-			if (!defined $largestDist || $dist > $largestDist) {
-				$largestDist = $dist;
-				$bestBlock = $_;
-			}
-		}
-
-		#message "Time spent: " . (time - $begin) . "\n";
-		#debug_showSpots('runFromTarget', \@blocks, $bestBlock);
-		$args->{avoiding} = 1;
-		$char->move(@{$bestBlock}{qw(x y)}, $ID);
 
 	} elsif ($realMonsterDist > $args->{attackMethod}{maxDistance}
 	  && !timeOut($args->{ai_attack_giveup})) {

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -456,7 +456,7 @@ sub processAttack {
 			}
 
 		} elsif ($config{$slave->{configPrefix}.'runFromTarget'} && ($realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_dist'} || $hitYou)) {
-			my $cell = get_kite_position($field, $slave, $target, $config{$slave->{configPrefix}.'runFromTarget_dist'}, $config{$slave->{configPrefix}.'runFromTarget_step'}, $char, $config{$slave->{configPrefix}.'followDistanceMax'});
+			my $cell = get_kite_position($field, $slave, $target, $config{$slave->{configPrefix}.'runFromTarget_dist'}, $config{$slave->{configPrefix}.'runFromTarget_minStep'}, $config{$slave->{configPrefix}.'runFromTarget_maxStep'}, $char, $config{$slave->{configPrefix}.'followDistanceMax'});
 			if ($cell) {
 				$slave->args->{avoiding} = 1;
 				$slave->move($cell->{x}, $cell->{y}, $ID);

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -456,7 +456,7 @@ sub processAttack {
 			}
 
 		} elsif ($config{$slave->{configPrefix}.'runFromTarget'} && ($realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_dist'} || $hitYou)) {
-			my $cell = get_kite_position($field, $slave, $target, $config{$slave->{configPrefix}.'runFromTarget_dist'}, $config{$slave->{configPrefix}.'runFromTarget_minStep'}, $config{$slave->{configPrefix}.'runFromTarget_maxStep'}, $char, $config{$slave->{configPrefix}.'followDistanceMax'});
+			my $cell = get_kite_position($field, $slave, $target, $config{$slave->{configPrefix}.'runFromTarget_dist'}, ($config{$slave->{configPrefix}.'runFromTarget_minStep'} || 7), ($config{$slave->{configPrefix}.'runFromTarget_maxStep'} || 9), $char, $config{$slave->{configPrefix}.'followDistanceMax'});
 			if ($cell) {
 				$slave->args->{avoiding} = 1;
 				$slave->move($cell->{x}, $cell->{y}, $ID);

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -458,8 +458,11 @@ sub processAttack {
 		} elsif ($config{$slave->{configPrefix}.'runFromTarget'} && ($realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_dist'} || $hitYou)) {
 			my $cell = get_kite_position($field, $slave, $target, $config{$slave->{configPrefix}.'runFromTarget_dist'}, ($config{$slave->{configPrefix}.'runFromTarget_minStep'} || 7), ($config{$slave->{configPrefix}.'runFromTarget_maxStep'} || 9), $char, $config{$slave->{configPrefix}.'followDistanceMax'});
 			if ($cell) {
+				debug TF("%s kiteing from (%d %d) to (%d %d), mob at (%d %d).\n", $slave, $realMyPos->{x}, $realMyPos->{y}, $cell->{x}, $cell->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'slave';
 				$slave->args->{avoiding} = 1;
 				$slave->move($cell->{x}, $cell->{y}, $ID);
+			} else {
+				debug TF("%s no acceptable place to kite from (%d %d), mob at (%d %d).\n", $slave, $realMyPos->{x}, $realMyPos->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'slave';
 			}
 
 		} elsif ($realMonsterDist > $args->{attackMethod}{maxDistance} && !timeOut($args->{ai_attack_giveup})) {

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -455,65 +455,14 @@ sub processAttack {
 				$slave->dequeue;
 			}
 
-		} elsif ($config{$slave->{configPrefix}.'runFromTarget'} && ($monsterDist < $config{$slave->{configPrefix}.'runFromTarget_dist'} || $hitYou)) {
-			#my $begin = time;
-			# Get a list of blocks that we can run to
-			my @blocks = calcRectArea($myPos->{x}, $myPos->{y},
-				# If the monster hit you while you're running, then your recorded
-				# location may be out of date. So we use a smaller distance so we can still move.
-				($hitYou) ? $config{$slave->{configPrefix}.'runFromTarget_dist'} / 2 : $config{$slave->{configPrefix}.'runFromTarget_dist'});
-
-			# Find the distance value of the block that's farthest away from a wall
-			my $highest;
-			foreach (@blocks) {
-				my $dist = ord(substr($field->{dstMap}, $_->{y} * $field->width + $_->{x}));
-				if (!defined $highest || $dist > $highest) {
-					$highest = $dist;
-				}
+		} elsif ($config{$slave->{configPrefix}.'runFromTarget'} && ($realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_dist'} || $hitYou)) {
+			my $cell = get_kite_position($field, $slave, $target, $config{$slave->{configPrefix}.'runFromTarget_dist'}, $config{$slave->{configPrefix}.'runFromTarget_step'}, $char, $config{$slave->{configPrefix}.'followDistanceMax'});
+			if ($cell) {
+				$slave->args->{avoiding} = 1;
+				$slave->move($cell->{x}, $cell->{y}, $ID);
 			}
 
-			# Get rid of rediculously large route distances (such as spots that are on a hill)
-			# Get rid of blocks that are near a wall
-			my $pathfinding = new PathFinding;
-			use constant AVOID_WALLS => 4;
-			for (my $i = 0; $i < @blocks; $i++) {
-				# We want to avoid walls (so we don't get cornered), if possible
-				my $dist = ord(substr($field->{dstMap}, $blocks[$i]{y} * $field->width + $blocks[$i]{x}));
-				if ($highest >= AVOID_WALLS && $dist < AVOID_WALLS) {
-					delete $blocks[$i];
-					next;
-				}
-
-				$pathfinding->reset(
-					field => $field,
-					start => $myPos,
-					dest => $blocks[$i]);
-				my $ret = $pathfinding->runcount;
-				if ($ret <= 0 || $ret > $config{$slave->{configPrefix}.'runFromTarget_dist'} * 2) {
-					delete $blocks[$i];
-					next;
-				}
-			}
-
-			# Find the block that's farthest to us
-			my $largestDist;
-			my $bestBlock;
-			foreach (@blocks) {
-				next unless defined $_;
-				my $dist = distance($monsterPos, $_);
-				if (!defined $largestDist || $dist > $largestDist) {
-					$largestDist = $dist;
-					$bestBlock = $_;
-				}
-			}
-
-			#message "Time spent: " . (time - $begin) . "\n";
-			#debug_showSpots('runFromTarget', \@blocks, $bestBlock);
-			$slave->args->{avoiding} = 1;
-			$slave->move($bestBlock->{x}, $bestBlock->{y}, $ID);
-
-		} elsif (!$config{$slave->{configPrefix}.'runFromTarget'} && $monsterDist > $args->{attackMethod}{maxDistance}
-		  && !timeOut($args->{ai_attack_giveup})) {
+		} elsif ($realMonsterDist > $args->{attackMethod}{maxDistance} && !timeOut($args->{ai_attack_giveup})) {
 			# The target monster moved; move to target
 			$args->{move_start} = time;
 			$args->{monsterPos} = {%{$monsterPos}};

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -875,8 +875,6 @@ use constant AVOID_MASTER_BOUND => 2;
 sub get_kite_position {
 	my ($field, $actor, $target, $min_dist_from_target, $move_distance_min, $move_distance_max, $master, $max_dist_to_master) = @_;
 
-	message TF("[test kite] min_dist_from_target %d, move_distance_min %d, move_distance_max %d, max_dist_to_master %d.\n", $min_dist_from_target, $move_distance_min, $move_distance_max, $max_dist_to_master), 'slave';
-
 	my ($actor_pos, $enemy_pos, $master_pos);
 	my $pathfinding = new PathFinding;
 
@@ -998,13 +996,6 @@ sub get_kite_position {
 		} elsif ($skip_near_master_bound) {
 			next if ($cell->{master_bound_dist} < AVOID_MASTER_BOUND);
 		}
-
-		my $master_string;
-		if ($master) {
-			$master_string = TF(", master at (%d %d)", $master_pos->{x}, $master_pos->{y});
-		}
-		message TF("%s kiteing from (%d %d) to (%d %d), mob at (%d %d)%s.\n", $actor, $actor_pos->{x}, $actor_pos->{y}, $cell->{x}, $cell->{y}, $enemy_pos->{x}, $enemy_pos->{y}, $master_string), 'slave';
-
 		return { x => $cell->{x}, y => $cell->{y} };
 	}
 

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -859,14 +859,15 @@ use constant AVOID_WALLS => 4;
 use constant AVOID_MASTER_BOUND => 2;
 
 ##
-# get_kite_position(field, actor, target, min_dist_from_target, move_distance, master, max_dist_to_master)
+# get_kite_position(field, actor, target, min_dist_from_target, move_distance_min, move_distance_max, master, max_dist_to_master)
 # field: Field object of the map 'actor' should kite on.
 # actor: reference to the actor which is kiting.
 # target: reference to the actor which you are kiting.
-# min_dist_from_target: the minimun distance 'actor' should keep from 'target'.
-# move_distance: the distance which 'actor' should try to move away from 'target'.
+# min_dist_from_target: the minimum distance 'actor' should keep from 'target'.
+# move_distance: the minimum distance which 'actor' should try to move away from 'target'.
+# move_distance: the maximum distance which 'actor' should try to move away from 'target'.
 # master: reference to the actor which is the master of 'actor', if 'actor' is a slave (homunculus or mercenary).
-# max_dist_to_master: the maximun distance 'actor' should move away from 'master'.
+# max_dist_to_master: the maximum distance 'actor' should move away from 'master'.
 #
 # Returns: reference to a hash containing both x and y coordinates of the best kite position found on success, and undef on failure
 #

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -28,6 +28,8 @@ use Data::Dumper;
 use Compress::Zlib;
 use base qw(Exporter);
 use utf8;
+use Math::Trig;
+use Math::Trig qw/pi pi2 pip4/;
 
 use Globals;
 use Log qw(message warning error debug);
@@ -76,7 +78,8 @@ our @EXPORT = (
 	closestWalkableSpot
 	objectInsideSpell
 	objectIsMovingTowards
-	objectIsMovingTowardsPlayer/,
+	objectIsMovingTowardsPlayer
+	get_kite_position/,
 
 	# Inventory management
 	qw/inInventory
@@ -850,6 +853,133 @@ sub objectIsMovingTowardsPlayer {
 		}
 	}
 	return 0;
+}
+
+##
+# get_kite_position(field, actor, target, min_dist_from_target, move_distance, master, max_dist_to_master)
+# field: Field object of the map 'actor' should kite on.
+# actor: reference to the actor which is kiting.
+# target: reference to the actor which you are kiting.
+# min_dist_from_target: the minimun distance 'actor' should keep from 'target'.
+# move_distance: the distance which 'actor' should try to move away from 'target'.
+# master: reference to the actor which is the master of 'actor', if 'actor' is a slave (homunculus or mercenary).
+# max_dist_to_master: the maximun distance 'actor' should move away from 'master'.
+#
+# Returns: reference to a hash containing both x and y coordinates of the best kite position found on success, and undef on failure
+#
+# Kite algorithm used in runFromTarget
+sub get_kite_position {
+	my ($field, $actor, $target, $min_dist_from_target, $move_distance, $master, $max_dist_to_master) = @_;
+
+	my ($actor_pos, $enemy_pos, $master_pos);
+	
+	$actor_pos = calcPosition($actor);
+	$enemy_pos = calcPosition($target);
+	if ($master) {
+		$master_pos = calcPosition($master);
+	}
+
+	my $initial_rad = atan2(($actor_pos->{y} - $enemy_pos->{y}), ($actor_pos->{x} - $enemy_pos->{x}));
+	if ($initial_rad < 0) {
+		$initial_rad += pi2;
+	}
+
+	my $current_rad = $initial_rad;
+	my $cos_cur = cos($current_rad);
+	my $sin_cur = sin($current_rad);
+
+	# Biggest possible angle between 2 adjacent cells in dist $move_distance
+	my $angle_a = atan2(($move_distance-1), $move_distance);
+	my $angle_b = atan2(($move_distance-1), ($move_distance+1));
+	my $added_rad_per_loop = pip4 - max($angle_a, $angle_b);
+
+	my $current_mod = 1;
+	my $total_added_rad = 0;
+	my $max_rad = pi;
+	my %last_pos_by_mod = (
+		'1' => {
+			x => undef,
+			y => undef
+		},
+		'-1' => {
+			x => undef,
+			y => undef
+		}
+	);
+	my %best_not_distant_cell = (
+		x => undef,
+		y => undef,
+		distance_dif => undef,
+	);
+	my %kite_pos = (
+		x => undef,
+		y => undef,
+	);
+	my %result;
+	while ($total_added_rad < $max_rad) {
+		$result{x} = $enemy_pos->{x} + int($move_distance * $cos_cur);
+		$result{y} = $enemy_pos->{y} + int($move_distance * $sin_cur);
+		next if (defined $last_pos_by_mod{$current_mod}{x} && $result{x} == $last_pos_by_mod{$current_mod}{x} && $result{y} == $last_pos_by_mod{$current_mod}{y});
+		
+		$last_pos_by_mod{$current_mod}{x} = $result{x};
+		$last_pos_by_mod{$current_mod}{y} = $result{y};
+
+		next if (!$field->isWalkable($result{x}, $result{y}));
+		if ($master) {
+			next if (blockDistance($master_pos, \%result) > $max_dist_to_master);
+		}
+		next if (distance(\%result, $enemy_pos) < $min_dist_from_target);
+		next if (!checkLineWalkable($actor_pos, \%result, 2));
+		
+		my $dist_dif = distance(\%result, $actor_pos) - distance(\%result, $enemy_pos);
+		if ($dist_dif > 0) {
+			if (!defined $best_not_distant_cell{x} || $best_not_distant_cell{distance_dif} > $dist_dif) {
+				$best_not_distant_cell{x} = $result{x};
+				$best_not_distant_cell{y} = $result{y};
+				$best_not_distant_cell{distance_dif} = $dist_dif;
+			}
+			next;
+		}
+
+		$kite_pos{x} = $result{x};
+		$kite_pos{y} = $result{y};
+		last;
+
+	} continue {
+		if ($current_mod == 1 && $total_added_rad > 0) {
+			$current_mod = -1;
+		} else {
+			$current_mod = 1;
+			$total_added_rad += $added_rad_per_loop;
+		}
+
+		$current_rad = $initial_rad + ($total_added_rad * $current_mod);
+
+		if ($current_rad >= pi2) {
+			$current_rad -= pi2;
+		} elsif ($current_rad < 0) {
+			$current_rad += pi2;
+		}
+
+		$cos_cur = cos($current_rad);
+		$sin_cur = sin($current_rad);
+	}
+
+	if (!defined $kite_pos{x} && defined $best_not_distant_cell{x}) {
+		$kite_pos{x} = $best_not_distant_cell{x};
+		$kite_pos{y} = $best_not_distant_cell{y};
+	}
+
+	if (defined $kite_pos{x}) {
+		my $master_string;
+		if ($master) {
+			$master_string = TF(", master at (%d %d)", $master_pos->{x}, $master_pos->{y});
+		}
+		message TF("%s kiteing from (%d %d) to (%d %d), mob at (%d %d)%s.\n", $actor, $actor_pos->{x}, $actor_pos->{y}, $kite_pos{x}, $kite_pos{y}, $enemy_pos->{x}, $enemy_pos->{y}, $master_string), 'slave';
+		return \%kite_pos;
+	}
+
+	return undef;
 }
 
 


### PR DESCRIPTION
This PR is a rework of the runFromTarget logic, it also adds support for mercenary runFromTarget.
Most of the code is commented but the basic idea is that while the current code works, it does not specify the amount of distance you would like to keep from the target while also not being that smart.
This new code uses trigonometry to find the best cells to move.

Video of the current master code in action:
https://www.youtube.com/watch?v=f4wZ2xlpAgI

Video of the reworked logic in action:
https://www.youtube.com/watch?v=1oiesxS5EaM

Video of the reworked logic running in a mercenary:
https://www.youtube.com/watch?v=Ee99aKdcdsQ

```
runFromTarget_dist: The minimum distance to keep from target
runFromTarget_minStep: The minimum distance to try to move away from target
runFromTarget_maxStep: The maximum distance to try to move away from target
```

All videos were done with attackCheckLOS, attackCanSnipe and attackDistanceAuto enabled.