### PR TITLE
fix `repair` command

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -53,7 +53,7 @@ sub iterate {
 	processReAddMissingPortals();
 	processPortalRecording();
 	Benchmark::end("ai_prepare") if DEBUG;
-	
+
 	Plugins::callHook('AI_start', {state => AI::state});
 
 	return if AI::state == AI::OFF;
@@ -206,7 +206,7 @@ sub iterate {
 			$execCommand = join (";;", @cmdQueueList);
 		} else {
 			$execCommand = $cmdQueueList[0];
-		}	
+		}
 		@cmdQueueList = ();
 		$cmdQueue = 0;
 		$cmdQueueTime = 0;
@@ -302,7 +302,7 @@ sub processMisc {
 	if (timeOut($char->{muted}, $char->{mute_period})) {
 		delete $char->{muted};
 		delete $char->{mute_period};
-		
+
 		if ($char->statusActive('EFST_MUTED')) {
 			$char->setStatus('EFST_MUTED', 0);
 		}
@@ -588,7 +588,7 @@ sub processEscapeUnknownMaps {
 	# Todo: Make kore do a random walk searching for portal if there's no portal arround.
 
 	if (AI::action eq "escape" && AI::state == AI::AUTO) {
-		my $skip = 0;                   
+		my $skip = 0;
 		if (timeOut($timeout{ai_route_escape}) && $timeout{ai_route_escape}{time}){
 			AI::dequeue;
 			if ($portalsID[0]) {
@@ -880,7 +880,7 @@ sub processPartyAuto {
 		} elsif ($config{partyAuto} == 2) {
 			message T("Auto-accepting party request\n");
 			# JOIN_ACCEPT
-			$messageSender->sendPartyJoin($incomingParty{'ID'}, 1); 
+			$messageSender->sendPartyJoin($incomingParty{'ID'}, 1);
 			if ($incomingParty{ACK} eq '02C7') {
 				$messageSender->sendPartyJoinRequestByNameReply($incomingParty{ID}, 1);
 			} else {
@@ -973,7 +973,7 @@ sub processDead {
 		AI::clear();
 		AI::queue("dead");
 		$char->setStatus('Dead', 1);
-		
+
 		my $dt = getFormattedDate(int(time));
 		push @deadTime, $dt;
 		if ($config{logDead}) {
@@ -1044,7 +1044,7 @@ sub processTransferItems {
 
 		# Verify that the item is still in the source list and has not changed.
 		my $item = $source->get( $row->{item}->{binID} );
-		
+
 		if ( !$item || $item->nameString ne $row->{item}->nameString ) {
 			error TF( "%s item '%s' disappeared!\n", $row->{source}, $row->{item} );
 			redo;
@@ -1061,7 +1061,7 @@ sub processTransferItems {
 				$freeWeight = int ($char->cart->{weight_max} - $char->cart->{weight});
 			}
 			my $weightNeeded = min( $item->{amount}, $row->{amount} || $item->{amount} ) * ($item->weight()/10);
-			
+
 			if ($weightNeeded > $freeWeight) {
 				#need to low down the amount
 				$row->{amount} = $freeWeight / ( $item->weight()/10 );
@@ -1073,21 +1073,21 @@ sub processTransferItems {
 			error TF( "Inventory item '%s' is equipped.\n", $item->{name} );
 			redo;
 		}
-		
+
 		my $target_item = $target->getByName( $row->{item}->{name} );
 		my $stack_limit = $target->item_max_stack( $row->{item}->{nameID} );
-		
+
 		my $amount = min($stack_limit, min( $item->{amount}, $row->{amount} || $item->{amount} ));
 		if ( $stack_limit - $amount < 0 || $target_item->{amount} - $stack_limit == 0) {
 			error TF("Unable to add %s to %s. You can't stack over %s of this item\n", $item->name, $row->{target}, $stack_limit);
 			redo;
-			
+
 		} elsif ( $target_item->{amount} + $amount > $stack_limit ) {
 			warning TF("Amount of %s will surpass the maximum %s capacity (%d), transfering maximum possible (%d)\n",
 			$row->{item}->name, $row->{target}, $stack_limit, $stack_limit - $target_item->{amount} );
-			
+
 			$amount = $stack_limit - $target_item->{amount};
-			
+
 		}
 		# Transfer the item!
 		$messageSender->$method( $item->{ID}, $amount );
@@ -1221,7 +1221,7 @@ sub processAutoStorage {
 			    ) &&
 				checkSelfCondition("getAuto_$i")
 			) {
-				if ($char->storage->isReady() && 
+				if ($char->storage->isReady() &&
 					!($char->storage->getByName($config{"getAuto_$i"}) || $char->storage->getByNameID($config{"getAuto_$i"}))) {
 =pod
 					#This works only for last getAuto item
@@ -1232,7 +1232,7 @@ sub processAutoStorage {
 					}
 =cut
 				} else {
-					if ($char->storage->wasOpenedThisSession() && 
+					if ($char->storage->wasOpenedThisSession() &&
 						!($char->storage->getByName($config{"getAuto_$i"}) || $char->storage->getByNameID($config{"getAuto_$i"}))) {
 						debug TF("storage: %s out of stock\n\n", $config{"getAuto_$i"});
 						Plugins::callHook("AI_storage_item_out_of_stock",  {
@@ -1302,7 +1302,7 @@ sub processAutoStorage {
 					AI::args->{distance} = $config{'storageAuto_distance'};
 				}
 			}
-			
+
 			# Determine whether we have to move to the NPC
 			if ($field->baseName ne $args->{npc}{map}) {
 				$do_route = 1;
@@ -1343,10 +1343,10 @@ sub processAutoStorage {
 					$messageSender->sendChat($config{storageAuto_useChatCommand});
 				} elsif ($config{storageAuto_useItem}) {
 					my $itemToOpenStorageWith = Actor::Item::get($config{storageAuto_useItem_item});
-					
+
 					if (!$itemToOpenStorageWith) {
 						error TF("Cannot find item %s to open storage\n", $config{storageAuto_useItem_item});
-						
+
 						if ($config{storageAuto_npc}) {
 							warning TF("Falling back to regular npc at %s, disabling storageAuto_useItem\n", $config{storageAuto_npc});
 							configModify("storageAuto_useItem", 0);
@@ -1357,10 +1357,10 @@ sub processAutoStorage {
 						}
 						return;
 					}
-					
+
 					if (timeOut($timeout{ai_storageAuto_useItem})) {
 						debug TF("Consuming item %s to open storage\n", $config{storageAuto_useItem});
-						
+
 						$itemToOpenStorageWith->use;
 						$timeout{ai_storageAuto_useItem}{time} = time;
 					}
@@ -1370,7 +1370,7 @@ sub processAutoStorage {
 						AI::args->{done} = 1;
 						return;
 					}
-					
+
 					if ($config{'storageAuto_npc_type'} eq "" || $config{'storageAuto_npc_type'} eq "1") {
 						warning T("Warning storageAuto has changed. Please read News.txt\n") if ($config{'storageAuto_npc_type'} eq "");
 						$config{'storageAuto_npc_steps'} = "c r1";
@@ -1383,7 +1383,7 @@ sub processAutoStorage {
 					} elsif ($config{'storageAuto_npc_type'} ne "" && $config{'storageAuto_npc_type'} ne "1" && $config{'storageAuto_npc_type'} ne "2" && $config{'storageAuto_npc_type'} ne "3") {
 						error T("Something is wrong with storageAuto_npc_type in your config.\n");
 					}
-					
+
 					my $realpos = {};
 					getNPCInfo($config{storageAuto_npc}, $realpos);
 
@@ -1409,7 +1409,7 @@ sub processAutoStorage {
 				# Storage not yet opened; stop and wait until it's open
 				return;
 			}
-			
+
 			my %pluginArgs;
 			Plugins::callHook("AI_storage_open", \%pluginArgs); # we can hook here to perform actions BEFORE any storage function
 			return if ($pluginArgs{return});
@@ -1423,7 +1423,7 @@ sub processAutoStorage {
 
 			if (!$args->{getStart}) {
 				$args->{done} = 1;
-				
+
 				# if storage is full disconnect if it says so in conf
 				if($char->storage->wasOpenedThisSession() && $char->storage->isFull()) {
 					Plugins::callHook("AI_storage_full", \%pluginArgs);
@@ -1448,8 +1448,8 @@ sub processAutoStorage {
 						$args->{lastAmount} == $item->{amount}
 					) {
 						error TF("Unable to store %s.\n", $item->{name});
-						
-						if($char->storage->getByName($item->{name})) {		
+
+						if($char->storage->getByName($item->{name})) {
 							Plugins::callHook("AI_storage_item_full", {
 									item => $item,
 								}
@@ -1564,26 +1564,26 @@ sub processAutoStorage {
 
 					# Try at most 3 times to get the item
 					if (($item{amount_get} > 0) && ($args->{retry} < 3)) {
-						
+
 						my $batchSize = $config{"getAuto_$args->{index}"."_batchSize"};
-						
+
 						if ($batchSize && $batchSize < $item{amount_get}) {
-							
+
 							my $remaining = $item{amount_get} - $batchSize;
 							$item{amount_get} = $batchSize;
-							
+
 							# Last loop attempted to get batchSize of item and succeeded
 							if ($args->{getAuto_batchSize_remaining} && $args->{getAuto_batchSize_remaining} != $remaining) {
 								$args->{retry} = 0;
 							}
-							
+
 							$args->{getAuto_batchSize_remaining} = $remaining;
-							
+
 							message TF("Attempt to get %s (batchSize) x %s from storage, retry: %s, remaining %s\n", $item{amount_get}, $item{name}, $ai_seq_args[0]{retry}, $args->{getAuto_batchSize_remaining}), "storage", 1;
 						} else {
 							message TF("Attempt to get %s x %s from storage, retry: %s\n", $item{amount_get}, $item{name}, $ai_seq_args[0]{retry}), "storage", 1;
 						}
-						
+
 						$messageSender->sendStorageGet($storeItem->{ID}, $item{amount_get});
 						$timeout{ai_storageAuto}{time} = time;
 						$args->{retry}++;
@@ -1637,7 +1637,7 @@ sub processAutoStorage {
 					quit();
 				}
 			}
-			
+
 			if ($config{'relogAfterStorage'} && $config{'XKore'} ne "1") {
 				writeStorageLog(0);
 				relog();
@@ -1669,11 +1669,11 @@ sub processAutoSell {
 	}
 
 	if (AI::action eq "sellAuto" && AI::args->{'done'}) {
-		
+
 		if (exists AI::args->{'error'}) {
 			error AI::args->{'error'}.".\n";
 		}
-		
+
 		my $var = AI::args->{'forcedByBuy'};
 		my $var2 = AI::args->{'forcedByStorage'};
 		message T("Auto-sell sequence completed.\n"), "success";
@@ -1685,21 +1685,21 @@ sub processAutoSell {
 		}
 	} elsif (AI::action eq "sellAuto" && timeOut($timeout{'ai_sellAuto'})) {
 		my $args = AI::args;
-		
+
 		if (exists $args->{sentSellPacket_time} && exists $args->{'sentEmptyList'}) {
 			$args->{'done'} = 1;
 			return;
-			
+
 		} elsif (exists $args->{sentSellPacket_time} && !exists $args->{'sentEmptyList'}) {
 			if (exists $args->{recv_sell_packet}) {
 				$args->{'done'} = 1;
-				
+
 			} elsif (timeOut($args->{sentSellPacket_time}, $timeout{ai_sellAuto_wait_after_packet_giveup}{timeout})) {
 				$args->{'error'} = 'Did not received the sell result from server after sell packet was sent';
 				$args->{'done'} = 1;
 			}
 			return;
-		
+
 		}
 
 		$args->{'npc'} = {};
@@ -1709,7 +1709,7 @@ sub processAutoSell {
 			$args->{'done'} = 1;
 			return;
 		}
-		
+
 		if (!$args->{distance}) {
 			if ($config{'sellAuto_standpoint'}) {
 				$args->{distance} = 1;
@@ -1719,7 +1719,7 @@ sub processAutoSell {
 				$args->{distance} = $config{'sellAuto_distance'};
 			}
 		}
-		
+
 		undef $ai_v{'temp'}{'do_route'};
 		if ($field->baseName ne $args->{'npc'}{'map'}) {
 			$ai_v{'temp'}{'do_route'} = 1;
@@ -1763,7 +1763,7 @@ sub processAutoSell {
 					noSitAuto => 1);
 			}
 		} else {
-		
+
 			if (!exists $args->{'sentNpcTalk'}) {
 
 				# load the real npc location just in case we used standpoint
@@ -1771,29 +1771,29 @@ sub processAutoSell {
 				getNPCInfo($config{"sellAuto_npc"}, $realpos);
 
 				ai_talkNPC($realpos->{pos}{x}, $realpos->{pos}{y}, $config{sellAuto_npc_steps} || 's');
-				
+
 				$args->{'sentNpcTalk'} = 1;
 				$args->{'sentNpcTalk_time'} = time;
-				
+
 				return;
-				
+
 			} elsif ($ai_v{'npc_talk'}{'talk'} ne 'sell') {
 				if (timeOut($args->{'sentNpcTalk_time'}, $timeout{ai_sellAuto_wait_giveup_npc}{timeout})) {
 					$args->{'error'} = 'Npc did not respond';
 					$args->{'done'} = 1;
 				}
 				return;
-				
+
 			} elsif (!exists $args->{'recv_sellList_time'}) {
 				$args->{'recv_sellList_time'} = time;
 				return;
-				
+
 			} else {
 				return unless (timeOut($args->{'recv_sellList_time'}, $timeout{ai_sellAuto_wait_before_sell}{timeout}));
 			}
-			
+
 			Plugins::callHook("AI_sell_auto");
-			
+
 			# Form list of items to sell
 			my @sellItems;
 			for my $item (@{$char->inventory}) {
@@ -1808,19 +1808,19 @@ sub processAutoSell {
 					push @sellItems, \%obj;
 				}
 			}
-			
+
 			if (@sellItems == 0) {
 				$args->{'sentEmptyList'} = 1;
 			}
-		
+
 			completeNpcSell(\@sellItems);
-			
+
 			delete $args->{'sentNpcTalk'};
 			delete $args->{'sentNpcTalk_time'};
 			delete $args->{'recv_sellList_time'};
 
 			$args->{sentSellPacket_time} = time;
-			
+
 			Plugins::callHook('AI_sell_auto_done');
 		}
 	}
@@ -1832,7 +1832,7 @@ sub processAutoBuy {
 	my $needitem;
 	if ((AI::action eq "" || AI::action eq "route" || AI::action eq "follow") && timeOut($timeout{'ai_buyAuto'}) && $char->inventory->isReady()) {
 		undef $ai_v{'temp'}{'found'};
-		
+
 		for(my $i = 0; exists $config{"buyAuto_$i"}; $i++) {
 			next if (!$config{"buyAuto_$i"} || !$config{"buyAuto_$i"."_npc"} || $config{"buyAuto_${i}_disabled"});
 			my $amount;
@@ -1869,11 +1869,11 @@ sub processAutoBuy {
 	}
 
 	if (AI::action eq "buyAuto" && AI::args->{'done'}) {
-		
+
 		if (exists AI::args->{'error'}) {
 			error AI::args->{'error'}.".\n";
 		}
-		
+
 		# buyAuto finished
 		$ai_v{'temp'}{'var'} = AI::args->{'forcedBySell'};
 		$ai_v{'temp'}{'var2'} = AI::args->{'forcedByStorage'};
@@ -1889,7 +1889,7 @@ sub processAutoBuy {
 	} elsif (AI::action eq "buyAuto" && timeOut($timeout{ai_buyAuto_wait})) {
 		Plugins::callHook('AI_buy_auto');
 		my $args = AI::args;
-		
+
 		if (exists $args->{sentBuyPacket_time} && exists $args->{index_failed}{$args->{lastIndex}}) {
 			if (timeOut($args->{sentBuyPacket_time}, $timeout{ai_buyAuto_wait_after_restart}{timeout})) {
 				delete $args->{sentBuyPacket_time};
@@ -1897,19 +1897,19 @@ sub processAutoBuy {
 				delete $args->{distance};
 			}
 			return;
-			
+
 		} elsif (exists $args->{sentBuyPacket_time} && !exists $args->{index_failed}{$args->{lastIndex}}) {
 			if (exists $args->{recv_buy_packet}) {
 				delete $args->{sentBuyPacket_time};
 				delete $args->{recv_buy_packet};
 				$args->{recv_buy_packet_time} = time;
-				
+
 			} elsif (timeOut($args->{sentBuyPacket_time}, $timeout{ai_buyAuto_wait_after_packet_giveup}{timeout})) {
 				$args->{'error'} = 'Did not received the buy result from server after buy packet was sent';
 				$args->{'done'} = 1;
 			}
 			return;
-		
+
 		} elsif (exists $args->{recv_buy_packet_time}) {
 			if (timeOut($args->{recv_buy_packet_time}, $timeout{ai_buyAuto_wait_after_restart}{timeout})) {
 				delete $args->{recv_buy_packet_time};
@@ -1917,11 +1917,11 @@ sub processAutoBuy {
 				delete $args->{distance};
 			}
 			return;
-			
+
 		}
-		
+
 		if (!exists $args->{lastIndex}) {
-			
+
 			delete $args->{index};
 			for (my $i = 0; exists $config{"buyAuto_$i"}; $i++) {
 				next if (!$config{"buyAuto_$i"} || $config{"buyAuto_${i}_disabled"});
@@ -1937,7 +1937,7 @@ sub processAutoBuy {
 				else {
 					$amount = $char->inventory->sumByName($config{"buyAuto_$i"});
 				}
-				
+
 				if ($config{"buyAuto_$i"."_maxAmount"} ne "" && $amount < $config{"buyAuto_$i"."_maxAmount"}) {
 					next if (($config{"buyAuto_$i"."_price"} && ($char->{zeny} < $config{"buyAuto_$i"."_price"})) || ($config{"buyAuto_$i"."_zeny"} && !inRange($char->{zeny}, $config{"buyAuto_$i"."_zeny"})));
 
@@ -1972,7 +1972,7 @@ sub processAutoBuy {
 					$args->{distance} = $config{"buyAuto_$args->{index}"."_distance"};
 				}
 			}
-			
+
 			if ($field->baseName ne $args->{'npc'}{'map'}) {
 				$ai_v{'temp'}{'do_route'} = 1;
 			} else {
@@ -1999,7 +1999,7 @@ sub processAutoBuy {
 				if ($args->{warpedToSave} && !$args->{mapChanged} && !timeOut($args->{warpStart}, 8)) {
 					undef $args->{warpedToSave};
 				}
-				
+
 				my $msgneeditem;
 				if (
 					$config{'saveMap'} ne "" &&
@@ -2016,7 +2016,7 @@ sub processAutoBuy {
 					message T($msgneeditem."Teleporting to auto-buy\n"), "teleport";
 					useTeleport(2);
 					$timeout{ai_buyAuto_wait}{time} = time;
-					
+
 				} else {
 					if ($needitem ne "") {
 						$msgneeditem = "Auto-buy: $needitem\n";
@@ -2029,45 +2029,45 @@ sub processAutoBuy {
 				return;
 			}
 		}
-		
+
 		if (!exists $args->{lastIndex}) {
 			$args->{lastIndex} = $args->{index};
 			return;
-		
+
 		} elsif (!exists $args->{'sentNpcTalk'}) {
 
 			# load the real npc location just in case we used standpoint
 			my $realpos = {};
 			getNPCInfo($config{"buyAuto_".$args->{lastIndex}."_npc"}, $realpos);
-			
+
 			if ( $config{"buyAuto_".$args->{lastIndex}."_isMarket"} ) {
 				ai_talkNPC($realpos->{pos}{x}, $realpos->{pos}{y}, undef);
 			} else {
 				ai_talkNPC($realpos->{pos}{x}, $realpos->{pos}{y}, $config{"buyAuto_".$args->{lastIndex}."_npc_steps"} || 'b');
 			}
-			
+
 			$args->{'sentNpcTalk'} = 1;
 			$args->{'sentNpcTalk_time'} = time;
-			
+
 			return;
-			
+
 		} elsif ($ai_v{'npc_talk'}{'talk'} ne 'store') {
 			if (timeOut($args->{'sentNpcTalk_time'}, $timeout{ai_buyAuto_wait_giveup_npc}{timeout})) {
 				$args->{'error'} = 'Npc did not respond';
 				$args->{'done'} = 1;
 			}
 			return;
-			
+
 		} elsif (!exists $args->{'recv_buyList_time'}) {
 			$args->{'recv_buyList_time'} = time;
 			return;
-			
+
 		} else {
 			return unless (timeOut($args->{'recv_buyList_time'}, $timeout{ai_buyAuto_wait_before_buy}{timeout}));
 		}
-		
+
 		my @buyList;
-		
+
 		my $item;
 		if ($config{"buyAuto_".$args->{lastIndex}} =~ /^\d{3,}$/) {
 			$item = $storeList->getByNameID( $config{"buyAuto_".$args->{lastIndex}} );
@@ -2077,19 +2077,19 @@ sub processAutoBuy {
 			$item = $storeList->getByName( $config{"buyAuto_".$args->{lastIndex}} );
 			$args->{'nameID'} = $item->{nameID} if (defined $item);
 		}
-		
+
 		if (!exists $args->{'nameID'}) {
 			$args->{index_failed}{$args->{lastIndex}} = 1;
 			error "buyAuto index ".$args->{lastIndex}." (".$config{"buyAuto_".$args->{lastIndex}}.") failed, item doesn't exist in npc sell list.\n", "npc";
-			
+
 		} else {
 			my $maxbuy = ($config{"buyAuto_".$args->{lastIndex}."_price"}) ? int($char->{zeny}/$config{"buyAuto_$args->{index}"."_price"}) : 30000; # we assume we can buy 30000, when price of the item is set to 0 or undef
 			my $needbuy = $config{"buyAuto_".$args->{lastIndex}."_maxAmount"};
-			
+
 			my $inv_amount = $char->inventory->sumByNameID($args->{'nameID'});
 
 			$needbuy -= $inv_amount;
-			
+
 			my $buy_amount = ($maxbuy > $needbuy) ? $needbuy : $maxbuy;
 
 			# support to market
@@ -2098,9 +2098,9 @@ sub processAutoBuy {
 			}
 
 			my $batchSize = $config{"buyAuto_".$args->{lastIndex}."_batchSize"};
-			
+
 			if ($batchSize && $batchSize < $buy_amount) {
-			
+
 				while ($buy_amount > 0) {
 					my $amount = ($buy_amount > $batchSize) ? $batchSize : $buy_amount;
 					my %buy = (
@@ -2110,7 +2110,7 @@ sub processAutoBuy {
 					push(@buyList, \%buy);
 					$buy_amount -= $amount;
 				}
-				
+
 			} else {
 				my %buy = (
 					itemID  => $args->{'nameID'},
@@ -2119,9 +2119,9 @@ sub processAutoBuy {
 				push(@buyList, \%buy);
 			}
 		}
-		
+
 		completeNpcBuy(\@buyList);
-		
+
 		delete $args->{'nameID'};
 		delete $args->{'sentNpcTalk'};
 		delete $args->{'sentNpcTalk_time'};
@@ -2270,7 +2270,7 @@ sub processMoveNearSlave {
 		&& $char->{slaves}
 		&& !AI::SlaveManager::isIdle()
 	) {
-	
+
 		my $slave = AI::SlaveManager::mustMoveNear();
 		if (defined $slave) {
 			ai_route($field->baseName, $slave->{pos_to}{x}, $slave->{pos_to}{y}, distFromGoal => ($config{$slave->{configPrefix}.'moveNearWhenIdle_minDistance'} || 4), attackOnRoute => 1, noSitAuto => 1, isMoveNearSlave => 1);
@@ -2283,7 +2283,7 @@ sub processMoveNearSlave {
 sub processRandomWalk {
 	if (AI::isIdle && (AI::SlaveManager::isIdle()) && $config{route_randomWalk} && !$ai_v{sitAuto_forcedBySitCommand}
 		&& (!$field->isCity || $config{route_randomWalk_inTown})
-		&& length($field->{rawMap}) 
+		&& length($field->{rawMap})
 		){
 		if($char->{pos}{x} == $config{'lockMap_x'} && !($config{'lockMap_randX'} > 0) && ($char->{pos}{y} == $config{'lockMap_y'} && !($config{'lockMap_randY'} >0))) {
 			error T("Coordinate lockmap is used; randomWalk disabled\n");
@@ -2355,7 +2355,7 @@ sub processFollow {
 				AI::clear(qw/move route/);
  				message TF("Found my master - %s\n", $player->name), "follow";
 				last;
-			}			
+			}
 		}
 	} elsif (!$args->{'following'} && $players{$args->{'ID'}} && %{$players{$args->{'ID'}}} && !${$players{$args->{'ID'}}}{'dead'} && ($players{$args->{'ID'}}->name eq $config{followTarget})) {
 		$args->{'following'} = 1;
@@ -2393,7 +2393,7 @@ sub processFollow {
 						getVector(\%vec, $player->{pos_to}, $char->{pos_to});
 						moveAlongVector(\%pos, $char->{pos_to}, \%vec, $dist - $config{followDistanceMin});
 						$timeout{ai_sit_idle}{time} = time;
-						
+
 						if($config{followRandom}) {
 							if(int(rand(2))) {
 								$pos{x} += int(rand($config{followRandomDistance})); }
@@ -2405,7 +2405,7 @@ sub processFollow {
 							else {
 								$pos{y} -= int(rand($config{followRandomDistance})); }
 						}
-						
+
 						$char->sendMove(@pos{qw(x y)});
 					}
 				}
@@ -2585,7 +2585,7 @@ sub processFollow {
 	if (!exists $args->{following} && !exists $args->{ai_follow_lost}) {
 		ai_partyfollow();
 	}
-	
+
 	Plugins::callHook("ai_follow", $args);
 }
 
@@ -2740,7 +2740,7 @@ sub processAutoSkillUse {
 					$amount = (int(($char->{lv} + $char->{int} + $char->{'int_bonus'}) / 5) * 30) * ($i / 10) * (1 + $meditatioBonus) + ($char->{'attack_magic_min'});
 				} else {
 					$amount = (int(($char->{lv} + $char->{int}) / 8) * (4 + $i * 8)) * $meditatioBonus;
-				} 
+				}
 				if ($char->{sp} < $sp_req) {
 					$smartHeal_lv--;
 					last;
@@ -2775,10 +2775,10 @@ sub processPartySkillUse {
 			next unless checkSelfCondition("partySkill_$i");
 			$party_skill{skillObject} = Skill->new(auto => $config{"partySkill_$i"});
 			$party_skill{owner} = $party_skill{skillObject}->getOwner;
-			
+
 			foreach my $ID ($accountID, @slavesID, @playersID) {
 				next if $ID eq '' || $ID eq $party_skill{owner}{ID};
-				
+
 				if ($ID eq $accountID) {
 					#
 				} elsif ($slavesList->getByID($ID)) {
@@ -2787,23 +2787,23 @@ sub processPartySkillUse {
 				} elsif ($playersList->getByID($ID)) {
 					unless ($config{"partySkill_$i"."_notPartyOnly"}) {
 						next unless $char->{party}{joined} && $char->{party}{users}{$ID};
-						
+
 						# party member should be online, otherwise it's another character on the same account (not in party)
 						next unless $char->{party}{users}{$ID}{online};
 					}
-					
+
 					# if that intended to distinguish between party members and other characters on the same accounts, then it didn't work
 					my $player = $playersList->getByID($ID);
 					next if (($char->{party}{users}{$ID}{name} ne $player->{name}) && !$config{"partySkill_$i"."_notPartyOnly"});
 				}
-				
+
 				my $player = Actor::get($ID);
 				next unless (
 					UNIVERSAL::isa($player, 'Actor::You')
 					|| UNIVERSAL::isa($player, 'Actor::Player')
 					|| UNIVERSAL::isa($player, 'Actor::Slave')
 				);
-				
+
 				if (
 					( # range check
 						$party_skill{owner}{ID} eq $player->{ID}
@@ -2844,7 +2844,7 @@ sub processPartySkillUse {
 			my $smartHeal_lv = 1;
 			my $hp_diff;
 			my $modifier = 1 + int(($char->{skills}{HP_MEDITATIO}{lv} * 2) / 100);
-			
+
 			if ($char->{party}{joined} && $char->{party}{users}{$party_skill{targetID}} && $char->{party}{users}{$party_skill{targetID}}{hp}) {
 				$hp_diff = $char->{party}{users}{$party_skill{targetID}}{hp_max} - $char->{party}{users}{$party_skill{targetID}}{hp};
 			} elsif($char->{mercenary} && $char->{mercenary}{hp} && $char->{mercenary}{hp_max}) {
@@ -2864,7 +2864,7 @@ sub processPartySkillUse {
 					$amount = (int(($char->{lv} + $char->{int} + $char->{'int_bonus'}) / 5) * 30) * ($i / 10) * (1 + $modifier) + ($char->{'attack_magic_min'});
 				} else {
 					$amount = (int(($char->{lv} + $char->{int}) / 8) * (4 + $i * 8)) * $modifier;
-				} 
+				}
 				if ($char->{sp} < $sp_req) {
 					$smartHeal_lv--;
 					last;
@@ -2936,7 +2936,7 @@ sub processAutoEquip {
 			my $ID = AI::args($ai_index_attack)->{ID};
 			$monster = $monsters{$ID};
 		}
-		
+
 		my @skip_slots;
 		if (AI::is('skill_use')) {
 			my $args = AI::args;
@@ -3354,7 +3354,7 @@ sub processAutoTeleport {
 			}
 		}
 		$timeout{ai_teleport_away}{time} = time;
-	}	
+	}
 
 	##### TELEPORT IDLE / PORTAL #####
 	if ($config{teleportAuto_idle} && (AI::action ne "" || !AI::SlaveManager::isIdle)) {
@@ -3526,8 +3526,7 @@ sub processDcOnPlayer {
 ##### REPAIR AUTO #####
 sub processRepairAuto {
 	if ($config{'repairAuto'} && $conState == 5 && timeOut($timeout{ai_repair}) && $repairList) {
-		my ($listID, $name);
-		my $brokenIndex = 0;
+		my $name;
 		foreach my $repairListItem (@{$repairList}) {
 			next if (!$repairListItem);
 			$name = itemNameSimple($repairListItem->{nameID});
@@ -3568,20 +3567,20 @@ sub processFeed {
 }
 
 sub processPartyShareAuto {
-	return if (!$char->{party}{users}{$accountID}{admin} || $char->{party}{shareForcedByCommand});	
-	
+	return if (!$char->{party}{users}{$accountID}{admin} || $char->{party}{shareForcedByCommand});
+
 	if (timeOut($timeout{ai_partyShareCheck})) {
 		if (!exists($char->{party}{shareTimes})) { $char->{party}{shareTimes} = 1; }
-		
+
 		if (($config{partyAutoShare} || $config{partyAutoShareItem} || $config{partyAutoShareItemDiv}) && $char->{party}{joined} && ($char->{party}{share} ne $config{partyAutoShare} || $char->{party}{itemPickup} ne $config{partyAutoShareItem} || $char->{party}{itemDivision} ne $config{partyAutoShareItemDiv})) {
 			$messageSender->sendPartyOption($config{partyAutoShare}, $config{partyAutoShareItem}, $config{partyAutoShareItemDiv});
 			$char->{party}{shareTimes}++;
 			if ($char->{party}{shareTimes} > 5) {
 				warning T("Party Share Settings have been sent many times, please check your party\n");
-			}			
+			}
 		}
 		$timeout{ai_partyShareCheck}{time} = time;
-	}	
+	}
 }
 
 sub processCheckMonster {

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -3529,6 +3529,7 @@ sub processRepairAuto {
 		my ($listID, $name);
 		my $brokenIndex = 0;
 		foreach my $repairListItem (@{$repairList}) {
+			next if (!$repairListItem);
 			$name = itemNameSimple($repairListItem->{nameID});
 			if (existsInList($config{'repairAuto_list'}, $name) || !$config{'repairAuto_list'}) {
 				$messageSender->sendRepairItem($repairListItem);

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -469,7 +469,11 @@ sub initHandlers {
 			["", T("logout and login after 5 seconds")],
 			[T("<seconds>"), T("logout and login after <seconds>")]
 			], \&cmdRelog],
-		['repair', undef, \&cmdRepair],
+		['repair', [
+			T("Repair player's items."),
+			[T("<repair_item #>"), T("repair the specified player's item")],
+			[T("cancel"), T("cancel repair item")],
+			], \&cmdRepair],
 		['respawn', T("Respawn back to the save point."), \&cmdRespawn],
 		['revive', undef, \&cmdRevive],
 		['rodex', undef, \&cmdRodex],
@@ -4927,14 +4931,22 @@ sub cmdRepair {
 		return;
 	}
 	my (undef, $listID) = @_;
-	if ($listID =~ /^\d+$/) {
+	if (!$repairList) {
+		error T("'Repair List' is empty.\n");
+	} elsif ($listID =~ /^\d+$/) {
 		if ($repairList->[$listID]) {
 			my $name = itemNameSimple($repairList->[$listID]{nameID});
 			message TF("Attempting to repair item: %s\n", $name);
 			$messageSender->sendRepairItem($repairList->[$listID]);
 		} else {
-			error TF("Item with index: %s does either not exist in the 'Repair List' or the list is empty.\n", $listID);
+			error TF("Item with index: %s does either not exist in the 'Repair List'.\n", $listID);
 		}
+	} elsif ($listID eq "cancel") {
+		message T("Cancel repair item.\n");
+		my %cancel = (
+			index => 65535, # 0xFFFF
+		);
+		$messageSender->sendRepairItem(\%cancel);
 	} else {
 		error T("Syntax Error in function 'repair' (Repair player's items.)\n" .
 			"Usage: repair [Repair List index]\n");

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4988,16 +4988,16 @@ sub cmdRepair {
 			T("   # Short name                     Full name\n");
 		for (my $i = 0; $i < @{$repairList}; $i++) {
 			next if ($repairList->[$i] eq "");
-			my $name = itemNameSimple($repairList->[$i]{nameID});
-			$msg .= sprintf("%4d %-30s %s\n", $i, $name, $char->inventory->get($i)->{name});
+			my $shortName = itemNameSimple($repairList->[$i]{nameID});
+			$msg .= sprintf("%4d %-30s %s\n", $i, $shortName, $repairList->[$i]->{name});
 		}
 		$msg .= ('-'x80) . "\n";
 		message $msg, "list";
 
 	} elsif ($binID =~ /^\d+$/) {
 		if ($repairList->[$binID]) {
-			my $name = itemNameSimple($repairList->[$binID]{nameID});
-			message TF("Attempting to repair item: %s (%d)\n", $name, $binID);
+			my $shortName = itemNameSimple($repairList->[$binID]{nameID});
+			message TF("Attempting to repair item: %s (%d)\n", $shortName, $binID);
 			$messageSender->sendRepairItem($repairList->[$binID]);
 		} else {
 			error TF("Item with index: %s does either not exist in the 'Repair List'.\n", $binID);

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -4929,9 +4929,9 @@ sub cmdRepair {
 	my (undef, $listID) = @_;
 	if ($listID =~ /^\d+$/) {
 		if ($repairList->[$listID]) {
-			$messageSender->sendRepairItem($repairList->[$listID]);
-			my $name = itemNameSimple($repairList->[$listID]);
+			my $name = itemNameSimple($repairList->[$listID]{nameID});
 			message TF("Attempting to repair item: %s\n", $name);
+			$messageSender->sendRepairItem($repairList->[$listID]);
 		} else {
 			error TF("Item with index: %s does either not exist in the 'Repair List' or the list is empty.\n", $listID);
 		}

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -846,7 +846,7 @@ sub received_characters {
 	}
 }
 
-# Tell client how many pages have character selection screen 
+# Tell client how many pages have character selection screen
 # 09A0 <total count>.W (PACKET_HC_CHARLIST_NOTIFY)
 # total count: Server send from total pages until 1 page
 sub sync_received_characters {
@@ -1155,7 +1155,7 @@ sub map_loaded {
 		ai_clientSuspend(0, $timeout{'ai_clientSuspend'}{'timeout'});
 	} else {
 		$messageSender->sendReqRemainTime() if (grep { $masterServer->{serverType} eq $_ } qw(Zero Sakray));
-		
+
 		$messageSender->sendMapLoaded();
 
 		$messageSender->sendSync(1);
@@ -1164,7 +1164,7 @@ sub map_loaded {
 		$messageSender->sendGuildRequestInfo(0);
 
 		$messageSender->sendRequestCashItemsList() if (grep { $masterServer->{serverType} eq $_ } qw(bRO idRO_Renewal)); # tested at bRO 2013.11.30, request for cashitemslist
-		$messageSender->sendCashShopOpen() if ($config{whenInGame_requestCashPoints});	
+		$messageSender->sendCashShopOpen() if ($config{whenInGame_requestCashPoints});
 
 		# request to unfreeze char - alisonrag
 		$messageSender->sendBlockingPlayerCancel() if $masterServer->{blockingPlayerCancel};
@@ -1179,7 +1179,7 @@ sub map_loaded {
 	makeCoordsDir($char->{pos}, $args->{coords}, \$char->{look}{body});
 	$char->{pos_to} = {%{$char->{pos}}};
 	message(TF("Your Coordinates: %s, %s\n", $char->{pos}{x}, $char->{pos}{y}), undef, 1);
-	
+
 	# set initial status from data received from the char server (seems needed on eA, dunno about kRO)}
 	if($masterServer->{private}){ setStatus($char, $char->{opt1}, $char->{opt2}, $char->{option}); }
 
@@ -1598,8 +1598,8 @@ sub stats_added {
 }
 
 # Character status (ZC_STATUS).
-# 00BD <stpoint>.W <str>.B <need str>.B <agi>.B <need agi>.B <vit>.B <need vit>.B <int>.B <need int>.B <dex>.B <need dex>.B <luk>.B <need luk>.B 
-# <atk>.W <atk2>.W <matk min>.W <matk max>.W <def>.W <def2>.W <mdef>.W <mdef2>.W <hit>.W <flee>.W <flee2>.W <crit>.W <aspd>.W <aspd2>.W 
+# 00BD <stpoint>.W <str>.B <need str>.B <agi>.B <need agi>.B <vit>.B <need vit>.B <int>.B <need int>.B <dex>.B <need dex>.B <luk>.B <need luk>.B
+# <atk>.W <atk2>.W <matk min>.W <matk max>.W <def>.W <def2>.W <mdef>.W <mdef2>.W <hit>.W <flee>.W <flee2>.W <crit>.W <aspd>.W <aspd2>.W
 sub stats_info {
 	my ($self, $args) = @_;
 	return unless changeToInGameState();
@@ -1837,7 +1837,7 @@ sub actor_display {
 			} else {
 				$actor = $object_class->new();
 			}
-			
+
 			$actor->{appear_time} = time;
 			$actor->{name_given} = bytesToString($args->{name}) if exists $args->{name};
 			$actor->{jobID} = $args->{type} if exists $args->{type};
@@ -2778,10 +2778,10 @@ sub homunculus_info {
 	if ($args->{state} == HO_PRE_INIT) {
 		my $state = $char->{homunculus}{state}
 			if ($char->{homunculus} && $char->{homunculus}{ID} && $char->{homunculus}{ID} ne $args->{ID});
-		
+
 		# Some servers won't send 'homunculus_property' after a teleport, so we don't delete $char->{homunculus} object
 		$char->{homunculus} = Actor::get($args->{ID}) if ($char->{homunculus}{ID} ne $args->{ID});
-		
+
 		$char->{homunculus}{state} = $state if (defined $state);
 		$char->{homunculus}{map} = $field->baseName;
 		unless ($char->{slaves}{$char->{homunculus}{ID}}) {
@@ -3040,7 +3040,7 @@ sub misc_config {
 			message T("Your Equipment information is now open to the public.\n");
 		} else {
 			message T("Your Equipment information is now not open to the public.\n");
-		}		
+		}
 	}
 
 	if (defined ($args->{call_flag})) {
@@ -3048,7 +3048,7 @@ sub misc_config {
 			message T("Allowed being summoned by skills: Urgent Call, Marriage Skills, etc.\n");
 		} else {
 			message T("Not Allowed being summoned by skills: Urgent Call, Marriage Skills, etc.\n");
-		}		
+		}
 	}
 
 	if (defined ($args->{pet_autofeed_flag})) {
@@ -3056,7 +3056,7 @@ sub misc_config {
 			message T("Pet automatic feeding is ON. (Ragexe Client Feature)\n");
 		} else {
 			message T("Pet automatic feeding is OFF. (Ragexe Client Feature)\n");
-		}		
+		}
 	}
 
 	if (defined ($args->{homunculus_autofeed_flag})) {
@@ -3064,7 +3064,7 @@ sub misc_config {
 			message T("Homunculus automatic feeding is ON. (Ragexe Client Feature)\n");
 		} else {
 			message T("Homunculus automatic feeding is OFF. (Ragexe Client Feature)\n");
-		}		
+		}
 	}
 }
 
@@ -6083,13 +6083,13 @@ sub guild_info {
 
 # Guild member manager information
 # 0154 <packet len>.W { <account>.L <char id>.L <hair style>.W <hair color>.W <gender>.W <class>.W <level>.W <contrib exp>.L <state>.L <position>.L <memo>.50B <name>.24B }* (ZC_MEMBERMGR_INFO)
-# 0AA5 <packet len>.W { <account>.L <char id>.L <hair style>.W <hair color>.W <gender>.W <class>.W <level>.W <contrib exp>.L <state>.L <position>.L <lastlogin>.L }* 
+# 0AA5 <packet len>.W { <account>.L <char id>.L <hair style>.W <hair color>.W <gender>.W <class>.W <level>.W <contrib exp>.L <state>.L <position>.L <lastlogin>.L }*
 # state:
 #     0 = offline
 #     1 = online
 sub guild_members_list {
 	my ($self, $args) = @_;
-	
+
 	my $guild_member_info;
 	if ($args->{switch} eq "0AA5") { # 0AA5
 		$guild_member_info = {
@@ -6104,7 +6104,7 @@ sub guild_members_list {
 			types => 'a4 a4 v5 V3 Z50 Z24',
 			keys => [qw(ID charID hair_style hair_color sex jobID lv contribution online position memo name)],
 		};
-	} 
+	}
 
 	delete $guild{member};
 	my $index = 0;
@@ -6208,7 +6208,7 @@ sub guild_member_online_status {
 # 0156 <packet len>.W { <account id>.L <char id>.L <position id>.L }*
 sub guild_update_member_position {
 	my ($self, $args) = @_;
-	
+
 	my $guild_position_info = {
 		len => 12,
 		types => 'a4 a4 V',
@@ -6268,7 +6268,7 @@ sub guild_name {
 	$messageSender->sendGuildRequestInfo(0);			# Requests for Basic Information Guild, Hostile Alliance Information
 	$messageSender->sendGuildRequestInfo(1);			# Requests for Members list, list job title
 	$messageSender->sendGuildRequestEmblem($guildID);	# Requests for Guild Emblem
-	# TODO: check if is necessary use PAGE 2 (title information list) 
+	# TODO: check if is necessary use PAGE 2 (title information list)
 	# $messageSender->sendGuildRequestInfo(2);			# Requests for List job title, title information list [Guild Title System]
 }
 
@@ -6385,7 +6385,7 @@ sub guild_skills_list {
 # Change 64 to 88 if needed
 sub guild_expulsionlist {
 	my ($self, $args) = @_;
-	for (my $i = 4; $i < $args->{RAW_MSG_SIZE}; $i += 64) { 
+	for (my $i = 4; $i < $args->{RAW_MSG_SIZE}; $i += 64) {
 
 		my ($name, $acc, $cause) = unpack('Z24 Z24 Z40', substr($args->{RAW_MSG}, $i, 64));
 
@@ -6413,7 +6413,7 @@ sub guild_member_map_change {
 # 0182 <account>.L <char id>.L <hair style>.W <hair color>.W <gender>.W <class>.W <level>.W <contrib exp>.L <state>.L <position>.L <memo>.50B <name>.24B
 sub guild_member_add {
 	my ($self, $args) = @_;
-	
+
 	if($guild{member}) {
 		my $index = scalar $guild{member};
 		foreach (@{$args->{KEYS}}) {
@@ -7355,7 +7355,7 @@ sub npc_market_info {
 		$item->{ID} = $storeList->size;
 
 		$item->{name} = itemName($item);
-		
+
 		$storeList->add($item);
 
 		debug "Item added to Store: $item->{name} - $item->{price}z\n", "parseMsg", 2;
@@ -7429,7 +7429,7 @@ sub npc_market_purchase_result {
 		$item->{ID} = $storeList->size;
 
 		$item->{name} = itemName($item);
-		
+
 		$storeList->add($item);
 
 		debug "Item added to Store: $item->{name} - $item->{price}z\n", "parseMsg", 2;
@@ -8073,7 +8073,7 @@ sub party_users_info {
 		$char->{party}{users}{$ID}{name} = bytesToString($char->{party}{users}{$ID}{name});
 		$char->{party}{users}{$ID}{admin} = !$char->{party}{users}{$ID}{admin};
 		$char->{party}{users}{$ID}{online} = !$char->{party}{users}{$ID}{online};
-		
+
 		# If party member return to saveMap out of our screen, the server will send to us party_users_info [iRO-RT 2020-jan]
 		undef $char->{party}{users}{$ID}{'dead'};
 		undef $char->{party}{users}{$ID}{'dead_time'};
@@ -8105,10 +8105,10 @@ sub party_dead {
 
 sub rodex_mail_list {
 	my ( $self, $args ) = @_;
-	
+
 	my $mail_info;
 
-	if ($args->{switch} eq '0AC2') {  
+	if ($args->{switch} eq '0AC2') {
 		$mail_info = {
 			len => 41,
 			types => 'C V2 C2 Z24 V v',
@@ -9264,7 +9264,7 @@ sub buying_store_items_list {
 
 	$msg .= "\n" . TF("Price limit: %s Zeny\n", $zeny) . ('-'x79) . "\n";
 	message $msg, "list";
-	
+
 	if($args->{expireDate}) {
 		$expireDate = $args->{expireDate};
 		my $date = int(time) + int($args->{expireDate}/1000);
@@ -9577,7 +9577,7 @@ sub rank_points {
 	message "Unknown rank type %s.\n", $args->{type} if $args->{type} > 2;
 }
 
-# Updates the fame rank points for the Blacksmith ranking. 
+# Updates the fame rank points for the Blacksmith ranking.
 # 021B <points>.L <total points>.L (ZC_BLACKSMITH_POINT)
 sub blacksmith_points {
 	my ($self, $args) = @_;
@@ -10245,7 +10245,7 @@ sub taekwon_packets {
 	}
 }
 
-# Updates the fame rank points for the Taekwon ranking. 
+# Updates the fame rank points for the Taekwon ranking.
 # 0224 <points>.L <total points>.L (ZC_TAEKWON_POINT)
 sub taekwon_rank {
 	my ($self, $args) = @_;
@@ -10549,22 +10549,22 @@ sub pvp_rank {
 # 01FC <packet len>.W { <index>.W <name id>.W <refine>.B <card1>.W <card2>.W <card3>.W <card4>.W }*
 sub repair_list {
 	my ($self, $args) = @_;
-	my $msg = T("--------Repair List--------\n");
+	my $msg = center(T(" Repair List "), 27, '-') ."\n";
 	undef $repairList;
 	for (my $i = 4; $i < $args->{RAW_MSG_SIZE}; $i += 13) {
 		my $item = {};
 
-		($item->{ID},
+		($item->{index},
 		$item->{nameID},
 		$item->{upgrade},
 		$item->{cards},
-		) = unpack('a2 v C a8', substr($args->{RAW_MSG}, $i, 13));
+		) = unpack('v2 C a8', substr($args->{RAW_MSG}, $i, 13));
 
-		$repairList->[$item->{ID}] = $item;
+		$repairList->[$item->{index}] = $item;
 		my $name = itemNameSimple($item->{nameID});
-		$msg .= $item->{ID} . " $name\n";
+		$msg .= $item->{index} . " $name\n";
 	}
-	$msg .= "---------------------------\n";
+	$msg .= ('-'x27) . "\n";
 	message $msg, "list";
 }
 
@@ -11060,9 +11060,9 @@ sub stylist_res {
 #    0x7 = ATTENDANCE_UI
 sub open_ui {
 	my ($self, $args) = @_;
-	
+
 	debug TF("Received request from server to open UI: %s\n", $args->{type});
-	
+
 	if($args->{type} == BANK_UI) { # TODO: implement bank system and add Bank open Request
 		message T("Server requested to open Bank UI.\n");
 	} elsif($args->{type} == STYLIST_UI) { # TODO: implement Stylist system and add Stylist open Request
@@ -11116,10 +11116,10 @@ sub attendance_ui {
 			message swrite( "@<<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<< @<<<<<<<<<", ["Day", "Item", "Amount", "Requested"]), "info";
 
 			for (my $i = 1; $i <= 20; $i++) {
-				my $requested = ($attendance_count >= $i) ? "yes" : "no";				
+				my $requested = ($attendance_count >= $i) ? "yes" : "no";
 				if ($attendance_count == $i && !$already_requested) { $requested = "can"; }
-				message swrite( 
-					"@<<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<< @<<<<<<<<<", 
+				message swrite(
+					"@<<< @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< @<<<<<< @<<<<<<<<<",
 					[$i, itemNameSimple($attendance_rewards{items}{$i}{item_id}), $attendance_rewards{items}{$i}{amount}, $requested]
 				), "info";
 			}
@@ -11151,7 +11151,7 @@ sub move_interrupt {
 #    1 = mark opening and closing
 sub banking_check {
 	my ($self, $args) = @_;
-	
+
 	$bankingopened = 1;
 	$banking{zeny} = $args->{zeny};
 
@@ -11159,7 +11159,7 @@ sub banking_check {
 	message TF("In Bank : %s z\n", $args->{zeny}), "info";
 	message TF("On Hand : %s z\n", $char->{zeny}), "info";
 	message ('-'x40) . "\n", "info";
-	
+
 	Plugins::callHook("banking_opened");
 }
 
@@ -11179,7 +11179,7 @@ sub banking_deposit {
 		Plugins::callHook("banking_deposit_success");
 		return;
 	} elsif ($args->{reason} == 0x1) {
-		error T("Bank: Deposit Error (Try it again).\n");		
+		error T("Bank: Deposit Error (Try it again).\n");
 	} elsif ($args->{reason} == 0x2) {
 		error T("Bank: No Money For Deposit.\n");
 	} elsif ($args->{reason} == 0x3) {
@@ -11216,7 +11216,7 @@ sub banking_withdraw {
 
 # start a navigation to designed location/map
 # 08E2 <type>.B <flag>.B <hide>.B <map>.16B <x pos>.W <y pos>.W <mob id>.W
-# TODO: document type and flag 
+# TODO: document type and flag
 sub navigate_to {
 	my ($self, $args) = @_;
 
@@ -11266,7 +11266,7 @@ sub roulette_window {
 # 0A1C <length>.W <serial>.L { { <level>.W <column>.W <item>.L <amount>.L } * MAX_ROULETTE_COLUMNS } * MAX_ROULETTE_LEVEL (ZC_ACK_ROULEITTE_INFO) >= 20180516
 sub roulette_info {
 	my ($self, $args) = @_;
-	
+
 	my $item_info = {
 			len => 8, # or 12
 			types => 'v4', # or v2 V2
@@ -11287,7 +11287,7 @@ sub roulette_info {
 sub roulette_recv_item {
 	my ($self, $args) = @_;
 	message TF("Roulette Bonus - Type: %s  Bonus Item: %s\n", $args->{type}, itemNameSimple($args->{item_id})), "info";
-	
+
 }
 
 # Update Roulette window with current stats
@@ -11299,7 +11299,7 @@ sub roulette_window_update {
 	foreach (@{$args->{KEYS}}) {
 		$roulette{$_} = $args->{$_};
 	}
-	
+
 	if($args->{result} == 1) {
 		warning T("Roulette: Something went wrong\n");
 		return;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -10578,11 +10578,12 @@ sub repair_list {
 sub repair_result {
 	my ($self, $args) = @_;
 	undef $repairList;
-	my $itemName = itemNameSimple($args->{nameID});
+	my $index = $args->{ID};
+	my $item = $char->inventory->getByID($index);
 	if ($args->{flag}) {
-		message TF("Repair of %s failed.\n", $itemName);
+		message TF("Repair of %s failed.\n", $item->{name});
 	} else {
-		message TF("Successfully repaired %s.\n", $itemName);
+		message TF("Successfully repaired '%s'\n", $item->{name});
 	}
 }
 

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -10549,22 +10549,27 @@ sub pvp_rank {
 # 01FC <packet len>.W { <index>.W <name id>.W <refine>.B <card1>.W <card2>.W <card3>.W <card4>.W }*
 sub repair_list {
 	my ($self, $args) = @_;
-	my $msg = center(T(" Repair List "), 27, '-') ."\n";
 	undef $repairList;
+	my $msg = center(T(" Repair List "), 80, '-') ."\n".
+			T("   # Short name                     Full name\n");
+
 	for (my $i = 4; $i < $args->{RAW_MSG_SIZE}; $i += 13) {
-		my $item = {};
+		my $repairItem = {};
 
-		($item->{index},
-		$item->{nameID},
-		$item->{upgrade},
-		$item->{cards},
+		($repairItem->{index},
+		$repairItem->{nameID},
+		$repairItem->{upgrade},
+		$repairItem->{cards},
 		) = unpack('v2 C a8', substr($args->{RAW_MSG}, $i, 13));
+		my $ID = $repairItem->{index} + 2;
+		$ID = pack("v", $ID);
+		my $item = $char->inventory->getByID($ID);
+		$repairList->[$item->{binID}] = $repairItem;
 
-		$repairList->[$item->{index}] = $item;
-		my $name = itemNameSimple($item->{nameID});
-		$msg .= $item->{index} . " $name\n";
+		my $name = itemNameSimple($repairItem->{nameID});
+		$msg .= sprintf("%4d %-30s %s\n", $item->{binID}, $name, $item->{name});
 	}
-	$msg .= ('-'x27) . "\n";
+	$msg .= ('-'x80) . "\n";
 	message $msg, "list";
 }
 

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -321,7 +321,7 @@ sub new {
 		'01F6' => ['adopt_request', 'a4 a4 Z24', [qw(sourceID targetID name)]],
 		#'01F8' => ['adopt_unknown'], # clif_adopt_process
 		'01FC' => ['repair_list'],
-		'01FE' => ['repair_result', 'v C', [qw(nameID flag)]],
+		'01FE' => ['repair_result', 'a2 C', [qw(ID flag)]], # 5
 		'01FF' => ['high_jump', 'a4 v2', [qw(ID x y)]],
 		'0201' => ['friend_list'],
 		'0205' => ['divorced', 'Z24', [qw(name)]], # clif_divorced
@@ -927,7 +927,7 @@ sub parse_items {
 	for (my $i = 0; $i < $length; $i += $unpack->{len}) {
 		my $item;
 		@{$item}{@{$unpack->{keys}}} = unpack($unpack->{types}, substr($args->{itemInfo}, $i, $unpack->{len}));
-    
+
 		if ( $args->{switch} eq '0B09' && $masterServer->{serverType} ne 'iRO_Renewal' && existsInList("10, 16, 17, 19", $item->{type}) ) { # workaround arrow/ammunition byte bug
 			$item->{amount} = unpack("v", substr($args->{itemInfo}, $i+7, 2));
 		}

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -321,7 +321,7 @@ sub new {
 		'01F6' => ['adopt_request', 'a4 a4 Z24', [qw(sourceID targetID name)]],
 		#'01F8' => ['adopt_unknown'], # clif_adopt_process
 		'01FC' => ['repair_list'],
-		'01FE' => ['repair_result', 'a2 C', [qw(ID flag)]], # 5
+		'01FE' => ['repair_result', 'v C', [qw(index flag)]], # 5
 		'01FF' => ['high_jump', 'a4 v2', [qw(ID x y)]],
 		'0201' => ['friend_list'],
 		'0205' => ['divorced', 'Z24', [qw(name)]], # clif_divorced

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -332,7 +332,7 @@ sub new {
 		'01F6' => ['adopt_request', 'a4 a4 Z24', [qw(sourceID targetID name)]], # 34
 		'01F8' => ['adopt_start'], # 2
 		'01FC' => ['repair_list'], # -1
-		'01FE' => ['repair_result', 'a2 C', [qw(ID flag)]], # 5
+		'01FE' => ['repair_result', 'v C', [qw(index flag)]], # 5
 		'01FF' => ['high_jump', 'a4 v2', [qw(ID x y)]], # 10
 		'0201' => ['friend_list'], # -1
 		'0205' => ['divorced', 'Z24', [qw(name)]], # 26 # clif_divorced

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -222,7 +222,7 @@ sub new {
 		'014B' => ['GM_silence', 'C Z24', [qw(type name)]], # 27
 		'014C' => ['guild_allies_enemy_list'], # -1
 		'014E' => ['guild_master_member', 'V', [qw(type)]], # 6
-		'0150' => ['guild_info', 'a4 V9 a4 Z24 Z24 Z16 V', [qw(ID lv conMember maxMember average exp exp_next tax tendency_left_right tendency_down_up emblemID name master castles_string zeny)]],		
+		'0150' => ['guild_info', 'a4 V9 a4 Z24 Z24 Z16 V', [qw(ID lv conMember maxMember average exp exp_next tax tendency_left_right tendency_down_up emblemID name master castles_string zeny)]],
 		'0152' => ['guild_emblem', 'v a4 a4 a*', [qw(len guildID emblemID emblem)]], # -1
 		'0154' => ['guild_members_list', 'v a*', [qw(len member_list)]],
 		'0156' => ['guild_update_member_position', 'v a*', [qw(len member_list)]],
@@ -332,7 +332,7 @@ sub new {
 		'01F6' => ['adopt_request', 'a4 a4 Z24', [qw(sourceID targetID name)]], # 34
 		'01F8' => ['adopt_start'], # 2
 		'01FC' => ['repair_list'], # -1
-		'01FE' => ['repair_result', 'v C', [qw(nameID flag)]], # 5
+		'01FE' => ['repair_result', 'a2 C', [qw(ID flag)]], # 5
 		'01FF' => ['high_jump', 'a4 v2', [qw(ID x y)]], # 10
 		'0201' => ['friend_list'], # -1
 		'0205' => ['divorced', 'Z24', [qw(name)]], # 26 # clif_divorced
@@ -888,7 +888,7 @@ sub parse_items {
 	for (my $i = 0; $i < $length; $i += $unpack->{len}) {
 		my $item;
 		@{$item}{@{$unpack->{keys}}} = unpack($unpack->{types}, substr($args->{itemInfo}, $i, $unpack->{len}));
-    
+
 		if ( $args->{switch} eq '0B09' && $masterServer->{serverType} ne 'iRO_Renewal' && existsInList("10, 16, 17, 19", $item->{type}) ) { # workaround arrow/ammunition byte bug
 			$item->{amount} = unpack("v", substr($args->{itemInfo}, $i+7, 2));
 		}

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -33,7 +33,7 @@ use Digest::MD5;
 use Math::BigInt;
 
 # TODO: remove 'use Globals' from here, instead pass vars on
-use Globals qw(%config $bytesSent %packetDescriptions $enc_val1 $enc_val2 $char $masterServer $syncSync $accountID %timeout %talk $skillExchangeItem $net $rodexList $rodexWrite %universalCatalog %rpackets $mergeItemList);
+use Globals qw(%config $bytesSent %packetDescriptions $enc_val1 $enc_val2 $char $masterServer $syncSync $accountID %timeout %talk $skillExchangeItem $net $rodexList $rodexWrite %universalCatalog %rpackets $mergeItemList $repairList);
 
 use I18N qw(bytesToString stringToBytes);
 use Utils qw(existsInList getHex getTickCount getCoordString makeCoordsDir);
@@ -100,7 +100,7 @@ sub import {
 sub encryptMessageID {
 	my ($self, $r_message) = @_;
 	my $messageID = unpack("v", $$r_message);
-	
+
 	if ($self->{encryption}->{crypt_key_3}) {
 		if (sprintf("%04X",$messageID) eq $self->{packet_lut}{map_login}) {
 			$self->{encryption}->{crypt_key} = $self->{encryption}->{crypt_key_1};
@@ -108,21 +108,21 @@ sub encryptMessageID {
 			# Turn off keys
 			$self->{encryption}->{crypt_key} = 0; return;
 		}
-			
+
 		# Checking if Encryption is Activated
 		if ($self->{encryption}->{crypt_key} > 0) {
 			# Saving Last Informations for Debug Log
 			my $oldMID = $messageID;
 			my $oldKey = ($self->{encryption}->{crypt_key} >> 16) & 0x7FFF;
-			
+
 			# Calculating the Encryption Key
 			$self->{encryption}->{crypt_key} = ($self->{encryption}->{crypt_key} * $self->{encryption}->{crypt_key_3} + $self->{encryption}->{crypt_key_2}) & 0xFFFFFFFF;
-		
+
 			# Xoring the Message ID
 			$messageID = ($messageID ^ (($self->{encryption}->{crypt_key} >> 16) & 0x7FFF)) & 0xFFFF;
 			$$r_message = pack("v", $messageID) . substr($$r_message, 2);
 
-			# Debug Log	
+			# Debug Log
 			debug (sprintf("Encrypted MID : [%04X]->[%04X] / KEY : [0x%04X]->[0x%04X]\n", $oldMID, $messageID, $oldKey, ($self->{encryption}->{crypt_key} >> 16) & 0x7FFF), "sendPacket", 0) if $config{debugPacket_sent};
 		}
 	} else {
@@ -250,7 +250,7 @@ sub sendToServer {
 
 	$net->serverSend($msg);
 	$bytesSent += length($msg);
-	
+
 	if ($config{debugPacket_sent} && !existsInList($config{debugPacket_exclude}, $messageID) && $config{debugPacket_include_dumpMethod} < 3) {
 		my $label = $packetDescriptions{Send}{$messageID} ?
 			"[$packetDescriptions{Send}{$messageID}]" : '';
@@ -260,7 +260,7 @@ sub sendToServer {
 			Misc::visualDump($msg, ">> Sent packet: $messageID  $label");
 		}
 	}
-	
+
 	if ($config{'debugPacket_include_dumpMethod'} && !existsInList($config{debugPacket_exclude}, $messageID) && existsInList($config{'debugPacket_include'}, $messageID)) {
 		my $label = $packetDescriptions{Send}{$messageID} ?
 			"[$packetDescriptions{Send}{$messageID}]" : '';
@@ -298,7 +298,7 @@ sub sendRaw {
 
 sub parse_master_login {
 	my ($self, $args) = @_;
-	
+
 	if (exists $args->{password_md5_hex}) {
 		$args->{password_md5} = pack 'H*', $args->{password_md5_hex};
 	}
@@ -315,12 +315,12 @@ sub parse_master_login {
 
 sub reconstruct_master_login {
 	my ($self, $args) = @_;
-	
+
 	$args->{ip} = '192.168.0.2' unless exists $args->{ip}; # gibberish
 	$args->{mac} = '111111111111' unless exists $args->{mac}; # gibberish
 	$args->{mac_hyphen_separated} = join '-', $args->{mac} =~ /(..)/g;
 	$args->{isGravityID} = 0 unless exists $args->{isGravityID};
-	
+
 	if (exists $args->{password}) {
 		for (Digest::MD5->new) {
 			$_->add($args->{password});
@@ -349,7 +349,7 @@ sub sendMasterLogin {
 		&& ($self->{packet_lut}{master_login} = $masterServer->{masterLogin_packet})
 	) {
 		$self->sendClientMD5Hash() unless $masterServer->{clientHash} eq ''; # this is a hack, just for testing purposes, it should be moved to the login algo later on
-		
+
 		$msg = $self->reconstruct({
 			switch => 'master_login',
 			version => $version || $self->version,
@@ -371,7 +371,7 @@ sub sendMasterLogin {
 sub secureLoginHash {
 	my ($self, $password, $salt, $type) = @_;
 	my $md5 = Digest::MD5->new;
-	
+
 	$password = stringToBytes($password);
 	if ($type % 2) {
 		$salt = $salt . $password;
@@ -379,7 +379,7 @@ sub secureLoginHash {
 		$salt = $password . $salt;
 	}
 	$md5->add($salt);
-	
+
 	$md5->digest
 }
 
@@ -387,7 +387,7 @@ sub sendMasterSecureLogin {
 	my ($self, $username, $password, $salt, $version, $master_version, $type, $account) = @_;
 
 	$self->{packet_lut}{master_login} ||= $type < 3 ? '01DD' : '01FA';
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'master_login',
 		version => $version || $self->version,
@@ -428,10 +428,10 @@ sub sendMapLogin {
 	my ($self, $accountID, $charID, $sessionID, $sex) = @_;
 	my $msg;
 	$sex = 0 if ($sex > 1 || $sex < 0); # Sex can only be 0 (female) or 1 (male)
-	
+
 	if ($self->{serverType} == 0 || $self->{serverType} == 17 || $self->{serverType} == 18 || $self->{serverType} == 19 ||
 		$self->{serverType} == 20 || $self->{serverType} == 21 || $self->{serverType} == 22) {
-		
+
 		$msg = $self->reconstruct({
 			switch => 'map_login',
 			accountID => $accountID,
@@ -488,21 +488,21 @@ sub parse_character_move {
 
 sub reconstruct_character_move {
 	my ($self, $args) = @_;
-	
+
 	$args->{no_padding} = exists $args->{no_padding} ? $args->{no_padding} : $masterServer->{serverType} == 0;
-	
+
 	$args->{coords} = getCoordString(@{$args}{qw(x y)}, $args->{no_padding});
 }
 
 sub sendMove {
 	my ($self, $x, $y) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'character_move',
 		x => $x,
 		y => $y
 	}));
-	
+
 	debug "Sent move to: $x, $y\n", "sendPacket", 2;
 }
 
@@ -675,9 +675,9 @@ sub sendStorageGet {
 
 sub sendStoragePassword {
 	my ($self, $pass, $type) = @_;
-	
+
 	# $pass -> 16 byte packed hex data
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'storage_password',
 		type => $type,
@@ -687,12 +687,12 @@ sub sendStoragePassword {
 
 sub reconstruct_storage_password {
 	my ($self, $args) = @_;
-	
+
 	my $aux = pack "H*", "EC62E539BB6BBC811A60C06FACCB7EC8";
-	
+
 	# $type == 2 -> change password
 	# $type == 3 -> check password
-	
+
 	if ($args->{type} == 3) {
 		$args->{data} = pack '(a*)*', $args->{pass}, $aux;
 	} elsif ($args->{type} == 2) {
@@ -854,12 +854,12 @@ sub sendCloseShop {
 # 0x7DA
 sub sendPartyLeader {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'party_leader',
 		accountID => $ID,
 	}));
-	
+
 	debug "Sent Change Party Leader ".getHex($ID)."\n", "sendPacket", 2;
 }
 
@@ -935,14 +935,14 @@ sub sendCharDelete2Cancel {
 
 sub reconstruct_client_hash {
 	my ($self, $args) = @_;
-	
+
 	if (defined $args->{code}) {
 		# FIXME there's packet switch in that code. How to handle it correctly?
 		my $code = $args->{code};
 		$code =~ s/^02 04 //;
-		
+
 		$args->{hash} = pack 'C*', map hex, split / /, $code;
-		
+
 	} elsif ($args->{type}) {
 		if ($args->{type} == 1) {
 			$args->{hash} = pack('C*', 0x7B, 0x8A, 0xA8, 0x90, 0x2F, 0xD8, 0xE8, 0x30, 0xF8, 0xA5, 0x25, 0x7A, 0x0D, 0x3B, 0xCE, 0x52);
@@ -974,22 +974,22 @@ sub parse_actor_move {
 
 sub reconstruct_actor_move {
 	my ($self, $args) = @_;
-	
+
 	$args->{no_padding} = exists $args->{no_padding} ? $args->{no_padding} : !($masterServer->{serverType} > 0);
-	
+
 	$args->{coords} = getCoordString(@{$args}{qw(x y)}, $args->{no_padding});
 }
 
 sub sendSlaveMove {
 	my ($self, $ID, $x, $y) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'actor_move',
 		ID => $ID,
 		x => $x,
 		y => $y,
 	}));
-	
+
 	debug sprintf("Sent %s move to: %d, %d\n", Actor::get($ID), $x, $y), "sendPacket", 2;
 }
 
@@ -1027,15 +1027,15 @@ sub sendHomunculusCommand {
 	debug "Sent Homunculus Command $command", "sendPacket", 2;
 }
 
-sub sendPartyJoinRequestByName 
+sub sendPartyJoinRequestByName
 {
 	my ($self, $name) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'party_join_request_by_name',
 		partyName => stringToBytes ($name),
-	}));	
-	
+	}));
+
 	debug "Sent Request Join Party (by name): $name\n", "sendPacket", 2;
 }
 
@@ -1052,10 +1052,10 @@ sub sendSkillSelect {
 sub sendReplySyncRequestEx {
 	my ($self, $SyncID) = @_;
 	# Packing New Message and Dispatching
-	
+
 	$self->sendToServer(pack("v", $SyncID));
 	# Debug Log
-	# print "Dispatching Sync Ex Reply : 0x" . $pid . "\n";		
+	# print "Dispatching Sync Ex Reply : 0x" . $pid . "\n";
 	# Debug Log
 	debug "Sent Reply Sync Request Ex\n", "sendPacket", 2;
 }
@@ -1109,20 +1109,20 @@ sub sendCashShopClose {
 
 sub sendCashBuy {
 	my ($self, $kafra_points, $items) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'cash_shop_buy',
 		kafra_points => $kafra_points,
 		count => scalar @{$items},
 		items => $items,
 	}));
-	
+
 	debug "Requesting cash shop buy\n", "sendPacket", 2;
 }
 
 sub reconstruct_cash_shop_buy {
 	my ($self, $args) = @_;
-	
+
 	$args->{buy_info} = pack '(a*)*', map { pack 'V V v', $_->{nameID}, $_->{amount}, $_->{tab} } @{$args->{items}};
 	# Some older clients (prior to 2013, I don't know the exact date) use 'v3' instead of 'V2 v' - lututui
 	# $args->{buy_info} = pack '(a*)*', map { pack 'v v v', $_->{nameID}, $_->{amount}, $_->{tab} } @{$args->{items}};
@@ -1262,9 +1262,9 @@ sub sendEquipSwitchSingle {
 
 sub sendProgress {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'notify_progress_bar_complete'}));
-	
+
 	debug "Sent Progress Bar Finish\n", "sendPacket", 2;
 }
 
@@ -1359,7 +1359,7 @@ sub sendTokenToServer {
 	my $ip = '192.168.0.14';
 	my $mac = '20CF3095572A';
 	my $mac_hyphen_separated = join '-', $mac =~ /(..)/g;
-	
+
 	$net->serverDisconnect();
 	$net->serverConnect($ott_ip, $ott_port);
 
@@ -1373,7 +1373,7 @@ sub sendTokenToServer {
 		mac => $mac_hyphen_separated,
 		ip => $ip,
 		token => $token,
-	});	
+	});
 
 	$self->sendToServer($msg);
 
@@ -1491,7 +1491,7 @@ sub rodex_checkname {
 	}));
 }
 
-#note ! 
+#note !
 #merge sub of 0A6E / 09EC ? [sctnightcore]
 sub rodex_send_mail {
 	my ($self) = @_;
@@ -1593,7 +1593,7 @@ sub sendAddStatusPoint {
     $self->sendToServer($self->reconstruct({
         switch => 'send_add_status_point',
         statusID => $ID,
-        Amount => '1', 
+        Amount => '1',
     }));
 }
 
@@ -1601,13 +1601,13 @@ sub sendAddSkillPoint {
     my ($self, $skillID) = @_;
     $self->sendToServer($self->reconstruct({
         switch => 'send_add_skill_point',
-        skillID => $skillID, 
+        skillID => $skillID,
     }));
 }
 
 sub sendHotKeyChange {
 	my ($self, $args) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'hotkey_change',
 		idx => $args->{idx},
@@ -1624,7 +1624,7 @@ sub sendQuestState {
         questID => $questID,
         state => $state, #TODO:[active=0x00],[inactive=0x01]
     }));
-	debug "Sent Quest State.\n", "sendPacket", 2;	
+	debug "Sent Quest State.\n", "sendPacket", 2;
 }
 
 sub sendClanChat {
@@ -1639,7 +1639,7 @@ sub sendchangetitle {
         switch => 'send_change_title',
         ID => $title_id,
     }));
-	debug "Sent Change Title.\n", "sendPacket", 2;	
+	debug "Sent Change Title.\n", "sendPacket", 2;
 }
 
 sub sendRecallSso {
@@ -1706,7 +1706,7 @@ sub sendWeaponRefine {
 		switch => 'refine_item',
 		ID => $ID,
 	});
-	
+
 	$self->sendToServer($msg);
 
 	debug "Sent Weapon Refine.\n", "sendPacket", 2;
@@ -1736,17 +1736,17 @@ sub sendMakeItemRequest {
 
 sub sendSearchStoreClose {
 	my ($self, $args) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'search_store_close'}));
-	
+
 	$universalCatalog{open} = 0;
-	
+
 	debug "Sent search store close\n", "sendPacket", 2;
 }
 
 sub sendSearchStoreSearch {
 	my ($self, $args) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'search_store_info',
 		type => $args->{type},
@@ -1755,16 +1755,16 @@ sub sendSearchStoreSearch {
 		item_list => \@{$args->{item_list}},
 		card_list => \@{$args->{card_list}},
 	}));
-	
+
 	debug "Sent search store search\n", "sendPacket", 2;
 }
 
 sub reconstruct_search_store_info {
 	my ($self, $args) = @_;
-	
+
 	$args->{item_count} = scalar(@{$args->{item_list}});
 	$args->{card_count} = scalar(@{$args->{card_list}});
-	
+
 	my @id_list = (@{$args->{item_list}}, @{$args->{card_list}});
 
 	$args->{item_card_list} = pack "(a*)*", map { pack "v", $_ } @id_list;
@@ -1772,95 +1772,94 @@ sub reconstruct_search_store_info {
 
 sub sendSearchStoreRequestNextPage {
 	my ($self, $args) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'search_store_request_next_page'}));
-	
+
 	debug "Sent search store next page request\n", "sendPacket", 2;
 }
 
 sub sendSearchStoreSelect {
 	my ($self, $args) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'search_store_select',
 		accountID => $args->{accountID},
 		storeID => $args->{storeID},
 		nameID => $args->{nameID},
 	}));
-	
+
 	debug "Sent search store select request\n", "sendPacket", 2;
 }
 
 sub sendNoviceDoriDori {
 	my ($self, $args) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'novice_dori_dori'}));
-	
+
 	debug "Sent Novice Dori Dori\n", "sendPacket", 2;
 }
 
 sub sendChangeDress {
 	my ($self, $args) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'change_dress'}));
-	
+
 	debug "Sent Change Dress\n", "sendPacket", 2;
 }
 
 sub sendFriendRemove {
 	my ($self, $accountID, $charID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'friend_remove',
 		accountID => $accountID,
 		charID => $charID,
 	}));
-	
+
 	debug "Sent Remove a friend\n", "sendPacket";
 }
 
 sub sendRepairItem {
 	my ($self, $args) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'repair_item',
-		index => $args->{ID},
+		index => $args->{index},
 		nameID => $args->{nameID},
-		status => $args->{status},
-		status2 => $args->{status2},
-		listID => $args->{listID},
+		upgrade => $args->{upgrade},
+		cards => $args->{cards},
 	}));
-	
-	debug ("Sent repair item: ".$args->{ID}."\n", "sendPacket", 2);
+	undef $repairList;
+	debug ("Sent repair item index: ".$args->{index}."\n", "sendPacket", 2);
 }
 
 sub sendAdoptRequest {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'adopt_request',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent Adoption Request.\n", "sendPacket", 2;
 }
 
 sub sendAdoptReply {
 	my ($self, $parentID1, $parentID2, $result) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'adopt_reply_request',
 		parentID1 => $parentID1,
 		parentID2 => $parentID2,
 		result => $result
 	}));
-	
+
 	debug "Sent Adoption Reply.\n", "sendPacket", 2;
 }
 
 sub sendPrivateAirshipRequest {
 	my ($self, $map_name, $nameID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'private_airship_request',
 		map_name => stringToBytes($map_name),
@@ -1870,49 +1869,49 @@ sub sendPrivateAirshipRequest {
 
 sub sendNoviceExplosionSpirits {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'novice_explosion_spirits'}));
-	
+
 	debug "Sent Novice Explosion Spirits\n", "sendPacket", 2;
 }
 
 sub sendBanCheck {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'ban_check',
 		accountID => $ID,
 	}));
-	
+
 	debug "Sent Account Ban Check Request : " . getHex($ID) . "\n", "sendPacket", 2;
 }
 
 sub sendChangeCart {
 	my ($self, $lvl) = @_;
-	
+
 	# lvl: 1..5
 	$self->sendToServer($self->reconstruct({
 		switch => 'change_cart',
 		lvl => $lvl,
 	}));
-	
+
 	debug "Sent Cart Change to : $lvl\n", "sendPacket", 2;
 }
 
 sub sendArrowCraft {
 	my ($self, $nameID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'make_arrow',
 		nameID => $nameID,
 	}));
-	
+
 	debug "Sent Arrowmake: $nameID\n", "sendPacket", 2;
 }
 
 sub sendAutoSpell {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auto_spell',
 		ID => $ID,
@@ -1921,25 +1920,25 @@ sub sendAutoSpell {
 
 sub sendEmotion {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'send_emotion',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent Emotion\n", "sendPacket", 2;
 }
 
 sub sendWho {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'request_user_count'}));
 	debug "Sent Who (User Count)\n", "sendPacket", 2;
 }
 
-sub sendNPCBuySellList { 
+sub sendNPCBuySellList {
 	my ($self, $ID, $type) = @_;
-	
+
 	# type: 0 get store list
 	# type: 1 get sell list
 	$self->sendToServer($self->reconstruct({
@@ -1947,40 +1946,40 @@ sub sendNPCBuySellList {
 		ID => $ID,
 		type => $type,
 	}));
-	
+
 	debug "Sent get ".($type ? "buy" : "sell")." list to NPC: ".getHex($ID)."\n", "sendPacket", 2;
 }
 
 sub sendIgnore {
 	my ($self, $name, $flag) = @_;
-	
+
 	my $nameToBytes = stringToBytes($name);
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'ignore_player',
 		name => $nameToBytes,
 		flag => $flag,
 	}));
-	
+
 	debug "Sent Ignore: $name, $flag\n", "sendPacket", 2;
 }
 
 sub sendIgnoreAll {
 	my ($self, $flag) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'ignore_all',
 		flag => $flag,
 	}));
-	
+
 	debug "Sent Ignore All: $flag\n", "sendPacket", 2;
 }
 
 sub sendGetIgnoreList {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'get_ignore_list'}));
-	
+
 	debug "Sent get Ignore List.\n", "sendPacket", 2;
 }
 
@@ -1994,19 +1993,19 @@ sub sendChatRoomCreate {
 		password => stringToBytes($password),
 		title => stringToBytes($title),
 	}));
-	
+
 	debug "Sent Create Chat Room: $title, $limit, $public, $password\n", "sendPacket", 2;
 }
 
 sub sendChatRoomJoin {
 	my ($self, $ID, $password) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'chat_room_join',
 		ID => $ID,
 		password => stringToBytes($password),
 	}));
-	
+
 	debug "Sent Join Chat Room: ".getHex($ID).", $password\n", "sendPacket", 2;
 }
 
@@ -2020,7 +2019,7 @@ sub sendChatRoomChange {
 		password => stringToBytes($password),
 		title => stringToBytes($title),
 	}));
-	
+
 	debug "Sent Change Chat Room: $title, $limit, $public, $password\n", "sendPacket", 2;
 }
 
@@ -2030,7 +2029,7 @@ sub sendChatRoomBestow {
 	$self->sendToServer($self->reconstruct({
 		switch => 'chat_room_bestow',
 		name => stringToBytes($name),
-		
+
 		# There are two roles:
 		# 	0 means 'admin'
 		# 	1 means 'normal (not-admin)'
@@ -2039,51 +2038,51 @@ sub sendChatRoomBestow {
 		# and in the official client you cannot try to bestow the chat window UNLESS
 		# you're admin - so it always sends role 0
 		# In rA and Hercules, this info is not used at all, instead it's checked whether
-		# you're actually the chat window admin or not. This might be exploitable in 
+		# you're actually the chat window admin or not. This might be exploitable in
 		# official servers (by lying that you're admin when you're not) but I never cared
 		# enough to test - lututui, Aug 2018
 		role => 0,
 	}));
-	
+
 	debug "Sent Chat Room Bestow: $name\n", "sendPacket", 2;
 }
 
 sub sendChatRoomKick {
 	my ($self, $name) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'chat_room_kick',
 		name => stringToBytes($name),
 	}));
-	
+
 	debug "Sent Chat Room Kick: $name\n", "sendPacket", 2;
 }
 
 sub sendChatRoomLeave {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'chat_room_leave'}));
-	
+
 	debug "Sent Leave Chat Room\n", "sendPacket", 2;
 }
 
 sub sendDeal {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'deal_initiate',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent Initiate Deal: ".getHex($ID)."\n", "sendPacket", 2;
 }
 
 sub sendDealReply {
 	my ($self, $action) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'deal_reply',
-		
+
 		# Action values:
 		# 0: Char is too far
 		# 1: Character does not exist
@@ -2095,156 +2094,156 @@ sub sendDealReply {
 		# and the server is the one that can reply 0~2 - technologyguild, Dec 2009
 		action => $action,
 	}));
-	
+
 	debug "Sent Deal Reply (Action: $action)\n", "sendPacket", 2;
 }
 
 sub sendDealFinalize {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'deal_finalize'}));
-	
+
 	debug "Sent Deal Finalize\n", "sendPacket", 2;
 }
 
 sub sendCurrentDealCancel {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'deal_cancel'}));
-	
+
 	debug "Sent Cancel Current Deal\n", "sendPacket", 2;
 }
 
 sub sendDealTrade {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'deal_trade'}));
-	
+
 	debug "Sent Deal Trade\n", "sendPacket", 2;
 }
 
 sub sendStorageClose {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'storage_close'}));
-	
+
 	debug "Sent Storage Close\n", "sendPacket", 2;
 }
 
 sub sendPartyJoinRequest {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'party_join_request',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent Party Request Join: ".getHex($ID)."\n", "sendPacket", 2;
 }
 
 sub sendPartyJoin {
 	my ($self, $ID, $flag) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'party_join',
 		ID => $ID,
 		flag => $flag,
 	}));
-	
+
 	debug "Sent Party Join: ".getHex($ID).", $flag\n", "sendPacket", 2;
 }
 
 sub sendPartyLeave {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'party_leave'}));
-	
+
 	debug "Sent Party Leave\n", "sendPacket", 2;
 }
 
 sub sendPartyKick {
 	my ($self, $ID, $name) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'party_kick',
 		ID => $ID,
 		name => stringToBytes($name),
 	}));
-	
+
 	debug "Sent Party Kick: ".getHex($ID).", $name\n", "sendPacket", 2;
 }
 
 sub sendMemo {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'memo_request'}));
-	
+
 	debug "Sent Memo\n", "sendPacket", 2;
 }
 
 sub sendCompanionRelease {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'companion_release'}));
-	
+
 	debug "Sent Companion Release (Cart, Falcon or Pecopeco)\n", "sendPacket", 2;
 }
 
 sub sendCartAdd {
 	my ($self, $ID, $amount) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'cart_add',
 		ID => $ID,
 		amount => $amount,
 	}));
-	
+
 	debug "Sent Cart Add: " . getHex($ID) . " x $amount\n", "sendPacket", 2;
 }
 
 sub sendCartGet {
 	my ($self, $ID, $amount) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'cart_get',
 		ID => $ID,
 		amount => $amount,
 	}));
-	
+
 	debug "Sent Cart Get: " . getHex($ID) . " x $amount\n", "sendPacket", 2;
 }
 
 sub sendIdentify {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'identify',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent Identify: ".getHex($ID)."\n", "sendPacket", 2;
 }
 
 sub sendCardMergeRequest {
 	my ($self, $cardID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'card_merge_request',
 		cardID => $cardID,
 	}));
-	
+
 	debug "Sent Card Merge Request: " . getHex($cardID) . "\n", "sendPacket", 2;
 }
 
 sub sendCardMerge {
 	my ($self, $cardID, $itemID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'card_merge',
 		cardID => $cardID,
 		itemID => $itemID,
 	}));
-	
+
 	debug "Sent Card Merge: " . getHex($cardID) . ", " . getHex($itemID) . "\n", "sendPacket", 2;
 }
 
@@ -2266,59 +2265,59 @@ sub sendCharCreate {
 		hair_color => $hair_color,
 		hair_style => $hair_style
 	}));
-	
+
 	debug "Sent Char Create\n", "sendPacket", 2;
 }
 
 sub sendCharDelete {
 	my ($self, $charID, $email) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'char_delete',
 		charID => $charID,
 		email => stringToBytes($email),
 	}));
-	
+
 	debug "Sent Char Delete\n", "sendPacket", 2;
 }
 
 sub sendGuildAlly {
 	my ($self, $ID, $flag) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_alliance_reply',
 		ID => $ID,
 		flag => $flag,
 	}));
-	
+
 	debug "Sent Ally Guild : ".getHex($ID).", $flag\n", "sendPacket", 2;
 }
 
 sub sendGuildRequestEmblem {
 	my ($self, $guildID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_emblem_request',
 		guildID => $guildID,
 	}));
-	
+
 	debug "Sent Guild Request Emblem.\n", "sendPacket";
 }
 
 sub sendGuildBreak {
 	my ($self, $guildName) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_break',
 		guildName => stringToBytes($guildName),
 	}));
-	
+
 	debug "Sent Guild Break: $guildName\n", "sendPacket", 2;
 }
 
 sub sendWarpTele {
 	my ($self, $skillID, $map) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'warp_select',
 		# skillID:
@@ -2327,48 +2326,48 @@ sub sendWarpTele {
 		skillID => $skillID,
 		mapName => stringToBytes($map),
 	}));
-	
+
 	debug "Sent ". ($skillID == 26 ? "Teleport" : "Open Warp") . "\n", "sendPacket", 2
 }
 
 sub sendStorageGetToCart {
 	my ($self, $ID, $amount) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'storage_to_cart',
 		ID => $ID,
 		amount => $amount,
 	}));
-	
+
 	debug "Sent Storage Get From Cart: " . getHex($ID) . " x $amount\n", "sendPacket", 2;
 }
 
 sub sendStorageAddFromCart {
 	my ($self, $ID, $amount) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'cart_to_storage',
 		ID => $ID,
 		amount => $amount,
 	}));
-	
+
 	debug "Sent Storage Add From Cart: " . getHex($ID) . " x $amount\n", "sendPacket", 2;
 }
 
 sub sendHomunculusName {
 	my ($self, $name) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'homunculus_name',
 		name => stringToBytes($name),
 	}));
-	
+
 	debug "Sent Homunculus Rename: $name\n", "sendPacket", 2;
 }
 
 sub sendGuildLeave {
 	my ($self, $reason, $guildID, $charID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_leave',
 		guildID => $guildID,
@@ -2376,13 +2375,13 @@ sub sendGuildLeave {
 		charID => $charID,
 		reason => stringToBytes($reason),
 	}));
-	
+
 	debug "Sent Guild Leave: $reason\n", "sendPacket";
 }
 
 sub sendGuildMemberKick {
 	my ($self, $guildID, $accountID, $charID, $reason) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_kick',
 		guildID => $guildID,
@@ -2390,82 +2389,82 @@ sub sendGuildMemberKick {
 		accountID => $accountID,
 		reason => stringToBytes($reason),
 	}));
-	
+
 	debug "Sent Guild Kick: ".getHex($charID)."\n", "sendPacket";
 }
 
 sub sendGuildCreate {
 	my ($self, $name, $charID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_create',
 		charID => $charID,
 		guildName => stringToBytes($name),
 	}));
-	
+
 	debug "Sent Guild Create: $name\n", "sendPacket", 2;
 }
 
 sub sendGuildJoin {
 	my ($self, $ID, $flag) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_join',
 		ID => $ID,
 		flag => $flag,
 	}));
-	
+
 	debug "Sent Join Guild : ".getHex($ID).", $flag\n", "sendPacket";
 }
 
 sub sendGuildJoinRequest {
 	my ($self, $ID, $charID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_join_request',
 		ID => $ID,
 		accountID => $accountID,
 		charID => $charID,
 	}));
-	
+
 	debug "Sent Request Join Guild: ".getHex($ID)."\n", "sendPacket";
 }
 
 sub sendGuildNotice {
 	my ($self, $guildID, $name, $notice) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_notice',
 		guildID => $guildID,
 		name => stringToBytes($name),
 		notice => stringToBytes($notice),
 	}));
-	
+
 	debug "Sent Change Guild Notice: $notice\n", "sendPacket", 2;
 }
 
 sub sendGuildSetAlly {
 	my ($self, $targetAID, $myAID, $charID) = @_;
-	
+
 	# this packet is for guildmaster asking to set alliance with another guildmaster
 	# the other sub for sendGuildAlly are responses to this sub
 	# kept the parameters open, but everything except $targetAID could be replaced with Global variables
 	# unless you plan to mess around with the alliance packet, no exploits though, I tried ;-)
 	# -zdivpsa
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'guild_alliance_request',
 		targetAccountID => $targetAID,
 		accountID => $myAID,
 		charID => $charID,
 	}));
-	
+
 	debug "Sent Guild Alliance Request\n", "sendPacket", 2;
 }
 
 sub sendPetCapture {
 	my ($self, $monID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'pet_capture',
 		ID => $monID,
@@ -2475,10 +2474,10 @@ sub sendPetCapture {
 
 sub sendPetMenu {
 	my ($self, $type) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'pet_menu',
-		
+
 		# Action
 		# 0 => info
 		# 1 => feed
@@ -2487,82 +2486,82 @@ sub sendPetMenu {
 		# 4 => unequip accessory
 		action => $type,
 	}));
-	
+
 	debug "Sent Pet Menu\n", "sendPacket", 2;
 }
 
 sub sendPetHatch {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'pet_hatch',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent Incubator hatch: " . getHex($ID) . "\n", "sendPacket", 2;
 }
 
 sub sendPetName {
 	my ($self, $name) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'pet_name',
 		name => stringToBytes($name),
 	}));
-	
+
 	debug "Sent Pet Rename: $name\n", "sendPacket", 2;
 }
 
 sub sendPetEmotion {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'pet_emotion',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent Pet Emotion: $ID\n", "sendPacket", 2;
 }
 
 
 sub sendBuyBulk {
 	my ($self, $r_array) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'buy_bulk',
 		items => \@{$r_array},
 	}));
-	
+
 	debug("Sent bulk buy: $_->{itemID} x $_->{amount}\n", "sendPacket", 2) foreach (@{$r_array});
 }
 
 sub reconstruct_buy_bulk {
 	my ($self, $args) = @_;
 	my $pack = $self->{send_buy_bulk_pack} || "v2";
-	
+
 	$args->{buyInfo} = pack "(a*)*", map { pack $pack, $_->{amount}, $_->{itemID} } @{$args->{items}};
 }
 
 sub sendSellBulk {
 	my ($self, $r_array) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'sell_bulk',
 		items => \@{$r_array},
 	}));
