### PR TITLE
[FIX] check for monster before try to back to route

### DIFF
--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -49,11 +49,12 @@ ai_mercenary_attack_auto 0.5
 
 # Give up attacking a monster if it can't be reached within x seconds
 ai_attack_giveup 12
+ai_check_monster_auto 0.4
 
 # If you've just killed a monster, and there are no aggressives,
 # and you're not picking up any items, wait x seconds before doing
 # anything else.
-ai_attack_waitAfterKill 0.7
+ai_attack_waitAfterKill 0.3
 ai_homunculus_attack_waitAfterKill 0.3
 ai_mercenary_attack_waitAfterKill 0.3
 

--- a/src/Actor.pm
+++ b/src/Actor.pm
@@ -713,6 +713,7 @@ sub attack {
 		pos_to => { %{$target->{pos_to}} },
 	);
 	
+	$self->queue('checkMonsters') if !AI::inQueue("checkMonsters");
 	$self->queue('attack', \%args);
 	
 	message sprintf($self->verb(T("%s are now attacking %s\n"), T("%s is now attacking %s\n")), $self, $target);


### PR DESCRIPTION
add checkmonster to ai queue give attackauto time to find other monster beforeback to route again, this avoid openkore to lost main route and walk away from monsters then back to kill