### PR TITLE
[Fix] items_control parser

### DIFF
--- a/src/FileParsers.pm
+++ b/src/FileParsers.pm
@@ -521,7 +521,8 @@ sub parseItemsControl {
 			$key =~ s/^.|.$//g;
 			$args_text =~ s/^\s+//;
 		} else {
-			$line =~ s/\s#.*//;
+			$line =~ s/#.*//;
+			chomp $line;
 			my @reverseString = reverse(split(//, $line));
 			my $separator = length $line;
 
@@ -536,7 +537,8 @@ sub parseItemsControl {
 		}
 
 		next if $key =~ /^$/;
-		$args_text =~ s/\s#.*//;
+		$args_text =~ s/#.*//;
+		chomp $args_text;
 		my @args = split /\s+/, $args_text;
 		# Cache similar entries to save memory.
 		$r_hash->{$key} = $cache{$args_text} ||= { map {$_ => shift @args} qw(keep storage sell cart_add cart_get) };

--- a/src/FileParsers.pm
+++ b/src/FileParsers.pm
@@ -512,15 +512,16 @@ sub parseItemsControl {
 	my $reader = new Utils::TextReader($file);
 	until ($reader->eof) {
 		my $line = lc $reader->readLine;
+		chomp $line;
 		next if $line =~ /^\s*#/;
 
-		chomp $line;
-		if (($key, $args_text) = extract_delimited($line) and $key) {
+		if($line =~ /^[\s0-9]+/) {
+			($key, $args_text) = $line =~ /^(\d+)\s(.*)$/;
+		} elsif(($key, $args_text) = extract_delimited($line) and $key) {
 			$key =~ s/^.|.$//g;
 			$args_text =~ s/^\s+//;
-		} elsif ($line =~ /^[\s0-9]+$/) {
-			($key, $args_text) = $line =~ /^(\d+)\s(.*)$/;
 		} else {
+			$line =~ s/\s#.*//;
 			my @reverseString = reverse(split(//, $line));
 			my $separator = length $line;
 
@@ -535,6 +536,7 @@ sub parseItemsControl {
 		}
 
 		next if $key =~ /^$/;
+		$args_text =~ s/\s#.*//;
 		my @args = split /\s+/, $args_text;
 		# Cache similar entries to save memory.
 		$r_hash->{$key} = $cache{$args_text} ||= { map {$_ => shift @args} qw(keep storage sell cart_add cart_get) };


### PR DESCRIPTION
this fix comment parse in items_control (https://github.com/OpenKore/openkore/pull/3064#issuecomment-624922830)

before:
![image](https://user-images.githubusercontent.com/10372732/81243086-394f4300-8fe5-11ea-8d1e-5985b0b1bae0.png)

after:
![image](https://user-images.githubusercontent.com/10372732/81243198-8c28fa80-8fe5-11ea-8b85-3c613b7c2bfe.png)


tested with:
```
all 0 1 0 1 1 # test
505 0 1 0 # Blue Potion
506 0 1 0 1 1
```