-	
+
 	debug("Sent bulk buy: " . getHex($_->{ID}) . " x $_->{amount}\n", "sendPacket", 2) foreach (@{$r_array});
 }
 
 sub reconstruct_sell_bulk {
 	my ($self, $args) = @_;
-	
+
 	$args->{sellInfo} = pack "(a*)*", map { pack "a2 v", $_->{ID}, $_->{amount} } @{$args->{items}};
 }
 
 sub sendAchievementGetReward {
 	my ($self, $ach_id) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'achievement_get_reward',
 		ach_id => $ach_id,
@@ -2571,58 +2570,58 @@ sub sendAchievementGetReward {
 
 sub sendTop10Alchemist {
 	my ($self) = @_;
-	
+
 	if (!$masterServer->{rankingSystemType}) {
 		$self->sendToServer($self->reconstruct({switch => 'rank_alchemist'}));
 	} else {
 		$self->sendTop10(1);
 	}
-	
+
 	debug "Sent Top 10 Alchemist request\n", "sendPacket", 2;
 }
 
 sub sendTop10Blacksmith {
 	my ($self) = @_;
-	
+
 	if (!$masterServer->{rankingSystemType}) {
 		$self->sendToServer($self->reconstruct({switch => 'rank_blacksmith'}));
 	} else {
 		$self->sendTop10(0);
 	}
-	
+
 	debug "Sent Top 10 Blacksmith request\n", "sendPacket", 2;
-}	
+}
 
 sub sendTop10PK {
 	my ($self) = @_;
-	
+
 	if (!$masterServer->{rankingSystemType}) {
 		$self->sendToServer($self->reconstruct({switch => 'rank_killer'}));
 	} else {
 		$self->sendTop10(3);
 	}
-	
-	debug "Sent Top 10 PK request\n", "sendPacket", 2;	
+
+	debug "Sent Top 10 PK request\n", "sendPacket", 2;
 }
 
 sub sendTop10Taekwon {
 	my ($self) = @_;
-	
+
 	if (!$masterServer->{rankingSystemType}) {
 		$self->sendToServer($self->reconstruct({switch => 'rank_taekwon'}));
 	} else {
 		$self->sendTop10(2);
 	}
-	
+
 	debug "Sent Top 10 Taekwon request\n", "sendPacket", 2;
 }
 
 sub sendTop10 {
 	my ($self, $type) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'rank_general',
-		
+
 		# Type:
 		# 0 => Blacksmith
 		# 1 => Alchemist
@@ -2634,7 +2633,7 @@ sub sendTop10 {
 
 sub sendGMSummon {
 	my ($self, $playerName) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_summon_player',
 		playerName => stringToBytes($playerName),
@@ -2643,10 +2642,10 @@ sub sendGMSummon {
 
 sub sendGMBroadcast {
 	my ($self, $message) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_broadcast',
-		
+
 		# to colorize, add in front of message: micc | ssss | blue | tool ?
 		message => stringToBytes($message),
 	}));
@@ -2654,7 +2653,7 @@ sub sendGMBroadcast {
 
 sub sendGMKick {
 	my ($self, $accountID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_kick',
 		targetAccountID => $accountID,
@@ -2663,13 +2662,13 @@ sub sendGMKick {
 
 sub sendGMKickAll {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'gm_kick_all'}));
 }
 
 sub sendGMMonsterItem {
 	my ($self, $name) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_item_mob_create',
 		name => stringToBytes($name),
@@ -2678,7 +2677,7 @@ sub sendGMMonsterItem {
 
 sub sendGMMapMove {
 	my ($self, $name, $x, $y) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_move_to_map',
 		mapName => stringToBytes($name),
@@ -2689,39 +2688,39 @@ sub sendGMMapMove {
 
 sub sendGMResetStateSkill {
 	my ($self, $type) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_reset_state_skill',
-		
+
 		# type
 		# 0 => status
 		# 1 => skills
 		type => $type,
 	}));
-	
+
 	debug "Sent GM Reset State/Skill.\n", "sendPacket", 2;
 }
 
 sub sendGMChangeMapType {
 	my ($self, $x, $y, $type) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_change_cell_type',
 		x => $x,
 		y => $y,
-		
+
 		# type
 		# 0 => not walkable
 		# 1 => walkable
 		type => $type,
 	}));
-	
+
 	debug "Sent GM Change Map Type.\n", "sendPacket", 2;
 }
 
 sub sendGMBroadcastLocal {
 	my ($self, $message) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_broadcast_local',
 		message => stringToBytes($message),
@@ -2730,18 +2729,18 @@ sub sendGMBroadcastLocal {
 
 sub sendGMChangeEffectState {
 	my ($self, $effect_state) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_change_effect_state',
 		effect_state => $effect_state
 	}));
-	
+
 	debug "Sent GM Hide.\n", "sendPacket", 2;
 }
 
 sub sendGMRemove {
 	my ($self, $playerName) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_remove',
 		playerName => stringToBytes($playerName),
@@ -2750,7 +2749,7 @@ sub sendGMRemove {
 
 sub sendGMShift {
 	my ($self, $playerName) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_shift',
 		playerName => stringToBytes($playerName),
@@ -2759,7 +2758,7 @@ sub sendGMShift {
 
 sub sendGMRecall {
 	my ($self, $playerName) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_recall',
 		playerName => stringToBytes($playerName),
@@ -2768,20 +2767,20 @@ sub sendGMRecall {
 
 sub sendAlignment {
 	my ($self, $ID, $alignment, $point) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'alignment',
 		targetID => $ID,
 		type => $alignment,
 		point => $point,
 	}));
-	
+
 	debug "Sent Alignment: ".getHex($ID).", $alignment\n", "sendPacket", 2;
 }
 
 sub sendOpenShop {
 	my ($self, $title, $items) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'shop_open',
 		title => stringToBytes($title),
@@ -2792,68 +2791,68 @@ sub sendOpenShop {
 
 sub reconstruct_shop_open {
 	my ($self, $args) = @_;
-	
+
 	$args->{vendingInfo} = pack "(a*)*", map { pack "a2 v V", $_->{ID}, $_->{amount}, $_->{price} } @{$args->{items}};
 }
 
 sub sendMailboxOpen {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'mailbox_open'}));
-	
+
 	debug "Sent mailbox open.\n", "sendPacket", 2;
 }
 
 sub sendMailRead {
 	my ($self, $mailID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'mail_read',
 		mailID => $mailID,
 	}));
-	
+
 	debug "Sent read mail.\n", "sendPacket", 2;
 }
 
 sub sendMailDelete {
 	my ($self, $mailID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'mail_delete',
 		mailID => $mailID,
 	}));
