### PR TITLE
[fix] Add config key to avoid hidden actors

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -140,6 +140,8 @@ avoidList_inLockOnly 0
 avoidList_reconnect 1800
 avoidList_ignoreList
 
+avoidHiddenActors 0
+
 cachePlayerNames 1
 cachePlayerNames_duration 900
 cachePlayerNames_maxSize 100

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3944,7 +3944,7 @@ sub isSafeActorQuery {
 		if ($actor) {
 			# Do not AutoVivify here!
 			if (defined $actor->{statuses} && %{$actor->{statuses}}) {
-				if ( $actor->statusActive('EFFECTSTATE_SPECIALHIDING') || $actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337 ) { # HIDDEN_ACTOR TYPES
+				if ( $actor->statusActive('EFFECTSTATE_SPECIALHIDING') || ($config{avoidHiddenActors} && ($actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337)) ) { # HIDDEN_ACTOR TYPES
 					return 0;
 				}
 			}

--- a/src/Task/TalkNPC.pm
+++ b/src/Task/TalkNPC.pm
@@ -827,7 +827,7 @@ sub findTarget {
 	if ($self->{nameID}) {
 		my ($actor) = grep { $self->{nameID} eq $_->{nameID} } @{$actorList->getItems};
 		if ( $actor && 
-		( $actor->{statuses}->{EFFECTSTATE_BURROW} || ( $actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337 ) ) && # HIDDEN_ACTOR TYPES
+		( $actor->{statuses}->{EFFECTSTATE_BURROW} || ($config{avoidHiddenActors} && ($actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337)) ) && # HIDDEN_ACTOR TYPES
 		$self->{type} ne 'autotalk' )
 		{
 			$self->setError(NPC_NOT_FOUND, T("Talk with a hidden NPC prevented."));
@@ -838,7 +838,7 @@ sub findTarget {
 	foreach my $actor (@{$actorList->getItems()}) {
 		my $pos = ($actor->isa('Actor::NPC')) ? $actor->{pos} : $actor->{pos_to};
 		next if ($actor->{statuses}->{EFFECTSTATE_BURROW});
-		next if ( $actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337 ); # HIDDEN_ACTOR TYPES
+		next if ($config{avoidHiddenActors} && ($actor->{type} == 111 || $actor->{type} == 139 || $actor->{type} == 2337)); # HIDDEN_ACTOR TYPES
 		if ($pos->{x} == $self->{x} && $pos->{y} == $self->{y}) {
 			if (defined $actor->{name}) {
 				return $actor;


### PR DESCRIPTION
this fixes #3137

log:
```
[Jun 17 20:24:37 2020.54] AI set to manual mode
[Jun 17 20:24:47 2020.49] NPC Exists: Milestone#1-3 (264, 191) (ID 110010770) - (0)
[Jun 17 20:24:54 2020.40] Milestone#1-3: - There is writing on a big rock. -
[Jun 17 20:24:54 2020.61] NPC Milestone#1-3 (0): Type 'talk cont' to continue talking
[Jun 17 20:24:55 2020.58] Milestone#1-3: - Those who advance may get hurt but are brave of heart and those who move back will remain safe.
[Jun 17 20:24:55 2020.60] Milestone#1-3: If you are brave, then take a step forward. Otherwise, step back. -
[Jun 17 20:24:55 2020.62] NPC Milestone#1-3 (0): Type 'talk cont' to continue talking
[Jun 17 20:24:57 2020.15] ------ Responses (Milestone#1-3) -------
#  Response
0  Step forward.
1  Stay.
2  Cancel Chat
----------------------------------------
[Jun 17 20:24:57 2020.17] NPC Milestone#1-3 (0): Type 'talk resp #' to choose a response.
[Jun 17 20:25:14 2020.95] Done talking with NPC Milestone#1-3 (0).
[Jun 17 20:25:26 2020.45] Config 'avoidHiddenActors' set to 1 (was 0)
[Jun 17 20:25:29 2020.23] Talk with a hidden NPC prevented.
```