### PR TITLE
[Fix] move in_game hook and initMapChangeVars to where is needed

### DIFF
--- a/src/Network/Receive/Sakray.pm
+++ b/src/Network/Receive/Sakray.pm
@@ -61,32 +61,34 @@ sub map_loaded {
 	undef $conState_tries;
 	$char = $chars[$config{char}];
 	return unless Network::Receive::changeToInGameState;
+	main::initMapChangeVars();
 
 	if ($net->version == 1) {
 		$net->setState(4);
 		message(T("Waiting for map to load...\n"), "connection");
 		ai_clientSuspend(0, $timeout{'ai_clientSuspend'}{'timeout'});
-		main::initMapChangeVars();
+		
 	} else {
 		$messageSender->sendReqRemainTime();
 		$messageSender->sendMapLoaded();
 		$messageSender->sendSync(1);
 		$messageSender->sendRequestCashItemsList();
 		$messageSender->sendGuildRequestInfo();
-		
-		message(T("You are now in the game\n"), "connection");
-		Plugins::callHook('in_game');
-		$timeout{'ai'}{'time'} = time;
-		our $quest_generation++;
-
-		$messageSender->sendIgnoreAll("all") if ($config{ignoreAll}); # broking xkore 1 and 3 when use cryptkey
 		$messageSender->sendBlockingPlayerCancel(); # request to unfreeze char
 	}
+
+	message(T("You are now in the game\n"), "connection");
+	Plugins::callHook('in_game');
+	$timeout{'ai'}{'time'} = time;
+	our $quest_generation++;
 
 	$char->{pos} = {};
 	makeCoordsDir($char->{pos}, $args->{coords}, \$char->{look}{body});
 	$char->{pos_to} = {%{$char->{pos}}};
 	message(TF("Your Coordinates: %s, %s\n", $char->{pos}{x}, $char->{pos}{y}), undef, 1);
+
+	# ignoreAll
+	$ignored_all = 0;
 }
 
 1;

