### PR TITLE
Fix slave attackauto party

### DIFF
--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -779,10 +779,20 @@ sub processAutoAttack {
 				
 				next if (blockDistance($master_pos, $pos) > ($config{$slave->{configPrefix}.'followDistanceMax'} + $config{$slave->{configPrefix}.'attackMaxDistance'}));
 
-				# List monsters that party members are attacking
-				if ($config{$slave->{configPrefix}.'attackAuto_party'} && $attackOnRoute
-				 && ($monster->{dmgFromYou} || $monster->{dmgFromParty} || $monster->{dmgToYou} || $monster->{dmgToParty} || $monster->{missedYou} || $monster->{missedToParty})
-				 && timeOut($monster->{$slave->{ai_attack_failed_timeout}}, $timeout{ai_attack_unfail}{timeout})) {
+				# List monsters that master and other slaves are attacking
+				if (
+					$config{$slave->{configPrefix}.'attackAuto_party'} &&
+					$attackOnRoute &&
+					(
+						$monster->{dmgFromYou} ||
+						$monster->{dmgToYou} ||
+						$monster->{missedYou} ||
+						scalar(grep { isMySlaveID($_, $slave->{ID}) } keys %{$monster->{dmgFromPlayer}}) > 0 ||
+						scalar(grep { isMySlaveID($_, $slave->{ID}) } keys %{$monster->{dmgToPlayer}}) > 0 ||
+						scalar(grep { isMySlaveID($_, $slave->{ID}) } keys %{$monster->{missedToPlayer}}) > 0
+					) &&
+					timeOut($monster->{$slave->{ai_attack_failed_timeout}}, $timeout{ai_attack_unfail}{timeout})
+				) {
 					push @partyMonsters, $_;
 					next;
 				}

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -1886,13 +1886,7 @@ sub slave_checkMonsterCleanness {
 	return 1 if $playersList->getByID($ID) || $slavesList->getByID($ID);
 	my $monster = $monstersList->getByID($ID);
 
-	# If party attacked monster, or if monster attacked/missed party
-	# Since openKore considers the slave as a member of the player party this won't work for now
-	#if ($config{$slave->{configPrefix}.'attackAuto_party'} && ($monster->{dmgFromParty} > 0 || $monster->{missedFromParty} > 0 || $monster->{dmgToParty} > 0 || $monster->{missedToParty} > 0)) {
-	#	return 1;
-	#}
-
-	# Instead we check for attacks against/made by master and/or other slaves
+	# Since openKore considers the slave as a member of the player party we check for attacks against/made by master and/or other slaves
 	if (
 		$config{$slave->{configPrefix}.'attackAuto_party'} &&
 		(

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -121,6 +121,7 @@ our @EXPORT = (
 	chatLog_clear
 	checkAllowedMap
 	checkFollowMode
+	isMySlaveID
 	checkMonsterCleanness
 	slave_checkMonsterCleanness
 	createCharacter
@@ -1766,6 +1767,15 @@ sub checkFollowMode {
 	return 0;
 }
 
+sub isMySlaveID {
+	my ($ID, $exclude) = @_;
+	return 0 unless ($char);
+	return 0 unless ($char->{slaves});
+	return 0 if (defined $exclude && $ID eq $exclude);
+	return 0 unless (exists $char->{slaves}{$ID});
+	return 1;
+}
+
 ##
 # boolean checkMonsterCleanness(Bytes ID)
 # ID: the monster's ID.
@@ -1824,17 +1834,18 @@ sub checkMonsterCleanness {
 	my $allowed = 1; 
 	if (scalar(keys %{$monster->{castOnByPlayer}}) > 0) 
 	{ 
-		foreach (keys %{$monster->{castOnByPlayer}}) 
-		{ 
-			my $ID1=$_; 
-			my $source = Actor::get($_); 
-			unless ( existsInList($config{tankersList}, $source->{name}) || 
-				($char->{party}{joined} && $char->{party}{users}{$ID1} && %{$char->{party}{users}{$ID1}})) 
-			{ 
+		foreach my $ID1 (keys %{$monster->{castOnByPlayer}}) 
+		{
+			my $source = Actor::get($ID1); 
+			unless (
+				existsInList($config{tankersList}, $source->{name}) ||
+				isMySlaveID($ID1) ||
+				($char->{party}{joined} && $char->{party}{users}{$ID1} && %{$char->{party}{users}{$ID1}})
+			) {
 				$allowed = 0; 
 				last; 
-			} 
-		} 
+			}
+		}
 	} 
 
 	# If monster hasn't been attacked by other players
@@ -1881,6 +1892,23 @@ sub slave_checkMonsterCleanness {
 	#	return 1;
 	#}
 
+	# Instead we check for attacks against/made by master and/or other slaves
+	if (
+		$config{$slave->{configPrefix}.'attackAuto_party'} &&
+		(
+			$monster->{dmgFromYou} ||
+			$monster->{missedFromYou} ||
+			$monster->{dmgToYou} ||
+			$monster->{missedYou} ||
+			scalar(grep { isMySlaveID($_, $slave->{ID}) } keys %{$monster->{missedFromPlayer}}) > 0 ||
+			scalar(grep { isMySlaveID($_, $slave->{ID}) } keys %{$monster->{dmgFromPlayer}}) > 0 ||
+			scalar(grep { isMySlaveID($_, $slave->{ID}) } keys %{$monster->{missedToPlayer}}) > 0 ||
+			scalar(grep { isMySlaveID($_, $slave->{ID}) } keys %{$monster->{dmgToPlayer}}) > 0
+		)
+	) {
+		return 1;
+	}
+
 	if ($config{aggressiveAntiKS}) {
 		# Aggressive anti-KS mode, for people who are paranoid about not kill stealing.
 
@@ -1909,18 +1937,19 @@ sub slave_checkMonsterCleanness {
 	my $allowed = 1; 
 	if (scalar(keys %{$monster->{castOnByPlayer}}) > 0) 
 	{ 
-		foreach (keys %{$monster->{castOnByPlayer}}) 
-		{ 
-			my $ID1=$_; 
-			my $source = Actor::get($_); 
-			unless ( existsInList($config{tankersList}, $source->{name}) || 
-				($char->{party}{joined} && $char->{party}{users}{$ID1} && %{$char->{party}{users}{$ID1}})) 
-			{ 
+		foreach my $ID1 (keys %{$monster->{castOnByPlayer}}) 
+		{
+			my $source = Actor::get($ID1); 
+			unless (
+				existsInList($config{tankersList}, $source->{name}) ||
+				isMySlaveID($ID1, $slave->{ID}) ||
+				($char->{party}{joined} && $char->{party}{users}{$ID1} && %{$char->{party}{users}{$ID1}})
+			) {
 				$allowed = 0; 
 				last; 
-			} 
-		} 
-	} 
+			}
+		}
+	}
 
 	# If monster hasn't been attacked by other players
 	if (


### PR DESCRIPTION
attackAuto_party does not work on the slaves AI because the damage tables (dmgToParty, dmgFromParty, etc) consider slaves as party members, this PR fixes that by checking for both the master and the other slaves in the damage tables and ignoring the party ones.