### PR TITLE
Avoid talk and query hidden Actors

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3962,7 +3962,7 @@ sub isSafeActorQuery {
 		if ($actor) {
 			# Do not AutoVivify here!
 			if (defined $actor->{statuses} && %{$actor->{statuses}}) {
-				if ($actor->statusActive('EFFECTSTATE_SPECIALHIDING')) {
+				if ( $actor->statusActive('EFFECTSTATE_SPECIALHIDING') || $actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337 ) { # HIDDEN_ACTOR TYPES
 					return 0;
 				}
 			}

--- a/src/Task/TalkNPC.pm
+++ b/src/Task/TalkNPC.pm
@@ -826,7 +826,10 @@ sub findTarget {
 	my ($self, $actorList) = @_;
 	if ($self->{nameID}) {
 		my ($actor) = grep { $self->{nameID} eq $_->{nameID} } @{$actorList->getItems};
-		if ($actor && $actor->{statuses}->{EFFECTSTATE_BURROW} && $self->{type} ne 'autotalk') {
+		if ( $actor && 
+		( $actor->{statuses}->{EFFECTSTATE_BURROW} || ( $actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337 ) ) && # HIDDEN_ACTOR TYPES
+		$self->{type} ne 'autotalk' )
+		{
 			$self->setError(NPC_NOT_FOUND, T("Talk with a hidden NPC prevented."));
 			return;
 		}
@@ -835,6 +838,7 @@ sub findTarget {
 	foreach my $actor (@{$actorList->getItems()}) {
 		my $pos = ($actor->isa('Actor::NPC')) ? $actor->{pos} : $actor->{pos_to};
 		next if ($actor->{statuses}->{EFFECTSTATE_BURROW});
+		next if ( $actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337 ); # HIDDEN_ACTOR TYPES
 		if ($pos->{x} == $self->{x} && $pos->{y} == $self->{y}) {
 			if (defined $actor->{name}) {
 				return $actor;


### PR DESCRIPTION
As reported in IRC:
Openkore was trying to talk with a hidden NPC when 2 NPCs was in the same coordinates

![image](https://user-images.githubusercontent.com/10372732/80269983-ea231d00-868a-11ea-92d8-8bf786d32696.png)

log:
https://uploads.kiwiirc.com/files/af0676ff2209a306e88f5190df007602/pasted.txt

with this pull, the openkore avoid and dont talk with hidden NPC anymore