--- a/src/Network/Receive/ServerType15.pm
+++ b/src/Network/Receive/ServerType15.pm
@@ -26,12 +26,12 @@ sub map_loaded {
 	undef $conState_tries;
 	$char = $chars[$config{char}];
 	$syncMapSync = pack('V1',$args->{syncMapSync});
+	main::initMapChangeVars();
 
 	if ($net->version == 1) {
 		$net->setState(4);
 		message T("Waiting for map to load...\n"), "connection";
 		ai_clientSuspend(0, $timeout{'ai_clientSuspend'}{'timeout'});
-		main::initMapChangeVars();
 	} else {
 		$messageSender->sendMapLoaded();
 		$messageSender->sendSync(1);
@@ -43,17 +43,19 @@ sub map_loaded {
 
 		# Replies 0166 (Guild Member Titles List) and 0154 (Guild Members List)
 		$messageSender->sendGuildRequestInfo(1);
-		message(T("You are now in the game\n"), "connection");
-		Plugins::callHook('in_game');
-		$timeout{'ai'}{'time'} = time;
 	}
+
+	message(T("You are now in the game\n"), "connection");
+	Plugins::callHook('in_game');
+	$timeout{'ai'}{'time'} = time;
 
 	$char->{pos} = {};
 	makeCoordsDir($char->{pos}, $args->{coords});
 	$char->{pos_to} = {%{$char->{pos}}};
 	message(TF("Your Coordinates: %s, %s\n", $char->{pos}{x}, $char->{pos}{y}), undef, 1);
 
-	$messageSender->sendIgnoreAll("all") if ($config{ignoreAll});
+	# ignoreAll
+	$ignored_all = 0;
 }
 
 1;

--- a/src/Network/Receive/ServerType19.pm
+++ b/src/Network/Receive/ServerType19.pm
@@ -26,12 +26,12 @@ sub map_loaded {
 	undef $conState_tries;
 	$char = $chars[$config{char}];
 	$syncMapSync = pack('V1',$args->{syncMapSync});
+	main::initMapChangeVars();
 
 	if ($net->version == 1) {
 		$net->setState(4);
 		message T("Waiting for map to load...\n"), "connection";
 		ai_clientSuspend(0, $timeout{'ai_clientSuspend'}{'timeout'});
-		main::initMapChangeVars();
 	} else {
 		$messageSender->sendMapLoaded();
 		$messageSender->sendSync(1);
@@ -43,17 +43,19 @@ sub map_loaded {
 
 		# Replies 0166 (Guild Member Titles List) and 0154 (Guild Members List)
 		$messageSender->sendGuildRequestInfo(1);
-		message(T("You are now in the game\n"), "connection");
-		Plugins::callHook('in_game');
-		$timeout{'ai'}{'time'} = time;
 	}
+
+	message(T("You are now in the game\n"), "connection");
+	Plugins::callHook('in_game');
+	$timeout{'ai'}{'time'} = time;
 
 	$char->{pos} = {};
 	makeCoordsDir($char->{pos}, $args->{coords});
 	$char->{pos_to} = {%{$char->{pos}}};
 	message(TF("Your Coordinates: %s, %s\n", $char->{pos}{x}, $char->{pos}{y}), undef, 1);
 
-	$messageSender->sendIgnoreAll("all") if ($config{ignoreAll});
+	# ignoreAll
+	$ignored_all = 0;
 }
 
 1;

--- a/src/Network/Receive/ServerType20.pm
+++ b/src/Network/Receive/ServerType20.pm
@@ -26,12 +26,12 @@ sub map_loaded {
 	undef $conState_tries;
 	$char = $chars[$config{char}];
 	$syncMapSync = pack('V1',$args->{syncMapSync});
+	main::initMapChangeVars();
 
 	if ($net->version == 1) {
 		$net->setState(4);
 		message T("Waiting for map to load...\n"), "connection";
 		ai_clientSuspend(0, $timeout{'ai_clientSuspend'}{'timeout'});
-		main::initMapChangeVars();
 	} else {
 		$messageSender->sendMapLoaded();
 		$messageSender->sendSync(1);
@@ -40,20 +40,22 @@ sub map_loaded {
 
 		# Replies 01B6 (Guild Info) and 014C (Guild Ally/Enemy List)
 		$messageSender->sendGuildRequestInfo(0);
-		
+
 		# Replies 0166 (Guild Member Titles List) and 0154 (Guild Members List)
 		$messageSender->sendGuildRequestInfo(1);
-		message(T("You are now in the game\n"), "connection");
-		Plugins::callHook('in_game');
-		$timeout{'ai'}{'time'} = time;
 	}
+
+	message(T("You are now in the game\n"), "connection");
+	Plugins::callHook('in_game');
+	$timeout{'ai'}{'time'} = time;
 
 	$char->{pos} = {};
 	makeCoordsDir($char->{pos}, $args->{coords});
 	$char->{pos_to} = {%{$char->{pos}}};
 	message(TF("Your Coordinates: %s, %s\n", $char->{pos}{x}, $char->{pos}{y}), undef, 1);
 
-	$messageSender->sendIgnoreAll("all") if ($config{ignoreAll});
+	# ignoreAll
+	$ignored_all = 0;
 }
 
 1;

--- a/src/Network/Receive/Zero.pm
+++ b/src/Network/Receive/Zero.pm
@@ -62,32 +62,34 @@ sub map_loaded {
 	undef $conState_tries;
 	$char = $chars[$config{char}];
 	return unless Network::Receive::changeToInGameState;
+	main::initMapChangeVars();
 
 	if ($net->version == 1) {
 		$net->setState(4);
 		message(T("Waiting for map to load...\n"), "connection");
 		ai_clientSuspend(0, $timeout{'ai_clientSuspend'}{'timeout'});
-		main::initMapChangeVars();
+		
 	} else {
 		$messageSender->sendReqRemainTime();
 		$messageSender->sendMapLoaded();
 		$messageSender->sendSync(1);
 		$messageSender->sendRequestCashItemsList();
 		$messageSender->sendGuildRequestInfo();
-		
-		message(T("You are now in the game\n"), "connection");
-		Plugins::callHook('in_game');
-		$timeout{'ai'}{'time'} = time;
-		our $quest_generation++;
-
-		$messageSender->sendIgnoreAll("all") if ($config{ignoreAll}); # broking xkore 1 and 3 when use cryptkey
 		$messageSender->sendBlockingPlayerCancel(); # request to unfreeze char
 	}
+
+	message(T("You are now in the game\n"), "connection");
+	Plugins::callHook('in_game');
+	$timeout{'ai'}{'time'} = time;
+	our $quest_generation++;
 
 	$char->{pos} = {};
 	makeCoordsDir($char->{pos}, $args->{coords}, \$char->{look}{body});
 	$char->{pos_to} = {%{$char->{pos}}};
 	message(TF("Your Coordinates: %s, %s\n", $char->{pos}{x}, $char->{pos}{y}), undef, 1);
+
+	# ignoreAll
+	$ignored_all = 0;
 }
 
 sub party_users_info {

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -928,7 +928,6 @@ sub _items_list {
 ###### Packet handling callbacks ######
 #######################################
 
-# from old ServerType0
 sub map_loaded {
 	my ($self, $args) = @_;
 	$net->setState(Network::IN_GAME);
@@ -936,13 +935,17 @@ sub map_loaded {
 	$char = $chars[$config{char}];
 	return unless changeToInGameState();
 	# assertClass($char, 'Actor::You');
+	main::initMapChangeVars();
 
 	if ($net->version == 1) {
 		$net->setState(4);
 		message(T("Waiting for map to load...\n"), "connection");
 		ai_clientSuspend(0, $timeout{'ai_clientSuspend'}{'timeout'});
-		main::initMapChangeVars();
 	} else {
+		$messageSender->sendMapLoaded();
+
+		$messageSender->sendSync(1);
+
 		$messageSender->sendGuildMasterMemberCheck();
 
 		# Replies 01B6 (Guild Info) and 014C (Guild Ally/Enemy List)
@@ -950,11 +953,18 @@ sub map_loaded {
 
 		# Replies 0166 (Guild Member Titles List) and 0154 (Guild Members List)
 		$messageSender->sendGuildRequestInfo(1);
-		message(T("You are now in the game\n"), "connection");
-		Plugins::callHook('in_game');
-		$messageSender->sendMapLoaded();
-		$timeout{'ai'}{'time'} = time;
+
+		$messageSender->sendRequestCashItemsList() if (grep { $masterServer->{serverType} eq $_ } qw(bRO idRO_Renewal)); # tested at bRO 2013.11.30, request for cashitemslist
+		$messageSender->sendCashShopOpen() if ($config{whenInGame_requestCashPoints});	
+
+		# request to unfreeze char - alisonrag
+		$messageSender->sendBlockingPlayerCancel() if $masterServer->{blockingPlayerCancel};
 	}
+
+	message(T("You are now in the game\n"), "connection");
+	Plugins::callHook('in_game');
+	$timeout{'ai'}{'time'} = time;
+	our $quest_generation++;
 
 	$char->{pos} = {};
 	makeCoordsDir($char->{pos}, $args->{coords}, \$char->{look}{body});
@@ -1456,6 +1466,7 @@ sub map_changed {
 	$char->{pos_to} = {%coords};
 
 	undef $conState_tries;
+	main::initMapChangeVars();
 	for (my $i = 0; $i < @ai_seq; $i++) {
 		ai_setMapChanged($i);
 	}


### PR DESCRIPTION
1 - The in_game hook is used by many plugins, but it was not called when xKore mode was in use.
2 - initMapChangeVars was planned to be used in map_change and map_changed, was only called in map_change and in xKore 1 mode (map_loaded) 
https://github.com/OpenKore/openkore/blob/1fa428f249e5ce8caef2255eaa7ecb87a9fb6cfd/src/functions.pl#L612-L613