-	
+
 	debug "Sent delete mail.\n", "sendPacket", 2;
 }
 
 sub sendMailGetAttach {
 	my ($self, $mailID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'mail_attachment_get',
 		mailID => $mailID,
 	}));
-	
+
 	debug "Sent mail get attachment.\n", "sendPacket", 2;
 }
 
 sub sendMailOperateWindow {
 	my ($self, $flag) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'mail_remove',
 		flag => $flag,
 	}));
-	
+
 	debug "Sent mail remove item/zeny.\n", "sendPacket", 2;
 }
 
 sub sendMailSetAttach {
 	my ($self, $amount, $ID) = @_;
-	
+
 	# 0 for zeny
 	$ID ||= 0;
-	
+
 	my $msg = pack("v a2 V", 0x0247, $ID, $amount);
 
 	# Before setting an attachment, we must remove any zeny/item that was attached but the mail wasn't sent
@@ -2863,20 +2862,20 @@ sub sendMailSetAttach {
 	} else {
 		$self->sendMailOperateWindow(2);
 	}
-	
+
 	$AI::temp::mailAttachAmount = $amount;
 	$self->sendToServer($self->reconstruct({
 		switch => 'mail_attachment_set',
 		ID => $ID,
 		amount => $amount,
 	}));
-	
+
 	debug "Sent mail set attachment.\n", "sendPacket", 2;
 }
 
 sub sendMailSend {
 	my ($self, $receiver, $title, $message) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'mail_send',
 		recipient => stringToBytes($receiver),
@@ -2884,99 +2883,99 @@ sub sendMailSend {
 		body_len => length $message > 255 ? 255 : length $message,
 		body => $message,
 	}));
