### PR TITLE
Fix homunculus map change again

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1822,9 +1822,13 @@ sub actor_display {
 		# Actor is a homunculus or a mercenary
 		$actor = $slavesList->getByID($args->{ID});
 		if (!defined $actor) {
-			$actor = ($char->{slaves} && $char->{slaves}{$args->{ID}})
-			? $char->{slaves}{$args->{ID}} : $object_class->new();
-
+			$actor = 
+				($char->{slaves} && $char->{slaves}{$args->{ID}}) ?
+					$char->{slaves}{$args->{ID}} : 
+					(($char->{homunculus} && $char->{homunculus}{ID} && $char->{homunculus}{ID} eq $args->{ID}) ?
+						$char->{homunculus} :
+						$object_class->new());
+			
 			$actor->{appear_time} = time;
 			$actor->{name_given} = bytesToString($args->{name}) if exists $args->{name};
 			$actor->{jobID} = $args->{type} if exists $args->{type};


### PR DESCRIPTION
After the fix on #3112 another bug was introduced, the homunculus object is never really deleted, but kept in $char->{homunculus}, but on every mapchange $char->{slaves} is deleted and also $slavesList is cleared, this makes it so when the homunculus actor connects after the map change it is not found by actor_display (in Receive.pm) in either $slavesList or $char->{slaves}, so a new actor is created and added to $slavesList, but when homunculus_info is received the object in $char->{homunculus} is copied to $char->{slaves}. So in the end 2 incomplete copies of the homunculus object are kept separate, one in both $char->{slaves} and $char->{homunculus} and another in $slavesList.

This fix just adds a third check in actor_display to also check for the actor ID in $char->{homunculus}, instead of only in $char->{slaves} and $slavesList.

This bug is not easy to reproduce, but can be done teleporting many times in the same map and comparing the information in $slavesList and $char->{slaves}

Log example of a Dump of the actor created by actor_display (to be added in slavesList), $char->{homunculus} and $slavesList, where is can be seen that there are clearly 2 separate homunculus objects, one being AI::Slave::Homunculus in $char->{homunculus} and another being Actor::Slave::Homunculus in actor_display, both being the same character but with different coordinates.
https://pastebin.com/zfKw8rAr