### PR TITLE
Change avoid gm and avoid list

### DIFF
--- a/control/avoid.txt
+++ b/control/avoid.txt
@@ -4,31 +4,31 @@
 # Format: <name> (TAB(s)) <disconnect when in sight> <teleport when in sight> <disconnect on chat>
 [Players]
 # Examples:
-[GM]Example		1 0 1
-# Sir Kills A Lot		1 0 1
-# GOD-POING		1 0 1
-# Petite Christy		1 0 1
+[GM]Example			1 0 1
+# Sir Kills A Lot	1 0 1
+# GOD-POING			1 0 1
+# Petite Christy	1 0 1
 # My Christy		1 0 1
 # pusher			1 0 1
-# Aerok			1 0 1
+# Aerok				1 0 1
 # Newbie			1 0 1
 # Queenstown		1 0 1
 # karlina			1 0 1
-# Style			1 0 1
+# Style				1 0 1
 # -Aerok-			1 0 1
-# Kross			1 0 1
+# Kross				1 0 1
 # ~Jinx~			1 0 1
-# Rose			1 0 1
+# Rose				1 0 1
 # Ebi-chu			1 0 1
 # MeloColmECA		1 0 1
 # Leileil			1 0 1
-# Angel			1 0 1
+# Angel				1 0 1
 
 [ID]
 # Same as above, but uses player IDs instead of names
 # There is no disconnect on chat for this section.
 # Examples:
-000001		1 0
+000001			1 0
 # 100001		1 0
 # 100002		1 0
 # 100003		1 0
@@ -52,3 +52,15 @@
 # 527205		1 0
 # 483471		1 0
 # 527211		1 0
+
+[Jobs]
+# Same as above, but uses player jobs instead of names
+# There is no disconnect on chat for this section.
+# Examples:
+# see https://github.com/OpenKore/openkore/blob/master/src/Globals.pm#L141
+#Acolyte	0 1
+#Priest		0 1
+#Monk		0 1
+#Thief		0 1
+#Assassin	0 1
+#Rogue		0 1

--- a/control/config.txt
+++ b/control/config.txt
@@ -138,6 +138,7 @@ avoidGM_ignoreList
 avoidList 1
 avoidList_inLockOnly 0
 avoidList_reconnect 1800
+avoidList_ignoreList
 
 cachePlayerNames 1
 cachePlayerNames_duration 900

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3950,23 +3950,28 @@ sub avoidGM_near {
 		if ($config{avoidGM_near} == 1) {
 			# Mode 1: teleport & disconnect
 			useTeleport(1);
-			$msg = TF("GM %s is nearby, teleport & disconnect for %d seconds", $player->{name}, $config{avoidGM_reconnect});
+			$msg = TF("GM %s (%s) is nearby, teleport & disconnect for %d seconds", $player->{name}, $player->{nameID}, $config{avoidGM_reconnect});
 			relog($config{avoidGM_reconnect}, 1);
 
 		} elsif ($config{avoidGM_near} == 2) {
 			# Mode 2: disconnect
-			$msg = TF("GM %s is nearby, disconnect for %s seconds", $player->{name}, $config{avoidGM_reconnect});
+			$msg = TF("GM %s (%s) is nearby, disconnect for %s seconds", $player->{name}, $player->{nameID}, $config{avoidGM_reconnect});
 			relog($config{avoidGM_reconnect}, 1);
 
 		} elsif ($config{avoidGM_near} == 3) {
 			# Mode 3: teleport
 			useTeleport(1);
-			$msg = TF("GM %s is nearby, teleporting", $player->{name});
+			$msg = TF("GM %s (%s) is nearby, teleporting", $player->{name}, $player->{nameID});
 
-		} elsif ($config{avoidGM_near} >= 4) {
+		} elsif ($config{avoidGM_near} == 4) {
 			# Mode 4: respawn
 			useTeleport(2);
-			$msg = TF("GM %s is nearby, respawning", $player->{name});
+			$msg = TF("GM %s (%s) is nearby, respawning", $player->{name}, $player->{nameID});
+		} elsif ($config{avoidGM_near} >= 5) {
+			# Mode 5: respawn & disconnect
+			useTeleport(2);
+			$msg = TF("GM %s (%s) is nearby, respawning & disconnect for %d seconds", $player->{name}, $player->{nameID}, $config{avoidGM_reconnect});
+			relog($config{avoidGM_reconnect}, 1);
 		}
 
 		warning "$msg\n";

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3995,6 +3995,8 @@ sub avoidList_near {
 	for my $player (@$playersList) {
 		# skip this person if we dont know the name
 		next if (!defined $player->{name});
+		# Check whether this Player is on the ignore list in order to prevent false matches
+		next if (existsInList($config{avoidList_ignoreList}, $player->{name}));
 
 		my $avoidPlayer = $avoid{Players}{lc($player->{name})};
 		my $avoidID = $avoid{ID}{$player->{nameID}};


### PR DESCRIPTION
1. Added new mode for `avoidGM_near`
2. Changed reaction to avoidList, like avoidGM

Mode 1: `test3	1 1 0`
```
Disconnecting (69.197.167.236:5121)...disconnected
Player test3 (2000742) is nearby, teleport & disconnect for 10 seconds
```

Mode 2: `test3	1 0 0`
```
Disconnecting (69.197.167.236:5121)...disconnected
Player test3 (2000742) is nearby, disconnect for 10 seconds
```

Mode 3: `test3	0 1 0`
```
Player test3 (2000742) is nearby, teleporting
You are casting Teleport on yourself (Delay: 0ms)
You use Teleport on yourself (Lv: 1)
```

Mode 4: `test3	0 2 0`
```
Player test3 (2000742) is nearby, respawning
You are casting Teleport on yourself (Delay: 0ms)
You use Teleport on yourself (Lv: 2)
```

Mode 5: `test3	1 2 0`
```
Sending Teleport using Level 2
Disconnecting (69.197.167.236:5121)...disconnected
Player test3 (2000742) is nearby, respawning & disconnect for 10 seconds
```