### PR TITLE
small fix avoid hash

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3933,12 +3933,11 @@ sub avoidGM_near {
 		# skip this person if we dont know the name
 		next if (!defined $player->{name});
 
-		# Check whether this "GM" is on the ignore list
-		# in order to prevent false matches
-		last if (existsInList($config{avoidGM_ignoreList}, $player->{name}));
+		# Check whether this "GM" is on the ignore list in order to prevent false matches
+		next if (existsInList($config{avoidGM_ignoreList}, $player->{name}));
 
 		# check if this name matches the GM filter
-		last unless ($config{avoidGM_namePattern} ? $player->{name} =~ /$config{avoidGM_namePattern}/ : $player->{name} =~ /^([a-z]?ro)?-?(Sub)?-?\[?GM\]?/i);
+		next unless ($config{avoidGM_namePattern} ? $player->{name} =~ /$config{avoidGM_namePattern}/ : $player->{name} =~ /^([a-z]?ro)?-?(Sub)?-?\[?GM\]?/i);
 
 		my %args = (
 			name => $player->{name},
@@ -3988,11 +3987,14 @@ sub avoidList_near {
 	return if ($config{avoidList_inLockOnly} && $field->baseName ne $config{lockMap});
 
 	for my $player (@$playersList) {
+		# skip this person if we dont know the name
+		next if (!defined $player->{name});
+
 		my $avoidPlayer = $avoid{Players}{lc($player->{name})};
 		my $avoidID = $avoid{ID}{$player->{nameID}};
 
-		# Exit if the player is not on the avoid list
-		last if (!$avoidPlayer and !$avoidID);
+		# next if the player is not on the avoid list
+		next if (!$avoidPlayer and !$avoidID);
 
 		my %args = (
 			name => $player->{name},


### PR DESCRIPTION
every time the `avoidList_talk` function is run, the name of the new player is added to the% avoid hash
Example:
```perl
#!/usr/bin/env perl
%avoid = ();
$avoid{Players}{"[GM]Example"}{disconnect_on_chat} = 0;
$avoid{ID}{"000001"}{disconnect_on_chat} = 3;
use Data::Dumper; print Dumper(%avoid);

print "====================\n";
$user = "zzzzzzzzzzzzzzzzzzzzzzzzzz";
if ($avoid{Players}{lc($user)}{disconnect_on_chat}) {
    print "if true $user\n";
}

use Data::Dumper; print Dumper(%avoid);
```
![avoid](https://user-images.githubusercontent.com/7117363/66642878-45794a80-ec26-11e9-9de7-03e90f518d1d.png)
this PR corrects this behavior