### PR TITLE
[FIX] Avoid looping while try to teleport

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -3204,9 +3204,11 @@ sub processItemsGather {
 
 ##### AUTO-TELEPORT #####
 sub processAutoTeleport {
+	return if(AI::inQueue("teleport", "NPC"));
+
 	my $safe = 0;
 
-	if (!$field->isCity && !AI::inQueue("storageAuto", "buyAuto") && $config{teleportAuto_allPlayers}
+	if (!$field->isCity && !AI::inQueue("storageAuto", "buyAuto", "skill_use") && $config{teleportAuto_allPlayers}
 	    && ($config{'lockMap'} eq "" || $field->baseName eq $config{'lockMap'})
 	 && binSize(\@playersID) && timeOut($AI::Temp::Teleport_allPlayers, 0.75)) {
 


### PR DESCRIPTION
if u set the following condition or other auto teleport related conditions, openkore will be stuck in infinity looping when u are talking with NPC, or if u already have a teleport in AI queue
teleportAuto_allPlayers 1

this pull fix the infinity  looping

