### PR TITLE
fixed removal trades

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2335,6 +2335,11 @@ sub actor_died_or_disappeared {
 				delete $venderLists{$ID};
 			}
 
+			if (grep { $ID eq $_ } @buyerListsID) {
+				binRemove(\@buyerListsID, $ID);
+				delete $buyerLists{$ID};
+			}
+
 			$player->{gone_time} = time;
 			$players_old{$ID} = $player->deepCopy();
 			Plugins::callHook('player_disappeared', {player => $player});


### PR DESCRIPTION
On rRO and euRO servers, when a buyer disappears, a special package "buying_store_lost" does not come. We only recived the package "actor_died_or_disappeared". I added a check of buyers in this package.

before:
```css
bl
------------------------------- Buyer List --------------------------------
#    Title                                 Coords      Owner
0    buy your fabric                       (110,  56)  gameWizzardd        
1    WTB                                   (110,  53)  CherryTea           
---------------------------------------------------------------------------
move 90 56
bl
------------------------------- Buyer List --------------------------------
#    Title                                 Coords      Owner
0    buy your fabric                       (  ?,   ?)  Unknown #173402     
1    WTB                                   (  ?,   ?)  Unknown #168285     
---------------------------------------------------------------------------
```
after:
```css
bl
------------------------------- Buyer List --------------------------------
#    Title                                 Coords      Owner
0    buy your fabric                       (110,  56)  gameWizzardd        
1    WTB                                   (110,  53)  CherryTea           
---------------------------------------------------------------------------
move 90 56
bl
------------------------------- Buyer List --------------------------------
#    Title                                 Coords      Owner
---------------------------------------------------------------------------
```