### PR TITLE
[fix] skill lvl in config

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -489,7 +489,7 @@ pet_return 20
 # configure two attack skills, just duplicate the attackSkillSlot block.
 
 attackSkillSlot {
-	lvl 10
+	lvl
 	dist 1.5
 	maxCastTime 0
 	minCastTime 0
@@ -577,7 +577,7 @@ doCommand {
 }
 
 useSelf_skill {
-	lvl 10
+	lvl
 	maxCastTime 0
 	minCastTime 0
 	hp
@@ -610,7 +610,7 @@ useSelf_skill_smartHeal 1
 partySkillDistance 0..8
 
 partySkill {
-	lvl 10
+	lvl
 	dist 3
 	maxCastTime 0
 	minCastTime 0


### PR DESCRIPTION
remove the skill level from the config so that the bot can use the maximum level available (see #3199)