-	
+
 	debug "Sent mail send.\n", "sendPacket", 2;
 }
 
 sub reconstruct_mail_send {
 	my ($self, $args) = @_;
-	
+
 	$args->{body} = pack "Z" . $args->{body_len}, stringToBytes($args->{body});
 }
 
 sub sendMailReturn {
 	my ($self, $mailID, $sender) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'mail_return',
 		mailID => $mailID,
 		sender => $sender,
 	}));
-	
+
 	debug "Sent return mail.\n", "sendPacket", 2;
 }
 
 sub sendAuctionAddItemCancel {
 	my ($self, $flag) = @_;
-	
+
 	$flag ||= 1;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auction_add_item_cancel',
 		flag => $flag,
 	}));
-	
+
 	debug "Sent Auction Add Item Cancel.\n", "sendPacket", 2;
 }
 
 sub sendAuctionAddItem {
 	my ($self, $ID, $amount) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auction_add_item',
 		ID => $ID,
 		amount => $amount,
 	}));
-	
+
 	debug "Sent Auction Add Item.\n", "sendPacket", 2;
 }
 
 sub sendAuctionCreate {
 	my ($self, $now_price, $max_price, $delete_time) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auction_create',
 		now_price => $now_price,
 		max_price => $max_price,
 		delete_time => $delete_time,
 	}));
