### PR TITLE
fix "quest list" command

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -6784,7 +6784,7 @@ sub cmdQuest {
 		my $msg .= center(" " . T("Quest List") . " ", 79, '-') . "\n";
 		foreach my $questID (keys %{$questList}) {
 			my $quest = $questList->{$questID};
-			$msg .= swrite(sprintf("\@%s \@%s \@%s \@%s \@%s", ('>'x2), ('<'x4), ('<'x30), ('<'x10), ('<'x24)),
+			$msg .= swrite(sprintf("\@%s \@%s \@%s \@%s \@%s", ('>'x2), ('<'x5), ('<'x30), ('<'x10), ('<'x24)),
 				[$k, $questID, $quests_lut{$questID} ? $quests_lut{$questID}{title} : '', $quest->{active} ? T("active") : T("inactive"), $quest->{time_expire} ? scalar localtime $quest->{time_expire} : '']);
 			foreach my $mobID (keys %{$quest->{missions}}) {
 				my $mission = $quest->{missions}->{$mobID};


### PR DESCRIPTION
the questID field is now 6 digits

see: https://github.com/OpenKore/openkore/commit/f5441d2a695ae8331f425124d65474e9cde8633b#commitcomment-42449551:

> Can you fix the quest list command that only show quest ID only 5 digit, because the official server i play the quest id have 6 digit

before:
```
quest list
--------------------------------- Quest List ----------------------------------
  0 7124  Battle Basics                   active
  - Lunatic                         5
  1 7126  Selling items                   active
  2 7123  Battle Basics                   active
  - Picky                           0
  3 7127  Battle Basics                   active
  - Willow                          0
-------------------------------------------------------------------------------
```
after:
```
quest list
--------------------------------- Quest List ----------------------------------
  0 7126   Selling items                   active
  1 7123   Battle Basics                   active
  - Picky                           1
  2 7127   Battle Basics                   active
  - Willow                          2
-------------------------------------------------------------------------------
```