### PR TITLE
fix sitAuto_forcedBySitCommand

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2469,7 +2469,7 @@ sub actor_action {
 			if ($config{sitAuto_idle}) {
 				$timeout{ai_sit_idle}{time} = time;
 			}
-			undef $ai_v{sitAuto_forcedBySitCommand} if $ai_v{sitAuto_forcedBySitCommand};
+			delete $ai_v{sitAuto_forcedBySitCommand} if $ai_v{sitAuto_forcedBySitCommand};
 			$char->{sitting} = 0;
 		} else {
 			message TF("%s is standing.\n", getActorName($args->{sourceID})), 'parseMsg_statuslook', 2;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2469,6 +2469,7 @@ sub actor_action {
 			if ($config{sitAuto_idle}) {
 				$timeout{ai_sit_idle}{time} = time;
 			}
+			undef $ai_v{sitAuto_forcedBySitCommand} if $ai_v{sitAuto_forcedBySitCommand};
 			$char->{sitting} = 0;
 		} else {
 			message TF("%s is standing.\n", getActorName($args->{sourceID})), 'parseMsg_statuslook', 2;


### PR DESCRIPTION
if user use sit command will trigger sitAuto_forcedBySitCommand, but if for some reason bot stand up (ai clear, monster attack, etc) this key will remain in the ai_v, this affect storage, sell, buy and route logic.

with this pull if bot stand up for some reason openkore delete this key.

this pull fixes #3188 