### PR TITLE
Del &listitem keyword

### DIFF
--- a/plugins/eventMacro/eventMacro/Data.pm
+++ b/plugins/eventMacro/eventMacro/Data.pm
@@ -54,7 +54,7 @@ our %parameters = (
 );
 
 our $macroKeywords = join '|', qw(
-	arg
+	arg listlength
 	cartamount cart Cart
 	config
 	defined
@@ -63,7 +63,6 @@ our $macroKeywords = join '|', qw(
 	delete
 	invamount inventory Inventory InventoryType
 	keys
-	listitem listlength
 	monster
 	nick
 	npc

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -18,7 +18,7 @@ use eventMacro::Core;
 use eventMacro::FileParser qw(isNewCommandBlock);
 use eventMacro::Utilities qw(cmpr getnpcID getItemIDs getItemPrice getStorageIDs getInventoryIDs getInventoryTypeIDs
 	getPlayerID getMonsterID getVenderID getRandom getRandomRange getInventoryAmount getCartAmount getShopAmount
-	getStorageAmount getVendAmount getConfig getWord q4rx q4rx2 getArgFromList getListLenght get_pattern find_variable get_key_or_index getQuestStatus
+	getStorageAmount getVendAmount getConfig getWord q4rx q4rx2 getArgFromList get_pattern find_variable get_key_or_index getQuestStatus
 	find_hash_and_get_keys find_hash_and_get_values);
 use eventMacro::Automacro;
 
@@ -2192,9 +2192,6 @@ sub parse_command {
 
 		} elsif ($keyword eq 'listitem') {
 			$result = getArgFromList($parsed);
-
-		} elsif ($keyword eq 'listlength') {
-			$result = getListLenght($parsed);
 
 		} elsif ($keyword eq 'strip') {
 			$parsed =~ s/\(|\)//g;

--- a/plugins/eventMacro/eventMacro/Utilities.pm
+++ b/plugins/eventMacro/eventMacro/Utilities.pm
@@ -151,20 +151,23 @@ sub getArgs {
 sub getWord {
 	my ($message, $wordno) = $_[0] =~ /^"(.*?)"\s*,\s?(\d+|\$[a-zA-Z][a-zA-Z\d]*)$/s;
 	my @words = split(/[ ,.:;\"\'!?\r\n]/, $message);
-	my $no = 1;
-	if ($wordno =~ /^\$/) {
-		my ($val) = $wordno =~ /^\$([a-zA-Z][a-zA-Z\d]*)\s*$/;
-		return "" unless defined $val;
-		if ($eventMacro->get_scalar_var($val) =~ /^[1-9][0-9]*$/) {$wordno = $eventMacro->get_scalar_var($val)}
-		else {return ""}
 
-	}
+# this code is never used
+#	if ($wordno =~ /^\$/) {
+#		my ($val) = $wordno =~ /^\$([a-zA-Z][a-zA-Z\d]*)\s*$/;
+#		return "" unless defined $val;
+#		if ($eventMacro->get_scalar_var($val) =~ /^[1-9][0-9]*$/) {$wordno = $eventMacro->get_scalar_var($val)}
+#		else {return ""}
+#	}
+
+	my $no = 1;
 	foreach (@words) {
 		next if /^$/;
 		return $_ if $no == $wordno;
 		$no++
 	}
-	return ""
+	warning "[eventMacro] the '$wordno' number item does not exist in &arg\n", "eventMacro";
+	return "";
 }
 
 # gets openkore setting

--- a/plugins/eventMacro/eventMacro/Utilities.pm
+++ b/plugins/eventMacro/eventMacro/Utilities.pm
@@ -8,7 +8,7 @@ our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(q4rx q4rx2 between cmpr match getArgs getnpcID getPlayerID
 	getMonsterID getVenderID getItemIDs getItemPrice getInventoryIDs getInventoryTypeIDs getStorageIDs getSoldOut getInventoryAmount
 	getCartAmount getShopAmount getStorageAmount getVendAmount getRandom getRandomRange getConfig
-	getWord call_macro getArgFromList getListLenght sameParty processCmd find_variable get_key_or_index getInventoryAmountbyID
+	getWord call_macro getArgFromList sameParty processCmd find_variable get_key_or_index getInventoryAmountbyID
 	getStorageAmountbyID getCartAmountbyID getQuestStatus get_pattern find_hash_and_get_keys find_hash_and_get_values);
 
 use Utils;
@@ -467,13 +467,6 @@ sub getArgFromList {
 		warning "[eventMacro] the $listID number item does not exist in the list\n", "eventMacro";
 		return -1
 	}
-}
-
-# returns the length of a comma separated list
-sub getListLenght {
-	my $list = $_[0];
-	my @items = split(/,\s*/, $list);
-	return scalar(@items)
 }
 
 # check if player is in party


### PR DESCRIPTION
this PR fixes: #3254 

additionally cleared the code
```perl
sub getWord {
	my ($message, $wordno) = $_[0] =~ /^"(.*?)"\s*,\s?(\d+|\$[a-zA-Z][a-zA-Z\d]*)$/s;
	my @words = split(/[ ,.:;\"\'!?\r\n]/, $message);
	my $no = 1;
	if ($wordno =~ /^\$/) {
		my ($val) = $wordno =~ /^\$([a-zA-Z][a-zA-Z\d]*)\s*$/;
		return "" unless defined $val;
		if ($eventMacro->get_scalar_var($val) =~ /^[1-9][0-9]*$/) {$wordno = $eventMacro->get_scalar_var($val)}
		else {return ""}

	}
	foreach (@words) {
		next if /^$/;
		return $_ if $no == $wordno;
		$no++
	}
	return ""
}
```

It looks like this piece of code is never used:
```perl
	if ($wordno =~ /^\$/) {
		my ($val) = $wordno =~ /^\$([a-zA-Z][a-zA-Z\d]*)\s*$/;
		return "" unless defined $val;
		if ($eventMacro->get_scalar_var($val) =~ /^[1-9][0-9]*$/) {$wordno = $eventMacro->get_scalar_var($val)}
		else {return ""}

	}
```

i added some debugging
```perl
# gets word from message
sub getWord {
error "[test1] _=$_[0]\n", "eventMacro";

	my ($message, $wordno) = $_[0] =~ /^"(.*?)"\s*,\s?(\d+|\$[a-zA-Z][a-zA-Z\d]*)$/s;
	my @words = split(/[ ,.:;\"\'!?\r\n]/, $message);
error "[test2] wordno=$wordno\n";
	if ($wordno =~ /^\$/) {
error "[test3] wordno=$wordno\n", "eventMacro";
		my $val = $wordno =~ /^\$([a-zA-Z][a-zA-Z\d]*)\s*$/;
error "[test4] val=$val\n";
		unless ($val) {
			warning "[eventMacro] wrong variable name in &arg\n", "eventMacro";
			return "";
		}
		if ($eventMacro->get_scalar_var($val) =~ /^[1-9][0-9]*$/) {
error "[test5] wordno=$wordno\n";
			$wordno = $eventMacro->get_scalar_var($val)
		} else {
			warning "[eventMacro] wrong variable value in &arg (must be a number)\n", "eventMacro";
			return "";
		}

	} else {
error "[test6] else\n";
	}

	my $no = 1;
	foreach (@words) {
		next if /^$/;
		return $_ if $no == $wordno;
		$no++
	}
	warning "[eventMacro] the '$wordno' number item does not exist in &arg\n", "eventMacro";
	return "";
}
```
and tested on a macro like this:
```
macro x {
   [
    $list = a!b c
	$num = 2
	$text = test
log \$list=$list
log \$num=$num
log text1=$text
log arg1: &arg \("\$list", \$wrong)
    log arg1: &arg ("$list", $wrong)
log arg2: &arg \("\$list", 3)
    log arg2: &arg ("$list", 3)
log arg3: &arg \("\$list", 6)
    log arg3: &arg ("$list", 6)
log arg4: &arg \("\$list", \$text)
    log arg4: &arg ("$list", $text)
log arg5: &arg ("$list", $666)
    log arg5: &arg \("\$list", \$666)
log arg6: &arg \("\$list", \$num)
    log arg6: &arg ("$list", $num)
   ]
 }
```

result:
![изображение](https://user-images.githubusercontent.com/7117363/95653781-f64d4a80-0b03-11eb-82a4-535147fc15f1.png)