-	
+
 	debug "Sent Auction Create.\n", "sendPacket", 2;
 }
 
 sub sendAuctionCancel {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auction_cancel',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent Auction Cancel.\n", "sendPacket", 2;
 }
 
 sub sendAuctionBuy {
 	my ($self, $ID, $price) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auction_buy',
 		ID => $ID,
 		price => $price,
 	}));
-	
+
 	debug "Sent Auction Buy.\n", "sendPacket", 2;
 }
 
 sub sendAuctionItemSearch {
 	my ($self, $type, $price, $search_string, $page) = @_;
 	$page ||= 1;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auction_search',
 		price => $price,
 		search_string => stringToBytes($search_string),
 		page => $page,
-		
+
 		# type
 		# 0 => armor
 		# 1 => weapon
@@ -2986,81 +2985,81 @@ sub sendAuctionItemSearch {
 		# 5 => auction id
 		type => $type,
 	}));
-	
+
 	debug "Sent Auction Item Search.\n", "sendPacket", 2;
 }
 
 sub sendAuctionReqMyInfo {
 	my ($self, $type) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auction_info_self',
 		type => $type,
 	}));
-	
+
 	debug "Sent Auction Request My Info.\n", "sendPacket", 2;
 }
 
 sub sendAuctionMySellStop {
 	my ($self, $ID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'auction_sell_stop',
 		ID => $ID,
 	}));
