### PR TITLE
Fix typo in Homunculus jobID

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -2827,7 +2827,7 @@ sub cmdSlave {
 		"Range: \@>>     Skill pt: \@>>>     Contract End:  \@<<<<<<<<<<\n"),
 		[$slave->{'name'}, $hp_string,
 		$slave->{'actorType'}, $sp_string,
-		$jobs_lut{$slave->{'jobId'}},
+		$jobs_lut{$slave->{'jobID'}},
 		$slave->{'level'}, $exp_string,
 		$slave->{'atk'}, $slave->{'matk'}, $hunger_string,
 		$slave->{'hit'}, $slave->{'critical'}, $intimacy_label, $intimacy_string,

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1827,7 +1827,7 @@ sub actor_display {
 
 			$actor->{appear_time} = time;
 			$actor->{name_given} = bytesToString($args->{name}) if exists $args->{name};
-			$actor->{jobId} = $args->{type} if exists $args->{type};
+			$actor->{jobID} = $args->{type} if exists $args->{type};
 			$mustAdd = 1;
 		}
 		$actor->{nameID} = $nameID;


### PR DESCRIPTION
In these 2 places there was a typo in the jobID key. Fixed them.