### PR TITLE
Fix homunculus not getting stats after map change

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2767,9 +2767,7 @@ sub homunculus_info {
 			if ($char->{homunculus} && $char->{homunculus}{ID} && $char->{homunculus}{ID} ne $args->{ID});
 		
 		# Some servers won't send 'homunculus_property' after a teleport, so we don't delete $char->{homunculus} object
-		if ($char->{homunculus}{ID} ne $args->{ID}) {
-			$char->{homunculus} = Actor::get($args->{ID});
-		}
+		$char->{homunculus} = Actor::get($args->{ID}) if ($char->{homunculus}{ID} ne $args->{ID});
 		
 		$char->{homunculus}{state} = $state if (defined $state);
 		$char->{homunculus}{map} = $field->baseName;


### PR DESCRIPTION
euRO seems to have stopped sending 'homunculus_property' after a map change, this makes it so now  openkore has to keep the information itself. This change makes it so homunculus_info won't delete the homunculus object after a map change if it still holds the same ID.

This introduces another problem, AI::SlaveManager::addSlave requires the actor type to be Actor::Slave::Homunculus, but after a map change it will have been changed to AI::Slave::Homunculus, so I also added a check to change it back to Actor::Slave::Homunculus.

Previous fix: #2907