### PR TITLE
fix teleport window stuck

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -649,7 +649,7 @@ sub processDelayedTeleport {
 			# We have already successfully used the Teleport skill,
 			# and the ai_teleport_delay timeout has elapsed
 			$messageSender->sendWarpTele(26, AI::args->{lv} == 2 ? "$config{saveMap}.gat" : "Random");
-			AI::dequeue;
+			$ai_v{temp}{clear_aiQueue} = 1;
 		} elsif (!$timeout{ai_teleport_delay}{time} && timeOut($timeout{ai_teleport_retry})) {
 			# We are still trying to use the Teleport skill
 			$messageSender->sendSkillUse(26, $char->{skills}{AL_TELEPORT}{lv}, $accountID);


### PR DESCRIPTION
If user use openkore with a low teleport send time, sometimes openkore will send the command and the server will ignore, causing a stuck at teleport window in openkore.
this pull fix this.

