### PR TITLE
Avoid fix

### DIFF
--- a/src/ChatQueue.pm
+++ b/src/ChatQueue.pm
@@ -16,7 +16,7 @@
 package ChatQueue;
 
 #TODO: Review and test the whole document before adding them back
-#use strict; 
+#use strict;
 #use warnings;
 
 use Time::HiRes qw(time);
@@ -89,7 +89,7 @@ sub processFirst {
 	my $userID = $cmd->{userID};
 
 	return if ( $user ne ""
-		&& (avoidGM_talk($user, $msg) || avoidList_talk($user, $msg, unpack("V1", $userID))) );
+		&& (avoidGM_talk($user, $msg, unpack("V1", $userID)) || avoidList_talk($user, $msg, unpack("V1", $userID))) );
 
 
 	# If the user is not authorized to use chat commands,
@@ -210,7 +210,7 @@ sub processChatCommand {
 				$vars->{gotItems} = sprintf("%-40s %5d", $item, $itemChange{$item});
 				sendMessage($messageSender, $type, getResponse("expItemS2"), $user) if $config{verbose};
 			}
-			
+
 		} else {
 			sendMessage($messageSender, $type, getResponse("expF"), $user) if $config{verbose};
 		}
@@ -398,7 +398,7 @@ sub processChatCommand {
 	} elsif ($switch eq "town") {
 		sendMessage($messageSender, $type, getResponse("moveS"), $user);
 		main::useTeleport(2);
-	
+
 	} elsif ($switch eq "version") {
 		$vars->{ver} = $Settings::VERSION;
 		sendMessage($messageSender, $type, getResponse("versionS"), $user) if $config{verbose};

--- a/src/ChatQueue.pm
+++ b/src/ChatQueue.pm
@@ -89,7 +89,7 @@ sub processFirst {
 	my $userID = $cmd->{userID};
 
 	return if ( $user ne ""
-		&& (avoidGM_talk($user, $msg, unpack("V1", $userID)) || avoidList_talk($user, $msg, unpack("V1", $userID))) );
+		&& (avoidGM_talk($user, unpack("V1", $userID)) || avoidList_talk($user, unpack("V1", $userID))) );
 
 
 	# If the user is not authorized to use chat commands,

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -1445,8 +1445,8 @@ sub avoidList_talk {
 	my $avoidID = $avoid{ID}{$ID};
 
 	if ($avoidPlayer->{disconnect_on_chat} || $avoidID->{disconnect_on_chat}) {
-		warning TF("Disconnecting to avoid %s!\n", $user);
-		main::chatLog("k", TF("*** %s talked to you, auto disconnected ***\n", $user));
+		warning TF("Disconnecting to avoid %s (%s)!\n", $user, $field->baseName);
+		main::chatLog("k", TF("*** %s talked to you, auto disconnected (%s) ***\n", $user, $field->baseName));
 		warning TF("Disconnect for %s seconds...\n", $config{avoidList_reconnect});
 		relog($config{avoidList_reconnect}, 1);
 		return 1;
@@ -4173,27 +4173,27 @@ sub avoidGM_near {
 		if ($config{avoidGM_near} == 1) {
 			# Mode 1: teleport & disconnect
 			useTeleport(1);
-			$msg = TF("GM %s (%d) is nearby, teleport & disconnect for %d seconds", $player->{name}, $player->{nameID}, $config{avoidGM_reconnect});
+			$msg = TF("GM %s (%d) is nearby (%s), teleport & disconnect for %d seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
 			relog($config{avoidGM_reconnect}, 1);
 
 		} elsif ($config{avoidGM_near} == 2) {
 			# Mode 2: disconnect
-			$msg = TF("GM %s (%d) is nearby, disconnect for %s seconds", $player->{name}, $player->{nameID}, $config{avoidGM_reconnect});
+			$msg = TF("GM %s (%d) is nearby (%s), disconnect for %s seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
 			relog($config{avoidGM_reconnect}, 1);
 
 		} elsif ($config{avoidGM_near} == 3) {
 			# Mode 3: teleport
 			useTeleport(1);
-			$msg = TF("GM %s (%d) is nearby, teleporting", $player->{name}, $player->{nameID});
+			$msg = TF("GM %s (%d) is nearby(%s), teleporting", $player->{name}, $player->{nameID}, $field->baseName);
 
 		} elsif ($config{avoidGM_near} == 4) {
 			# Mode 4: respawn
 			useTeleport(2);
-			$msg = TF("GM %s (%d) is nearby, respawning", $player->{name}, $player->{nameID});
+			$msg = TF("GM %s (%d) is nearby (%s), respawning", $player->{name}, $player->{nameID}, $field->baseName);
 		} elsif ($config{avoidGM_near} >= 5) {
 			# Mode 5: respawn & disconnect
 			useTeleport(2);
-			$msg = TF("GM %s (%d) is nearby, respawning & disconnect for %d seconds", $player->{name}, $player->{nameID}, $config{avoidGM_reconnect});
+			$msg = TF("GM %s (%d) is nearby (%s), respawning & disconnect for %d seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
 			relog($config{avoidGM_reconnect}, 1);
 		}
 
@@ -4242,7 +4242,7 @@ sub avoidList_near {
 			|| ($avoidJob && $avoidJob->{teleport_on_sight} &&  $avoidJob->{disconnect_on_sight}) ) {
 			# like avoidGM_near Mode 1: teleport & disconnect
 			useTeleport(1);
-			$msg = TF("Player %s (%d, %s) is nearby, teleport & disconnect for %d seconds", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}}, $config{avoidList_reconnect});
+			$msg = TF("Player %s (%d, %s) is nearby (%s), teleport & disconnect for %d seconds", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}}, $field->baseName, $config{avoidList_reconnect});
 			relog($config{avoidList_reconnect}, 1);
 			$return = 1;
 
@@ -4251,27 +4251,27 @@ sub avoidList_near {
 			|| ($avoidJob && $avoidJob->{teleport_on_sight} &&  $avoidJob->{disconnect_on_sight}) ) {
 			# like avoidGM_near Mode 5: respawn & disconnect
 			useTeleport(2);
-			$msg = TF("Player %s (%d, %s) is nearby, respawning & disconnect for %d seconds", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}}, $config{avoidList_reconnect});
+			$msg = TF("Player %s (%d, %s) is nearby (%s), respawning & disconnect for %d seconds", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}}, $field->baseName, $config{avoidList_reconnect});
 			relog($config{avoidList_reconnect}, 1);
 			$return = 1;
 
 		} elsif ( !$net->clientAlive() && ( ($avoidPlayer && $avoidPlayer->{disconnect_on_sight}) ||
 			($avoidID && $avoidID->{disconnect_on_sight}) && ($avoidJob && $avoidJob->{disconnect_on_sight}) ) ) {
 			# like avoidGM_near Mode 2: disconnect
-			$msg = TF("Player %s (%d, %s) is nearby, disconnect for %s seconds", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}}, $config{avoidList_reconnect});
+			$msg = TF("Player %s (%d, %s) is nearby (%s), disconnect for %s seconds", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}}, $field->baseName, $config{avoidList_reconnect});
 			relog($config{avoidList_reconnect}, 1);
 			$return = 1;
 
 		} elsif ( ($avoidPlayer && $avoidPlayer->{teleport_on_sight} == 1) || ($avoidID && $avoidID->{teleport_on_sight} == 1) || ($avoidJob && $avoidJob->{teleport_on_sight} == 1) ) {
 			# like avoidGM_near Mode 3: teleport
 			useTeleport(1);
-			$msg = TF("Player %s (%d, %s) is nearby, teleporting", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}});
+			$msg = TF("Player %s (%d, %s) is nearby (%s), teleporting", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}}, $field->baseName);
 			$return = 1;
 
 		} elsif ( ($avoidPlayer && $avoidPlayer->{teleport_on_sight} == 2) || ($avoidID && $avoidID->{teleport_on_sight} == 2) || ($avoidJob && $avoidJob->{teleport_on_sight} == 2) ) {
 			# like avoidGM_near Mode 4: respawn
 			useTeleport(2);
-			$msg = TF("Player %s (%d, %s) is nearby, respawning", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}});
+			$msg = TF("Player %s (%d, %s) is nearby (%s), respawning", $player->{name}, $player->{nameID}, $jobs_lut{$player->{jobID}}, $field->baseName);
 			$return = 1;
 		}
 
