### PR TITLE
add ai_v to ai::clear

### DIFF
--- a/src/AI.pm
+++ b/src/AI.pm
@@ -147,6 +147,7 @@ sub clear {
 	} else {
 		undef @ai_seq;
 		undef @ai_seq_args;
+		undef %ai_v;
 	}
 }
 


### PR DESCRIPTION
today when user insert the command `ai clear` a lot of variables are left in ai_v, openkore don't know what to do with these variabless, so clear these variables together with ai_queue is the better to avoid undesirable behavior

