### PR TITLE
Cmd plugin fix

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4487,7 +4487,9 @@ sub cmdPlugin {
 		my @names;
 
 		if ($args[1] =~ /^\d+$/) {
-			push @names, $Plugins::plugins[$args[1]]{name};
+			if ($Plugins::plugins[$args[1]]{name}) {
+				push @names, $Plugins::plugins[$args[1]]{name};
+			}
 
 		} elsif ($args[1] eq '') {
 			error T("Syntax Error in function 'plugin reload' (Reload Plugin)\n" .
@@ -4497,6 +4499,7 @@ sub cmdPlugin {
 		} elsif ($args[1] eq 'all') {
 			foreach my $plugin (@Plugins::plugins) {
 				next unless $plugin;
+				next unless $plugin->{name};
 				push @names, $plugin->{name};
 			}
 
@@ -4507,11 +4510,12 @@ sub cmdPlugin {
 					push @names, $plugin->{name};
 				}
 			}
-			if (!@names) {
-				error T("Error in function 'plugin reload' (Reload Plugin)\n" .
-					"The specified plugin names do not exist.\n");
-				return;
-			}
+		}
+
+		if (!@names) {
+				warning T("Error in function 'plugin reload' (Reload Plugin)\n" .
+					"The specified plugin do not exist.\n");
+			return;
 		}
 
 		foreach (my $i = 0; $i < @names; $i++) {

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4530,14 +4530,18 @@ sub cmdPlugin {
 		} elsif ($args[1] eq 'all') {
 			Plugins::loadAll();
 		} else {
-			if (-e $args[1]) {
-			# then search inside plugins folder !
-				Plugins::load($args[1]);
-			} elsif (-e $Plugins::current_plugin_folder."\\".$args[1]) {
-				Plugins::load($Plugins::current_plugin_folder."\\".$args[1]);
-			} elsif (-e $Plugins::current_plugin_folder."\\".$args[1].".pl") {
-				# we'll try to add .pl ....
-				Plugins::load($Plugins::current_plugin_folder."\\".$args[1].".pl");
+			my @folders = Settings::getPluginsFolders();
+			my $name = $args[1];
+			$name =~ s/.pl$//g;
+			if (-f @folders[0]."\\".$name.".pl") {
+				# plugins\$name.pl
+				Plugins::load(@folders[0]."\\".$name.".pl");
+			} elsif (-f @folders[0]."\\".$name."\\".$name.".pl") {
+				# plugins\$name\$name.pl
+				Plugins::load(@folders[0]."\\".$name."\\".$name.".pl");
+			} else {
+				error TF("Plugin '%s' does not exist\n", $name);
+				return;
 			}
 		}
 

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4487,7 +4487,7 @@ sub cmdPlugin {
 		my @names;
 
 		if ($args[1] =~ /^\d+$/) {
-			if ($Plugins::plugins[$args[1]]{name}) {
+			if ($Plugins::plugins[$args[1]]) {
 				push @names, $Plugins::plugins[$args[1]]{name};
 			}
 
@@ -4546,13 +4546,11 @@ sub cmdPlugin {
 		}
 
 	} elsif ($args[0] eq 'unload') {
+		my $name;
+
 		if ($args[1] =~ /^\d+$/) {
 			if ($Plugins::plugins[$args[1]]) {
-				my $name = $Plugins::plugins[$args[1]]{name};
-				Plugins::unload($name);
-				message TF("Plugin %s unloaded.\n", $name), "system";
-			} else {
-				error TF("'%s' is not a valid plugin number.\n", $args[1]);
+				$name = $Plugins::plugins[$args[1]]{name};
 			}
 
 		} elsif ($args[1] eq '') {
@@ -4562,16 +4560,24 @@ sub cmdPlugin {
 
 		} elsif ($args[1] eq 'all') {
 			Plugins::unloadAll();
+			message T("All plugins have been unloaded.\n"), "system";
+			return;
 
 		} else {
 			foreach my $plugin (@Plugins::plugins) {
 				next unless $plugin;
 				if ($plugin->{name} =~ /$args[1]/i) {
-					my $name = $plugin->{name};
-					Plugins::unload($name);
-					message TF("Plugin %s unloaded.\n", $name), "system";
+					$name = $plugin->{name};
 				}
 			}
+		}
+
+		if ($name) {
+			Plugins::unload($name);
+			message TF("Plugin %s unloaded.\n", $name), "system";
+		} else {
+			warning T("Error in function 'plugin unload' (Unload Plugin)\n" .
+				"The specified plugin do not exist.\n");
 		}
 
 	} else {


### PR DESCRIPTION
1) small fix for `plugin reload` command
warning output was added if you are trying to reload a non-existing plugin by its number
before:
```
 plugin reload 666
 ...
 <Nothing happens>
```
after:
```
 plugin reload 666
 Error in function 'plugin reload' (Reload Plugin)
 The specified plugin do not exist.
```
----
2) small fix for `plugin unload` command
2.1) every time when a non-existent plugin is unloaded by its number, a false plugin was registered in the system
2.2) warning output was added if you are trying to unload a non-existing plugin by its name
before:
```
plugin
-------------------------- Currently loaded plugins ---------------------------
#   Name                 Description
0   macro                allows usage of macros
-------------------------------------------------------------------------------
plugin unload test
 <Nothing happens>
plugin unload 666
Plugin  unloaded.
plugin
-------------------------- Currently loaded plugins ---------------------------
#   Name                 Description
0   macro                allows usage of macros
666
-------------------------------------------------------------------------------
```
after:
```
plugin
-------------------------- Currently loaded plugins ---------------------------
#   Name                 Description
0   macro                allows usage of macros
-------------------------------------------------------------------------------
plugin unload test
Error in function 'plugin unload' (Unload Plugin)
The specified plugin do not exist.
plugin unload 666
Error in function 'plugin unload' (Unload Plugin)
The specified plugin do not exist.
plugin
-------------------------- Currently loaded plugins ---------------------------
#   Name                 Description
0   macro                allows usage of macros
-------------------------------------------------------------------------------
```
----
3)  fixed the `plugin load` command
variable `$Plugins::current_plugin_folder` was always empty
before:
```
 plugin load macro
 ...
 <Nothing happens>
```
after:
```
 plugin load macro
 Loading plugin plugins\macro\macro.pl...
```