### PR TITLE
fix: Parse item including '#'

### DIFF
--- a/src/FileParsers.pm
+++ b/src/FileParsers.pm
@@ -169,7 +169,7 @@ sub parseCommandsDescription {
 
 	undef %{$r_hash} unless $no_undef;
 	my ($key, $commentBlock, $description);
-	
+
 	my $reader = new Utils::TextReader($file);
 	while (!$reader->eof()) {
 		my $line = $reader->readLine();
@@ -202,11 +202,11 @@ sub parseCommandsDescription {
 
 		} elsif ($line =~ /^(.*?)\t+(.*)$/) {
 			push @{$r_hash->{$key}}, [$1, $2];
-		
+
 		} elsif ($line !~ /\t/) {	#if a console command is without any params
 			push @{$r_hash->{$key}}, ["", $line];
 		}
-		
+
 	}
 	return 1;
 }
@@ -219,7 +219,7 @@ sub parseConfigFile {
 
 	undef %{$r_hash} unless $no_undef;
 	my ($key, $value, $inBlock, $commentBlock);
-	
+
 	my $reader = new Utils::TextReader($file);
 	while (!$reader->eof()) {
 		my $line = $reader->readLine();
@@ -228,13 +228,13 @@ sub parseConfigFile {
 		$line =~ s/[\r\n]//g;	# Remove line endings
 		$line =~ s/^[\t\s]*//;	# Remove leading tabs and whitespace
 		$line =~ s/\s+$//g;	# Remove trailing whitespace
-		
+
 		if (index($line, '#') != -1) {
 			warning T("Mid-line comments are not allowed in this file and therefore might cause problems.\n"), "parseConfigFile", 5;
 			warning T("If the '#' found is not a comment, this can be ignored.\n"), "parseConfigFile", 5;
 			warning TF("HERE: %s", $line), "parseConfigFile", 5;
 		}
-		
+
 		next if ($line eq "");
 
 		if (!defined $commentBlock && $line =~ /^\/\*/) {
@@ -399,7 +399,7 @@ sub parseDataFile2 {
 		$r_hash->{$key} = $value;
 	}
 	close FILE;
-	
+
 	return 1;
 }
 
@@ -454,11 +454,11 @@ sub parseShopControl {
 		$line =~ s/[\r\n\x{FEFF}]//g;
 		next if $line =~ /^$/ || $line =~ /^#/;
 
-		if (!$shop->{title_line}) { 
+		if (!$shop->{title_line}) {
 			$shop->{title_line} = $line;
 			next;
 		}
-		
+
 		# Strip mid-line comments after parsing the shop title, so shops can use '#' in their titles
 		$line =~ s/\s*#.*//;
 		next unless length $line;
@@ -507,12 +507,12 @@ sub parseItemsControl {
 	my ($file, $r_hash) = @_;
 	undef %{$r_hash};
 	my ($key, $args_text, %cache);
-	
+
 	my $reader = new Utils::TextReader($file);
 	until ($reader->eof) {
 		my $line = lc $reader->readLine;
 		next if $line =~ /^\s*#/;
-		$line =~ s/\s*#.*//;
+
 		chomp $line;
 		if (($key, $args_text) = extract_delimited($line) and $key) {
 			$key =~ s/^.|.$//g;
@@ -532,7 +532,7 @@ sub parseItemsControl {
 			$args_text =~ s/^\s+//;
 			$key = substr($line, 0, $separator);
 		}
-		
+
 		next if $key =~ /^$/;
 		my @args = split /\s+/, $args_text;
 		# Cache similar entries to save memory.
@@ -613,7 +613,7 @@ sub parsePortals {
 		$line =~ s/\s+/ /g;
 		$line =~ s/^\s+|\s+$//g;
 		$line =~ s/(.*)[\s\t]+#.*$/$1/;
-		
+
 		if ($line =~ /^([\w|@|-]+)\s(\d{1,3})\s(\d{1,3})\s([\w|@|-]+)\s(\d{1,3})\s(\d{1,3})\s?(.*)/) {
 		my ($source_map, $source_x, $source_y, $dest_map, $dest_x, $dest_y, $misc) = ($1, $2, $3, $4, $5, $6, $7);
 			my $portal = "$source_map $source_x $source_y";
@@ -640,7 +640,7 @@ sub parsePortals {
 				$$r_hash{$portal}{'dest'}{$dest}{'steps'} = $misc;
 			}
 		}
-		
+
 	}
 	return 1;
 }
@@ -795,14 +795,14 @@ sub parseROSlotsLUT {
 
 sub parseROQuestsLUT {
 	my ($file, $r_hash) = @_;
-	
+
 	my %ret = (
 		file => $file,
 		hash => $r_hash,
 	);
 	Plugins::callHook ('FileParsers::ROQuestsLUT', \%ret);
 	return if $ret{return};
-	
+
 	undef %{$r_hash};
 	my ($data, $flag);
 	my $reader = Utils::TextReader->new($file, { hide_comments => 0 });
@@ -825,13 +825,13 @@ sub parseROQuestsLUT {
 				$flag = 1;
 			}
 		}
-		
+
 		if ($flag) {
 			$$r_hash{$data->{id}} = $data;
 			undef $data; undef $flag;
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -857,7 +857,7 @@ sub parseRecvpackets {
 		#warning $r_hash->{$key}." ".$key."\n";
 	}
 	close FILE;
-	
+
 	return 1;
 }
 
@@ -961,26 +961,26 @@ sub parseWaypoint {
 sub parseItemStackLimit {
 	my ($file, $r_hash) = @_;
 	my $reader = Utils::TextReader->new($file);
-	
+
 	while (!$reader->eof()) {
 		my $line = $reader->readLine();
 		$line =~ s/\x{FEFF}//g;
 		$line =~ s/[\r\n]//g;
 		$line =~ s/#.*$//g;
 		$line =~ s/^\s+//g;
-		
+
 		next unless length $line;
-		
+
 		my ($ID, $stack, $mask) = split /\s+/, $line;
-		
+
 		next unless $mask;
-		
+
 		for (my $i = 1; $i < 16; $i = $i << 1) {
 			next unless $mask & $i;
 			$r_hash->{$ID}->{$i} = $stack;
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -1361,10 +1361,10 @@ sub updateMonsterLUT {
 
 sub updatePortalLUT {
 	my ($file, $sourceMap, $sourceX, $sourceY, $destMap, $destX, $destY) = @_;
-	
+
 	my $plugin_args = {file => $file, sourceMap => $sourceMap, sourceX => $sourceX, sourceY => $sourceY, destMap => $destMap, destX => $destX, destY => $destY};
 	Plugins::callHook('updatePortalLUT', $plugin_args);
-	
+
 	unless ($plugin_args->{return}) {
 		open FILE, ">>:utf8", $file;
 		print FILE "$sourceMap $sourceX $sourceY $destMap $destX $destY\n";
@@ -1375,10 +1375,10 @@ sub updatePortalLUT {
 #Add: NPC talk Sequence
 sub updatePortalLUT2 {
 	my ($file, $sourceMap, $sourceX, $sourceY, $destMap, $destX, $destY, $steps) = @_;
-	
+
 	my $plugin_args = {file => $file, sourceMap => $sourceMap, sourceX => $sourceX, sourceY => $sourceY, destMap => $destMap, destX => $destX, destY => $destY, steps => $steps};
 	Plugins::callHook('updatePortalLUT2', $plugin_args);
-	
+
 	unless ($plugin_args->{return}) {
 		open FILE, ">>:utf8", $file;
 		print FILE "$sourceMap $sourceX $sourceY $destMap $destX $destY $steps\n";

--- a/src/test/FileParsersTest.pm
+++ b/src/test/FileParsersTest.pm
@@ -14,7 +14,7 @@ sub start {
 	subtest 'FileParsers' => sub { SKIP: {
 		binmode STDOUT, ':utf8';
 		binmode STDERR, ':utf8';
-		
+
 		my $items = do {
 			use utf8;
 			{
@@ -28,39 +28,39 @@ sub start {
 				12153 => q(Bowman Scroll 1),
 			}
 		};
-		
+
 		my $itemSlotCount = {qw(
 			1207 3
 			1208 4
 		)};
-		
+
 		subtest 'tables' => sub {
 			for ('items.txt') {
 				parseROLUT($_, \%items_lut);
 				is_deeply(\%items_lut, $items, 'items.txt');
 			}
-			
+
 			for ('itemslotcounttable.txt') {
 				parseROLUT($_, \%itemSlotCount_lut);
 				is_deeply(\%itemSlotCount_lut, $itemSlotCount, $_);
 			}
 		} or skip 'failed to load tables', 1;
-		
+
 		# 502 - unknown item
 		my %item_names = map {$_ => itemName({nameID => $_, cards => pack('v*', (0)x4)})} 502, keys %items_lut;
 		my @item_names_part = map {[map {$item_names{$_}} @$_]} List::MoreUtils::part {$_ == 1208} keys %item_names;
-		
+
 		subtest 'items_control.txt' => sub {
 			parseItemsControl('items_control.txt', \%items_control);
-			
+
 			is(items_control(NOT_CONFIGURED_ITEM)->{keep}, 9, 'all');
 			is(items_control($_,$_)->{keep}, 2, $_) for @{$item_names_part[0]};
 			is(items_control($_,$_)->{keep}, 22, $_) for @{$item_names_part[1]};
 		};
-		
+
 		subtest 'pickupitems.txt' => sub {
 			parseDataFile_lc('pickupitems.txt', \%pickupitems);
-			
+
 			is(pickupitems(NOT_CONFIGURED_ITEM), 1, 'all');
 			is(pickupitems($_), 2, $_) for grep {!/Bowman Scroll 1/} @{$item_names_part[0]};
 			is(pickupitems($_), -1, $_) for @{$item_names_part[1]};

--- a/src/test/items_control.txt
+++ b/src/test/items_control.txt
@@ -5,6 +5,7 @@ MoNsTeR's FeEd 2 3 4 5 6
 Caixinha "Noite Feliz" 2 3 4 5 6
 КОКТЕЙЛЬ 'Дыхание дракона' 2 3 4 5 6
 "Bowman Scroll 1" 2 3 4 5 6
-Unknown #502 2 3 4 5 6
+"Unknown #502" 2 3 4 5 6 # Awesome Comment
 Main Gauche [3] 2 3 4 5 6
+# Super Awesome Comment
 "Main Gauche [4]" 22 33 44 55 66


### PR DESCRIPTION
Hi.
FileParses failed to parse name in items_control.txt like "Unknown #502" because the "#" was regarded comment