@@ -4289,8 +4289,8 @@ sub avoidList_ID {
 
 	my $avoidID = unpack("V", shift);
 	if ($avoid{ID}{$avoidID} && $avoid{ID}{$avoidID}{disconnect_on_sight}) {
-		warning TF("%s is nearby, disconnecting...\n", $avoidID);
-		chatLog("k", TF("*** Found %s nearby and disconnected ***\n", $avoidID));
+		warning TF("%s is nearby (%s), disconnecting...\n", $avoidID, $field->baseName);
+		chatLog("k", TF("*** Found %s nearby (%s) and disconnected ***\n", $avoidID, $field->baseName));
 		warning TF("Disconnect for %s seconds...\n", $config{avoidList_reconnect});
 		relog($config{avoidList_reconnect}, 1);
 		return 1;

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -4271,9 +4271,9 @@ sub avoidList_ID {
 
 	my $avoidID = unpack("V", shift);
 	if ($avoid{ID}{$avoidID} && $avoid{ID}{$avoidID}{disconnect_on_sight}) {
-		warning TF("%s is nearby (%s), disconnecting...\n", $avoidID, $field->baseName);
-		chatLog("k", TF("*** Found %s nearby (%s) and disconnected ***\n", $avoidID, $field->baseName));
-		warning TF("Disconnect for %s seconds...\n", $config{avoidList_reconnect});
+		my $msg = TF("Player with ID %s is nearby (%s), disconnect for %s seconds", $avoidID, $field->baseName, $config{avoidList_reconnect});
+		warning "$msg\n";
+		chatLog("k", "*** $msg ***\n");
 		relog($config{avoidList_reconnect}, 1);
 		return 1;
 	}

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -4166,7 +4166,7 @@ sub avoidGM_near {
 
 sub avoidGM_talk {
 	return 0 if ($net->clientAlive() || !$config{avoidGM_talk});
-	my ($player_name, $msg, $nameID) = @_;
+	my ($player_name, $nameID) = @_;
 
 	# Check whether this "GM" is on the ignore list in order to prevent false matches
 	return 0 if (existsInList($config{avoidGM_ignoreList}, $player_name));
@@ -4180,7 +4180,7 @@ sub avoidGM_talk {
 	Plugins::callHook('avoidGM_talk', \%args);
 	return 1 if ($args{return});
 
-	$msg = TF("GM '%s' (%d) talked to you (%s), disconnect for %s seconds", $player_name, $nameID, $field->baseName, $config{avoidGM_reconnect});
+	my $msg = TF("GM '%s' (%d) talked to you (%s), disconnect for %s seconds", $player_name, $nameID, $field->baseName, $config{avoidGM_reconnect});
 	warning "$msg\n";
 	chatLog("k", "*** $msg ***\n");
 	relog($config{avoidGM_reconnect}, 1);
@@ -4282,12 +4282,12 @@ sub avoidList_ID {
 
 sub avoidList_talk {
 	return 0 if ($net->clientAlive() || !$config{avoidList});
-	my ($player_name, $msg, $nameID) = @_;
+	my ($player_name, $nameID) = @_;
 	my $avoidPlayer = $avoid{Players}{lc($player_name)};
 	my $avoidID = $avoid{ID}{$nameID};
 
 	if ($avoidPlayer->{disconnect_on_chat} || $avoidID->{disconnect_on_chat}) {
-		$msg = TF("Player %s (%d) talked to you (%s), disconnect for %d seconds", $player_name, $nameID, $field->baseName, $config{avoidList_reconnect});
+		my $msg = TF("Player %s (%d) talked to you (%s), disconnect for %d seconds", $player_name, $nameID, $field->baseName, $config{avoidList_reconnect});
 		warning "$msg\n";
 		chatLog("k", "*** $msg ***\n");
 		relog($config{avoidList_reconnect}, 1);

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -1440,14 +1440,14 @@ sub avoidGM_talk {
 
 sub avoidList_talk {
 	return 0 if ($net->clientAlive() || !$config{avoidList});
-	my ($user, $msg, $ID) = @_;
-	my $avoidPlayer = $avoid{Players}{lc($user)};
-	my $avoidID = $avoid{ID}{$ID};
+	my ($player_name, $msg, $nameID) = @_;
+	my $avoidPlayer = $avoid{Players}{lc($player_name)};
+	my $avoidID = $avoid{ID}{$nameID};
 
 	if ($avoidPlayer->{disconnect_on_chat} || $avoidID->{disconnect_on_chat}) {
-		warning TF("Disconnecting to avoid %s (%s)!\n", $user, $field->baseName);
-		main::chatLog("k", TF("*** %s talked to you, auto disconnected (%s) ***\n", $user, $field->baseName));
-		warning TF("Disconnect for %s seconds...\n", $config{avoidList_reconnect});
+		$msg = TF("Player %s (%d) talked to you (%s), disconnect for %d seconds", $player_name, $nameID, $field->baseName, $config{avoidList_reconnect});
+		warning "$msg\n";
+		chatLog("k", "*** $msg ***\n");
 		relog($config{avoidList_reconnect}, 1);
 		return 1;
 	}

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -1415,27 +1415,25 @@ sub actorListClearing {
 
 sub avoidGM_talk {
 	return 0 if ($net->clientAlive() || !$config{avoidGM_talk});
-	my ($user, $msg) = @_;
+	my ($player_name, $msg, $nameID) = @_;
 
-	# Check whether this "GM" is on the ignore list
-	# in order to prevent false matches
-	return 0 if (existsInList($config{avoidGM_ignoreList}, $user));
+	# Check whether this "GM" is on the ignore list in order to prevent false matches
+	return 0 if (existsInList($config{avoidGM_ignoreList}, $player_name));
 
-	if ($user =~ /^([a-z]?ro)?-?(Sub)?-?\[?GM\]?/i || ($config{avoidGM_namePattern} && ($user =~ /$config{avoidGM_namePattern}/))) {
-		my %args = (
-			name => $user,
-		);
-		Plugins::callHook('avoidGM_talk', \%args);
-		return 1 if ($args{return});
+	return 0 unless ($config{avoidGM_namePattern} ? $player_name =~ /$config{avoidGM_namePattern}/ : $player_name =~ /^([a-z]?ro)?-?(Sub)?-?\[?GM\]?/i);
 
-		warning T("Disconnecting to avoid GM!\n");
-		main::chatLog("k", TF("*** The GM %s talked to you, auto disconnected ***\n", $user));
+	my %args = (
+		name => $player_name,
+		ID => $nameID
+	);
+	Plugins::callHook('avoidGM_talk', \%args);
+	return 1 if ($args{return});
 
-		warning TF("Disconnect for %s seconds...\n", $config{avoidGM_reconnect});
-		relog($config{avoidGM_reconnect}, 1);
-		return 1;
-	}
-	return 0;
+	$msg = TF("GM '%s' (%d) talked to you (%s), disconnect for %s seconds", $player_name, $nameID, $field->baseName, $config{avoidGM_reconnect});
+	warning "$msg\n";
+	chatLog("k", "*** $msg ***\n");
+	relog($config{avoidGM_reconnect}, 1);
+	return 1;
 }
 
 sub avoidList_talk {
@@ -4173,27 +4171,27 @@ sub avoidGM_near {
 		if ($config{avoidGM_near} == 1) {
 			# Mode 1: teleport & disconnect
 			useTeleport(1);
-			$msg = TF("GM %s (%d) is nearby (%s), teleport & disconnect for %d seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
+			$msg = TF("GM '%s' (%d) is nearby (%s), teleport & disconnect for %d seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
 			relog($config{avoidGM_reconnect}, 1);
 
 		} elsif ($config{avoidGM_near} == 2) {
 			# Mode 2: disconnect
-			$msg = TF("GM %s (%d) is nearby (%s), disconnect for %s seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
+			$msg = TF("GM '%s' (%d) is nearby (%s), disconnect for %s seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
 			relog($config{avoidGM_reconnect}, 1);
 
 		} elsif ($config{avoidGM_near} == 3) {
 			# Mode 3: teleport
 			useTeleport(1);
-			$msg = TF("GM %s (%d) is nearby(%s), teleporting", $player->{name}, $player->{nameID}, $field->baseName);
+			$msg = TF("GM '%s' (%d) is nearby(%s), teleporting", $player->{name}, $player->{nameID}, $field->baseName);
 
 		} elsif ($config{avoidGM_near} == 4) {
 			# Mode 4: respawn
 			useTeleport(2);
-			$msg = TF("GM %s (%d) is nearby (%s), respawning", $player->{name}, $player->{nameID}, $field->baseName);
+			$msg = TF("GM '%s' (%d) is nearby (%s), respawning", $player->{name}, $player->{nameID}, $field->baseName);
 		} elsif ($config{avoidGM_near} >= 5) {
 			# Mode 5: respawn & disconnect
 			useTeleport(2);
-			$msg = TF("GM %s (%d) is nearby (%s), respawning & disconnect for %d seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
+			$msg = TF("GM '%s' (%d) is nearby (%s), respawning & disconnect for %d seconds", $player->{name}, $player->{nameID}, $field->baseName, $config{avoidGM_reconnect});
 			relog($config{avoidGM_reconnect}, 1);
 		}
 


### PR DESCRIPTION
1. added a map name to the message (helps with log analysis)
2. changed the functions "avoid**_talk" similarly to "avoid**_near"
3. moved the "avoid**_talk" functions closer to "avoid**_near". For ease of analysis.
4. removed the excess parameter "$msg" that was passed to the "avoid**_talk" function