### PR TITLE
fixed cash shop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y libreadline6-dev libcurl4-openssl-dev
+        sudo apt install -y libreadline6-dev libcurl4-openssl-dev python
     - name: Run Tests
       run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,5 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y libreadline6-dev libcurl4-openssl-dev python
-
     - name: Run Tests
       run: make test

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -139,8 +139,18 @@ sub initHandlers {
 			["get <cart item #> [<amount>]", T("get <amount> items from cart to inventory")],
 			["desc <cart item #> [<amount>]", T("displays cart item description")]
 			], \&cmdCart],
-		['cash', undef, \&cmdCash],
-		['cashbuy', undef, \&cmdCashShopBuy],
+		['cash', [
+			T("Cash shop management"),
+			["open", T("open Cash shop")],
+			["close", T("close Cash shop")],
+			[T("buy <item> [<amount>] [<kafra shop points>]"), T("buy items from Cash shop")],
+			["points", T("show the number of available Cash shop points")],
+			["list", T("lists the Cash shop items")],
+			], \&cmdCash],
+		['cashbuy', [
+			T("Buy Cash item"),
+			["<kafra_points> <item #> [<amount>][, <item #> [<amount>]]...", T("buy items from cash dealer")],
+			], \&cmdCashShopBuy],
 		['charselect', T("Ask server to exit to the character selection screen."), \&cmdCharSelect],
 		['chat', [
 			T("Chat room management."),
@@ -1674,6 +1684,38 @@ sub cmdCash {
 		return;
 	}
 
+	if ($args[0] eq 'list') {
+		if (not defined $cashShop{list}) {
+			error T("The list of items of Cash shop is not available\n");
+			return;
+		}
+		my %cashitem_tab = (
+			0 => T('New'),
+			1 => T('Popular'),
+			2 => T('Limited'),
+			3 => T('Rental'),
+			4 => T('Perpetuity'),
+			5 => T('Buff'),
+			6 => T('Recovery'),
+			7 => T('Etc'),
+		);
+
+		my $msg;
+		for (my $tabcode = 0; $tabcode < @{$cashShop{list}}; $tabcode++) {
+			$msg .= center(T(' Tab: ') . $cashitem_tab{$tabcode} . ' ', 50, '-') ."\n".
+			T ("ID      Item Name                            Price\n");
+			foreach my $itemloop (@{$cashShop{list}[$tabcode]}) {
+				$msg .= swrite(
+					"@<<<<<  @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<  @>>>>>>C",
+					[$itemloop->{item_id}, itemNameSimple($itemloop->{item_id}), formatNumber($itemloop->{price})]);
+			}
+		}
+		$msg .= ('-'x50) . "\n";
+		message $msg, "list";
+
+		return;
+	}
+
 	if (not defined $cashShop{points}) {
 		error T("Cash shop is not open\n");
 		error T("Please use 'cash open' first\n");
@@ -1690,9 +1732,9 @@ sub cmdCash {
 		my ($amount, $item, $kafra_points);
 
 		if ($args[1] !~ /^\d+$/) {
-			$item = itemNameToID($item);
+			$item = itemNameToID($args[1]);
 			if (!$item) {
-				error TF("Error in function 'cash buy': invalid item name or tables needs to be updated \n");
+				error TF("Error in function 'cash buy': invalid item name '%s' or tables needs to be updated\n", $args[1]);
 				return;
 			}
 		} else {
@@ -1744,36 +1786,8 @@ sub cmdCash {
 		return;
 	}
 
-	if ($args[0] eq 'list') {
-		my %cashitem_tab = (
-			0 => T('New'),
-			1 => T('Popular'),
-			2 => T('Limited'),
-			3 => T('Rental'),
-			4 => T('Perpetuity'),
-			5 => T('Buff'),
-			6 => T('Recovery'),
-			7 => T('Etc'),
-		);
-
-		my $msg;
-		for (my $tabcode = 0; $tabcode < @{$cashShop{list}}; $tabcode++) {
-			$msg .= center(T(' Tab: ') . $cashitem_tab{$tabcode} . ' ', 50, '-') ."\n".
-			T ("ID      Item Name                            Price\n");
-			foreach my $itemloop (@{$cashShop{list}[$tabcode]}) {
-				$msg .= swrite(
-					"@<<<<<  @<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<  @>>>>>>C",
-					[$itemloop->{item_id}, itemNameSimple($itemloop->{item_id}), formatNumber($itemloop->{price})]);
-			}
-		}
-		$msg .= ('-'x50) . "\n";
-		message $msg, "list";
-
-		return;
-	}
-
 	error T("Syntax Error in function 'cash' (Cash shop)\n" .
-			"Usage: cash <open|close|buy|points|list>\n");
+			"Usage: cash <open | close | buy | points | list>\n");
 }
 
 sub cmdCharSelect {

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -3705,7 +3705,7 @@ sub shop_sold_long {
 sub vending_start {
 	my ($self, $args) = @_;
 
-	my $item_pack = $self->{vender_items_list_item_pack} || 'V v2 C v C3 a8';
+	my $item_pack = $self->{vender_items_list_item_pack_self} || $self->{vender_items_list_item_pack} || 'V v2 C v C3 a8';
 	my $item_len = length pack $item_pack;
 	my $item_list_len = length $args->{itemList};
 	#started a shop.

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -524,7 +524,7 @@ sub new {
 		'083A' => ['search_store_open', 'v C', [qw(type amount)]],
 		'083D' => ['search_store_pos', 'v v', [qw(x y)]],
 		'083E' => ['login_error', 'V Z20', [qw(type date)]],
-		'0845' => ['cash_shop_open_result', 'v2', [qw(cash_points kafra_points)]],
+		'0845' => ['cash_shop_open_result', 'V2', [qw(cash_points kafra_points)]], #10
 		'0849' => ['cash_shop_buy_result', 'V s V', [qw(item_id result updated_points)]],
 		'084B' => ['item_appeared', 'a4 v2 C v2 C2 v', [qw(ID nameID type identified x y subx suby amount)]],
 		'0856' => ['actor_moved', 'v C a4 v3 V v5 a4 v6 a4 a2 v V C2 a6 C2 v2 Z*', [qw(len object_type ID walk_speed opt1 opt2 option type hair_style weapon shield lowhead tick tophead midhead hair_color clothes_color head_dir costume guildID emblemID manner opt3 stance sex coords xSize ySize lv font name)]], # -1 # walking provided by try71023 TODO: costume
@@ -1484,8 +1484,8 @@ sub mail_refreshinbox {
 	$msg .= center(" " . T("Inbox") . " ", 79, '-') . "\n";
 	# truncating the title from 39 to 34, the user will be able to read the full title when reading the mail
 	# truncating the date with precision of minutes and leave year out
-	$msg .=	swrite(TF("\@> R \@%s \@%s \@%s", ('<'x34), ('<'x24), ('<'x11)),
-			["#", "Title", "Sender", "Date"]);
+	$msg .=	swrite("\@> R \@%s \@%s \@%s", ('<'x34), ('<'x24), ('<'x11),
+			["#", T("Title"), T("Sender"), T("Date")]);
 	$msg .= sprintf("%s\n", ('-'x79));
 
 	my $j = 0;
@@ -1496,7 +1496,7 @@ sub mail_refreshinbox {
 		$mailList->[$j]->{sender} = bytesToString(unpack("Z24", substr($args->{RAW_MSG}, $i+45, 24)));
 		$mailList->[$j]->{timestamp} = unpack("V1", substr($args->{RAW_MSG}, $i+69, 4));
 		$msg .= swrite(
-		TF("\@> %s \@%s \@%s \@%s", $mailList->[$j]->{read}, ('<'x34), ('<'x24), ('<'x11)),
+		"\@> %s \@%s \@%s \@%s", $mailList->[$j]->{read}, ('<'x34), ('<'x24), ('<'x11),
 		[$j, $mailList->[$j]->{title}, $mailList->[$j]->{sender}, getFormattedDate(int($mailList->[$j]->{timestamp}))]);
 		$j++;
 	}
@@ -1617,8 +1617,8 @@ sub auction_item_request_search {
 	message TF("Found %s items in auction.\n", $count), "info";
 	my $msg;
 	$msg .= center(" " . T("Auction") . " ", 79, '-') . "\n";
-	$msg .=	swrite(TF("\@%s \@%s \@%s \@%s \@%s", ('>'x2), ('<'x37), ('>'x10), ('>'x10), ('<'x11)),
-			["#", "Item", "High Bid", "Purchase", "End-Date"]);
+	$msg .=	swrite("\@%s \@%s \@%s \@%s \@%s", ('>'x2), ('<'x37), ('>'x10), ('>'x10), ('<'x11),
+			["#", T("Item"), T("High Bid"), T("Purchase"), T("End-Date")]);
 	$msg .= sprintf("%s\n", ('-'x79));
 
 	my $j = 0;
@@ -1650,7 +1650,7 @@ sub auction_item_request_search {
 		$item->{broken} = $auctionList->[$j]->{broken};
 		$item->{name} = itemName($item);
 
-		$msg .= swrite(TF("\@%s \@%s \@%s \@%s \@%s", ('>'x2),, ('<'x37), ('>'x10), ('>'x10), ('<'x11)),
+		$msg .= swrite("\@%s \@%s \@%s \@%s \@%s", ('>'x2),, ('<'x37), ('>'x10), ('>'x10), ('<'x11),
 				[$j, $item->{name}, formatNumber($auctionList->[$j]->{price}),
 					formatNumber($auctionList->[$j]->{buynow}), getFormattedDate(int($auctionList->[$j]->{timestamp}))]);
 		$j++;

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -523,7 +523,7 @@ sub new {
 		'083A' => ['search_store_open', 'v C', [qw(type amount)]],
 		'083D' => ['search_store_pos', 'v v', [qw(x y)]],
 		'083E' => ['login_error', 'V Z20', [qw(type date)]],
-		'0845' => ['cash_shop_open_result', 'v2', [qw(cash_points kafra_points)]],#10
+		'0845' => ['cash_shop_open_result', 'V2', [qw(cash_points kafra_points)]],#10
 		'0849' => ['cash_shop_buy_result', 'V s V', [qw(item_id result updated_points)]],#16
 		'084B' => ['item_appeared', 'a4 v2 C v2 C2 v', [qw(ID nameID type identified x y subx suby amount)]],
 		'0856' => ['actor_moved', 'v C a4 v3 V v5 a4 v6 a4 a2 v V C2 a6 C2 v2 Z*', [qw(len object_type ID walk_speed opt1 opt2 option type hair_style weapon shield lowhead tick tophead midhead hair_color clothes_color head_dir costume guildID emblemID manner opt3 stance sex coords xSize ySize lv font name)]], # -1 # walking provided by try71023 TODO: costume
@@ -1449,8 +1449,8 @@ sub mail_refreshinbox {
 	$msg .= center(" " . T("Inbox") . " ", 79, '-') . "\n";
 	# truncating the title from 39 to 34, the user will be able to read the full title when reading the mail
 	# truncating the date with precision of minutes and leave year out
-	$msg .=	swrite(TF("\@> R \@%s \@%s \@%s", ('<'x34), ('<'x24), ('<'x11)),
-			["#", "Title", "Sender", "Date"]);
+	$msg .=	swrite("\@> R \@%s \@%s \@%s", ('<'x34), ('<'x24), ('<'x11),
+			["#", T("Title"), T("Sender"), T("Date")]);
 	$msg .= sprintf("%s\n", ('-'x79));
 
 	my $j = 0;
@@ -1465,7 +1465,7 @@ sub mail_refreshinbox {
 		$mailList->[$j]->{sender} = bytesToString($mailList->[$j]->{sender});
 
 		$msg .= swrite(
-		TF("\@> %s \@%s \@%s \@%s", $mailList->[$j]->{read}, ('<'x34), ('<'x24), ('<'x11)),
+		"\@> %s \@%s \@%s \@%s", $mailList->[$j]->{read}, ('<'x34), ('<'x24), ('<'x11),
 		[$j, $mailList->[$j]->{title}, $mailList->[$j]->{sender}, getFormattedDate(int($mailList->[$j]->{timestamp}))]);
 		$j++;
 	}
@@ -1500,8 +1500,8 @@ sub auction_item_request_search {
 	message TF("Found %s items in auction.\n", $count), "info";
 	my $msg;
 	$msg .= center(" " . T("Auction") . " ", 79, '-') . "\n";
-	$msg .=	swrite(TF("\@%s \@%s \@%s \@%s \@%s", ('>'x2), ('<'x37), ('>'x10), ('>'x10), ('<'x11)),
-			["#", "Item", "High Bid", "Purchase", "End-Date"]);
+	$msg .=	swrite("\@%s \@%s \@%s \@%s \@%s", ('>'x2), ('<'x37), ('>'x10), ('>'x10), ('<'x11),
+			["#", T("Item"), T("High Bid"), T("Purchase"), T("End-Date")]);
 	$msg .= sprintf("%s\n", ('-'x79));
 
 	my $j = 0;
@@ -1531,7 +1531,7 @@ sub auction_item_request_search {
 		$item->{broken} = $auctionList->[$j]->{broken};
 		$item->{name} = itemName($item);
 
-		$msg .= swrite(TF("\@%s \@%s \@%s \@%s \@%s", ('>'x2),, ('<'x37), ('>'x10), ('>'x10), ('<'x11)),
+		$msg .= swrite("\@%s \@%s \@%s \@%s \@%s", ('>'x2),, ('<'x37), ('>'x10), ('>'x10), ('<'x11),
 				[$j, $item->{name}, formatNumber($auctionList->[$j]->{price}),
 					formatNumber($auctionList->[$j]->{buynow}), getFormattedDate(int($auctionList->[$j]->{timestamp}))]);
 		$j++;

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -33,7 +33,7 @@ use Digest::MD5;
 use Math::BigInt;
 
 # TODO: remove 'use Globals' from here, instead pass vars on
-use Globals qw(%config $bytesSent %packetDescriptions $enc_val1 $enc_val2 $char $masterServer $syncSync $accountID %timeout %talk $skillExchangeItem $net $rodexList $rodexWrite %universalCatalog %rpackets $mergeItemList $repairList);
+use Globals qw(%config $bytesSent %packetDescriptions $enc_val1 $enc_val2 $char $masterServer $syncSync $accountID %timeout %talk $skillExchangeItem $net $rodexList $rodexWrite %universalCatalog %rpackets $mergeItemList $repairList %cashShop);
 
 use I18N qw(bytesToString stringToBytes);
 use Utils qw(existsInList getHex getTickCount getCoordString makeCoordsDir);
@@ -1106,6 +1106,7 @@ sub sendCashShopOpen {
 sub sendCashShopClose {
 	my ($self) = @_;
 	$self->sendToServer($self->reconstruct({switch => 'cash_shop_close'}));
+	undef $cashShop{points};
 	debug "Requesting sendCashShopClose\n", "sendPacket", 2;
 }
 


### PR DESCRIPTION
- added description to 'cash' and 'cashbuy' commands
- now the 'cash list' command does not require running the 'cash open' command. After all, we receive this information immediately after loading the map
- fixed the 'cash buy <item_name>' command
- added clearing of the variable '$ cashShop {points}' after the store was closed, otherwise the 'cash open' command did not work after the store was closed
- updated the 'cash_shop_list' function. Added support for items 4 bytes ($ self -> {cash_shop_list_pack})
- updated the 'cash_shop_buy_result' function
- update wiki:
https://openkore.com/wiki/Cash
https://openkore.com/wiki/Cashbuy
https://openkore.com/wiki/WhenInGame_requestCashPoints


before:
![изображение](https://user-images.githubusercontent.com/7117363/107084894-b9226c00-6808-11eb-9c59-c06bad413264.png)
after:
![изображение](https://user-images.githubusercontent.com/7117363/107084949-ce979600-6808-11eb-8b48-a24b0c047896.png)