-	
+
 	debug "Sent My Sell Stop.\n", "sendPacket", 2;
 }
 
 sub sendPartyJoinRequestByNameReply {
 	my ($self, $accountID, $flag) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'party_join_request_by_name_reply',
 		accountID => $accountID,
 		flag => $flag,
 	}));
-	
+
 	debug "Sent reply Party Invite.\n", "sendPacket", 2;
 }
 
 sub sendAutoRevive {
 	my ($self) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({switch => 'auto_revive'}));
-	
+
 	debug "Sent Auto Revive.\n", "sendPacket", 2;
 }
 
 sub sendBattlegroundChat {
 	my ($self, $message) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'battleground_chat',
 		message => ($masterServer->{chatLangCode}) ? stringToBytes("|00" . $message) : stringToBytes($message),
 	}));
-	
+
 	debug "Sent Battleground chat.\n", "sendPacket", 2;
 }
 
 sub sendMercenaryCommand {
 	my ($self, $command) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'mercenary_command',
-		
+
 		# 0x0 => COMMAND_REQ_NONE
 		# 0x1 => COMMAND_REQ_PROPERTY
 		# 0x2 => COMMAND_REQ_DELETE
 		flag => $command
 	}));
-	
+
 	debug "Sent Mercenary Command $command", "sendPacket", 2;
 }
 
 sub sendSkillUseLocInfo {
 	my ($self, $ID, $lvl, $x, $y, $moreinfo) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'skill_use_location_text',
 		lvl => $lvl,
@@ -3069,13 +3068,13 @@ sub sendSkillUseLocInfo {
 		y => $y,
 		info => $moreinfo
 	}));
