### PR TITLE
[FIX] Avoid Info Request when Actor is Clone

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -2536,7 +2536,7 @@ sub objectAdded {
 
 	if ($type eq 'player' || $type eq 'slave') {
 		# Try to retrieve the player name from cache.
-		if (!getPlayerNameFromCache($obj)) {
+		if (!getPlayerNameFromCache($obj) && !$obj->{clone}) {
 			push @unknownPlayers, $ID;
 		}
 

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -6102,6 +6102,7 @@ sub offline_clone_found {
 	if (!defined $actor) {
 		$actor = new Actor::Player();
 		$actor->{object_type} = 0x0; #player
+		$actor->{clone} = 1;
 		$actor->{ID} = $args->{ID};
 		$actor->{nameID} = unpack("V", $args->{ID});
 		$actor->{name} =  bytesToString($args->{name});


### PR DESCRIPTION
Before openkore was stuck trying to request actor info from same clone, now dont query for clone infos and is working fine