### PR TITLE
[FIX] auto select the skill lvl when lvl in config is higher than the character have

### DIFF
--- a/src/AI.pm
+++ b/src/AI.pm
@@ -603,8 +603,8 @@ sub ai_skillUse {
 	}
 
 	if ($char->{skills}{$args{skillHandle}}{lv} < $args{lv}) {
-		debug "Attempted to use skill (".$args{skillHandle}.") level ".$args{lv}." which you do not have, adjusting to level ".$char->{skills}{$args{skillHandle}}{lv}.".\n";
-		return;
+		debug "Attempted to use skill (".$args{skillHandle}.") level ".$args{lv}." which you do not have, adjusting to level ".$char->{skills}{$args{skillHandle}}{lv}.".\n", "ai";
+		$args{lv} = $char->{skills}{$args{skillHandle}}{lv};
 	}
 
 	AI::queue("skill_use", \%args);


### PR DESCRIPTION
follow up to: #3199

before:
![image](https://user-images.githubusercontent.com/10372732/102016211-90b54e80-3d3e-11eb-94f5-acb7bc9842fb.png)


after:
![image](https://user-images.githubusercontent.com/10372732/102016230-9e6ad400-3d3e-11eb-8214-de3351d9da1f.png)