-	
+
 	debug "Skill Use on Location: $ID, ($x, $y)\n", "sendPacket", 2;
 }
 
 sub sendGMGiveMannerByName {
 	my ($self, $playerName) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'manner_by_name',
 		playerName => stringToBytes($playerName),
@@ -3084,7 +3083,7 @@ sub sendGMGiveMannerByName {
 
 sub sendGMRequestStatus {
 	my ($self, $playerName) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_request_status',
 		playerName => stringToBytes($playerName),
@@ -3093,29 +3092,29 @@ sub sendGMRequestStatus {
 
 sub sendFeelSaveOk {
 	my ($self, $flag) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'starplace_agree',
 		flag => $flag,
 	}));
-	
+
 	debug "Sent FeelSaveOk.\n", "sendPacket", 2;
 }
 
 sub sendGMReqAccName {
 	my ($self, $targetID) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'gm_request_account_name',
 		targetID => $targetID,
 	}));
-	
+
 	debug "Sent GM Request Account Name.\n", "sendPacket", 2;
 }
 
 sub sendClientVersion {
 	my ($self, $version) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'client_version',
 		clientVersion => $version,
@@ -3124,12 +3123,12 @@ sub sendClientVersion {
 
 sub sendCaptchaAnswer {
 	my ($self, $answer) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'captcha_answer',
 		accountID => $accountID,
 		answer => $answer,
-		
+
 		# Strangely, this packet has fixed length (dec 32, or hex 0x20) but has it padded into it - lututui
 		len => (exists $rpackets{'07E7'}{length}) ? $rpackets{'07E7'}{length} : 32,
 	}));
