### PR TITLE
Wx npc portal

### DIFF
--- a/src/Interface/Wx.pm
+++ b/src/Interface/Wx.pm
@@ -1418,22 +1418,28 @@ sub onMapMouseMove {
 
 		foreach my $portal (@{$self->{mapViewer}->{portals}->{$field->baseName}}) {
 			if (distance($portal,{x=>$x,y=>$y}) <= ($config{wx_map_portalSticking} || 5)) {
-					$self->{mouseMapText} = TF("Portal at %s %s  -  Destination: %s, at %s %s", $x, $y, $portal->{destination}{field}, $portal->{destination}{x}, $portal->{destination}{y});
+					if ($portal->{npcType}) {
+						# this is a Warp NPC
+						$self->{mouseMapText} = TF("Warp NPC at %d %d", $x, $y);
+					} else {
+						# this is a portal
+						$self->{mouseMapText} = TF("Portal at %d %d  -  Destination: %s, at %d %d", $x, $y, $portal->{destination}{field}, $portal->{destination}{x}, $portal->{destination}{y});
+					}
 				}
 			}
 		foreach my $monster (@{$self->{mapViewer}->{monsters}}) {
 			if (distance($monster->{pos},{x=>$x,y=>$y}) <= ($config{wx_map_monsterSticking} || 1)) {
-				$self->{mouseMapText} = TF("%s at %s, %s", Actor::get($monster->{ID}), $x, $y);
+				$self->{mouseMapText} = TF("%s at %d, %d", Actor::get($monster->{ID}), $x, $y);
 			}
 		}
 		foreach my $players (@{$self->{mapViewer}->{players}}) {
 			if (distance($players->{pos},{x=>$x,y=>$y}) <= ($config{wx_map_playersSticking} || 1)) {
-				$self->{mouseMapText} = TF("%s at %s, %s  -  Class: %s", Actor::get($players->{ID}), $x, $y, $jobs_lut{$players->{jobID}});
+				$self->{mouseMapText} = TF("%s at %d, %d  -  Class: %s", Actor::get($players->{ID}), $x, $y, $jobs_lut{$players->{jobID}});
 			}
 		}
 		foreach my $npc (@{$self->{mapViewer}->{npcs}}){
 			if (distance($npc->{pos},{x=>$x,y=>$y}) <= ($config{wx_map_npcSticking} || 1)) {
-				$self->{mouseMapText} = TF("%s at %s, %s", Actor::get($npc->{ID}), $x, $y);
+				$self->{mouseMapText} = TF("%s at %d, %d", Actor::get($npc->{ID}), $x, $y);
 			}
 		}
 	} else {

--- a/src/Interface/Wx.pm
+++ b/src/Interface/Wx.pm
@@ -94,7 +94,7 @@ sub OnInit {
 		['mainLoop_pre',                        sub { $self->onUpdateUI(); }],
 		['captcha_file',                        sub { $self->onCaptcha(@_); }],
 		['packet/minimap_indicator',            sub { $self->onMapIndicator (@_); }],
-		['start3',				sub { delete $interface->{mapViewer}->{portals} if ($interface->{mapViewer}->{portals});$interface->{mapViewer}->parsePortals(Settings::getTableFilename("portals.txt")); }],
+		['start3',                              sub { $interface->{mapViewer}->parsePortals(); }],
 		
 		# stat changes
 		['packet/map_changed',                  sub { $self->onSelfStatChange (@_); $self->onSlaveStatChange (@_); $self->onPetStatChange (@_); }],
@@ -795,7 +795,6 @@ sub createSplitterContent {
 	$mapView->onMouseMove(\&onMapMouseMove, $self);
 	$mapView->onClick(\&onMapClick, $self);
 	$mapView->onMapChange(\&onMap_MapChange, $mapDock);
-	#$mapView->parsePortals(Settings::getTableFilename("portals.txt"));#too early ?
 	if ($field && $char) {
 		$mapView->set($field->baseName, $char->{pos_to}{x}, $char->{pos_to}{y}, $field);
 	}

--- a/src/Interface/Wx/MapViewer.pm
+++ b/src/Interface/Wx/MapViewer.pm
@@ -55,6 +55,7 @@ sub new {
 	$self->{textColor}{npc}     = new Wx::Colour (127, 0, 127);
 	$self->{brush}{portal}      = new Wx::Brush(new Wx::Colour(255, 128, 64), wxSOLID);
 	$self->{textColor}{portal}  = new Wx::Colour (191, 95, 47);
+	$self->{brush}{portalNpc}   = new Wx::Brush(new Wx::Colour(0, 255, 255), wxSOLID);
 	$self->{brush}{slave}       = new Wx::Brush(new Wx::Colour(0, 0, 127), wxSOLID);
 	
 	$self->{brush}{gaugeBg}     = new Wx::Brush(new Wx::Colour(63, 63, 63), wxSOLID);
@@ -633,9 +634,13 @@ sub _onPaint {
 			$dc->SetPen(wxBLACK_PEN);
 		}
 		
+		foreach my $pos (@{$self->{portals}->{$self->{field}{name}}}) {
+			if ($pos->{npcType}) {
+				$dc->SetBrush($self->{brush}{portalNpc});
+			} else {
 				$dc->SetBrush($self->{brush}{portal});
 				$dc->SetTextForeground ($self->{textColor}{portal});
-		foreach my $pos (@{$self->{portals}->{$self->{field}{name}}}) {
+			}
 			($x, $y) = $self->_posXYToView($pos->{x}, $pos->{y});
 			$dc->DrawEllipse($x - $portal_r, $y - $portal_r, $portal_d, $portal_d);
 			if ($self->{zoom} >= ($config{wx_map_namesDetail} || 8)) {

--- a/tables/portals.txt
+++ b/tables/portals.txt
@@ -574,20 +574,6 @@ bat_room 169 211 bat_room 154 150
 #(chatroom) bat_room 169 205 bat_c01 147 56
 bat_c01 148 54 bat_room 154 150 0 c
 
-# iRO custom novice version of prt_fild08
-izlude 20 98 prt_fild08a 367 212
-moc_fild01 239 382 prt_fild08a 233 16
-moc_fild01 56 384 prt_fild08a 55 21
-prontera 156 22 prt_fild08a 170 378
-prt_fild07 383 239 prt_fild08a 16 239
-prt_fild07 385 186 prt_fild08a 16 187
-prt_fild08a 16 187 prt_fild07 385 186
-prt_fild08a 16 239 prt_fild07 383 239
-prt_fild08a 55 21 moc_fild01 56 384
-prt_fild08a 170 378 prontera 156 22
-prt_fild08a 233 16 moc_fild01 239 382
-prt_fild08a 371 212 izlude 24 98
-
 #################### Criatura Academy ####################
 izlude 125 257 iz_ac01 99 29
 izlude 130 257 iz_ac01 99 29


### PR DESCRIPTION
this patch fixes: #2429 and #2965:
- now function `parsePortals` uses global hash `%portals_lut`
- Warp NPCs are now cyan

Thanks @c4c1n6kr3m1 

![fix](https://user-images.githubusercontent.com/7117363/68078694-865f1c00-fdec-11e9-9c35-9953f42c163b.png)