@@ -3208,8 +3207,8 @@ sub sendStylistChange {
 	my ($self, $hair_color, $hair_style, $cloth_color, $head_top, $head_mid, $head_bottom ) = @_;
 	$self->sendToServer($self->reconstruct({
 		switch => 'stylist_change',
-		hair_color => $hair_color, 
-		hair_style => $hair_style, 
+		hair_color => $hair_color,
+		hair_style => $hair_style,
 		cloth_color => $cloth_color,
 		head_top => $head_top,
 		head_mid => $head_mid,
@@ -3228,7 +3227,7 @@ sub sendOpenUIRequest {
 
 	$self->sendToServer($self->reconstruct({
 		switch => 'open_ui_request',
-		UIType => $UIType, 
+		UIType => $UIType,
 	}));
 
 	debug "Sent Open UI Request (".$UIType.")\n", "sendPacket";

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -1829,7 +1829,6 @@ sub sendRepairItem {
 		upgrade => $args->{upgrade},
 		cards => $args->{cards},
 	}));
-	undef $repairList;
 	debug ("Sent repair item index: ".$args->{index}."\n", "sendPacket", 2);
 }
 

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -35,7 +35,7 @@ use Utils::Rijndael;
 sub new {
 	my ($class) = @_;
 	my $self = $class->SUPER::new(@_);
-	
+
 	my %packets = (
 		'0064' => ['master_login', 'V Z24 Z24 C', [qw(version username password master_version)]],
 		'0065' => ['game_login', 'a4 a4 a4 v C', [qw(accountID sessionID sessionID2 userLevel accountSex)]],
@@ -159,7 +159,7 @@ sub new {
 		'01F7' => ['adopt_reply_request', 'V3', [qw(parentID1 parentID2 result)]],
 		'01F9' => ['adopt_request', 'V', [qw(ID)]],
 		'01FA' => ['master_login', 'V Z24 a16 C C', [qw(version username password_salted_md5 master_version clientInfo)]],
-		'01FD' => ['repair_item', 'a2 v V2 C', [qw(index nameID status status2 listID)]],
+		'01FD' => ['repair_item', 'v2 C a8', [qw(index nameID upgrade cards)]],
 		'0202' => ['friend_request', 'a*', [qw(username)]],# len 26
 		'0203' => ['friend_remove', 'a4 a4', [qw(accountID charID)]],
 		'0204' => ['client_hash', 'a16', [qw(hash)]],
@@ -252,7 +252,7 @@ sub new {
 		'0843' => ['remove_aid_sso', 'V', [qw(ID)]],
 		'0846' => ['req_cash_tabcode', 'v', [qw(ID)]],
 		'0844' => ['cash_shop_open'],#2
-		'0848' => ($rpackets{'0848'}{minLength} == 6) ? 
+		'0848' => ($rpackets{'0848'}{minLength} == 6) ?
 			['cash_shop_buy', 'v v a*', [qw(len count buy_info)]] :
 			['cash_shop_buy', 'v v V a*', [qw(len count kafra_points buy_info)]],
 		'084A' => ['cash_shop_close'],#2
@@ -319,12 +319,12 @@ sub new {
 		'0ACF' => ['master_login', 'a4 Z25 a32 a5', [qw(game_code username password_rijndael flag)]],
 		'0AE8' => ['change_dress'],
 		'0AEF' => ['attendance_reward_request'],
-		'0B10' => ['start_skill_use', 'v2 a4', [qw(skillID lv targetID)]],		
+		'0B10' => ['start_skill_use', 'v2 a4', [qw(skillID lv targetID)]],
 		'0B11' => ['stop_skill_use', 'v', [qw(skillID)]],
 		'0B21' => ['hotkey_change', 'v2 C V v', [qw(tab idx type id lvl)]],
 	);
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
-	
+
 	# # it would automatically use the first available if not set
 	# my %handlers = qw(
 	# 	master_login 0064
@@ -334,7 +334,7 @@ sub new {
 	# 	buy_bulk_vender 0134
 	# );
 	# $self->{packet_lut}{$_} = $handlers{$_} for keys %handlers;
-	
+
 	return $self;
 }
 
@@ -437,7 +437,7 @@ sub sendPartyOrganize {
 	# my $msg = pack("C*", 0xF9, 0x00) . pack("Z24", stringToBytes($name));
 	# I think this is obsolete - which serverTypes still support this packet anyway?
 	# FIXME: what are shared with $share1 and $share2? experience? item? vice-versa?
-	
+
 	my $msg = pack("C*", 0xE8, 0x01) . pack("Z24", stringToBytes($name)) . pack("C*", $share1, $share2);
 
 	$self->sendToServer($msg);
@@ -448,7 +448,7 @@ sub sendPartyOrganize {
 # note: item share changing seems disabled in newest clients
 sub sendPartyOption {
 	my ($self, $exp, $itemPickup, $itemDivision) = @_;
-	
+
 	$self->sendToServer($self->reconstruct({
 		switch => 'party_setting',
 		exp => $exp,
@@ -473,9 +473,9 @@ sub sendPreLoginCode {
 sub sendRequestMakingHomunculus {
 	# WARNING: If you don't really know, what are you doing - don't touch this
 	my ($self, $make_homun) = @_;
-	
+
 	my $skill = new Skill (idn => 241);
-	
+
 	if (
 		Actor::Item::get (997) && Actor::Item::get (998) && Actor::Item::get (999)
 		&& ($char->getSkillLevel ($skill) > 0)

--- a/src/Network/Send/kRO/Sakexe_0.pm
+++ b/src/Network/Send/kRO/Sakexe_0.pm
@@ -35,7 +35,7 @@ sub version {
 sub new {
 	my ($class) = @_;
 	my $self = $class->SUPER::new(@_);
-	
+
 	my %packets = (
 		'0064' => ['master_login', 'V Z24 Z24 C', [qw(version username password master_version)]],
 		'0065' => ['game_login', 'a4 a4 a4 v C', [qw(accountID sessionID sessionID2 userLevel accountSex)]],
@@ -155,7 +155,7 @@ sub new {
 		'01ED' => ['novice_explosion_spirits'],
 		'01F7' => ['adopt_reply_request', 'V3', [qw(parentID1 parentID2 result)]],
 		'01F9' => ['adopt_request', 'V', [qw(ID)]],
-		'01FD' => ['repair_item', 'a2 v V2 C', [qw(index nameID status status2 listID)]],
+		'01FD' => ['repair_item', 'v2 C a8', [qw(index nameID upgrade cards)]],
 		'0202' => ['friend_request', 'a*', [qw(username)]],# len 26
 		'0203' => ['friend_remove', 'a4 a4', [qw(accountID charID)]],
 		'0204' => ['client_hash', 'a16', [qw(hash)]],
@@ -215,8 +215,8 @@ sub new {
 		'0842' => ['recall_sso', 'V', [qw(ID)]],
 		'0843' => ['remove_aid_sso', 'V', [qw(ID)]],
 		'0844' => ['cash_shop_open'],#2
-		'0846' => ['req_cash_tabcode', 'v', [qw(ID)]],	
-		'0848' => (exists $rpackets{'0848'}{minLength} && $rpackets{'0848'}{minLength} == 6) ? 
+		'0846' => ['req_cash_tabcode', 'v', [qw(ID)]],
+		'0848' => (exists $rpackets{'0848'}{minLength} && $rpackets{'0848'}{minLength} == 6) ?
 			['cash_shop_buy', 'v v a*', [qw(len count buy_info)]] :
 			['cash_shop_buy', 'v v V a*', [qw(len count kafra_points buy_info)]],
 		'084A' => ['cash_shop_close'],#2
@@ -270,14 +270,14 @@ sub new {
 		'0AC1' => ['rodex_refresh_maillist', 'C V6', [qw(type mailID1 mailID2 mailReturnID1 mailReturnID2 mailAccountID1 mailAccountID2)]], # 26 -- RodexRefreshMaillist
 		'0ACE' => ['equip_switch_single', 'a2', [qw(ID)]],
 		'0AEF' => ['attendance_reward_request'],
-		'0B10' => ['start_skill_use', 'v2 a4', [qw(skillID lv targetID)]],		
+		'0B10' => ['start_skill_use', 'v2 a4', [qw(skillID lv targetID)]],
 		'0B11' => ['stop_skill_use', 'v', [qw(skillID)]],
 		'0B14' => ['inventory_expansion_request'], #2
 		'0B19' => ['inventory_expansion_rejected'], #2
 		'0B21' => ['hotkey_change', 'v2 C V v', [qw(tab idx type id lvl)]],
 	);
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
-	
+
 	$self;
 }
 


### PR DESCRIPTION
Console command `repair` - does not work:
1) after using skill "Weapon Repair" - item numbers are not displayed correctly:
```
ss 108
You are casting Repair Weapon on yourself (Delay: 0ms)
--------Repair List--------
☺  Dagger
---------------------------
```
2) when using the `repair 1` command, nothing happens:
```
repair 1
Item with index: 1 does either not exist in the 'Repair List' or the list is empty.
```
3) `repairAuto` config parameter works, but the message displays an incorrect item name
```
You use Repair Weapon on yourself (Lv: 1)
Inventory Item Removed: Iron (3) x 1
Successfully repaired Unknown #3.
```

This PR corrects the indicated errors.

I also added two new commands:
`repair` - show list of items available for repair
`repair cancel` - cancel repair item

