### PR TITLE
Exchange checkLineWalkable for canMove and fix follow sitAuto Idle

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -169,7 +169,6 @@ dcOnJobLevel
 dcOnLevel
 
 follow 0
-followTarget testCreator
 followTarget
 followEmotion 1
 followEmotion_distance 4

--- a/control/config.txt
+++ b/control/config.txt
@@ -169,7 +169,7 @@ dcOnJobLevel
 dcOnLevel
 
 follow 0
-followCheckLOS 1
+followTarget testCreator
 followTarget
 followEmotion 1
 followEmotion_distance 4
@@ -179,8 +179,6 @@ followDistanceMin 3
 followLostStep 12
 followSitAuto 0
 followBot 0
-followRandom 0
-followRandomDistance 4
 
 itemsTakeAuto 2
 itemsTakeAuto_party 0

--- a/control/config.txt
+++ b/control/config.txt
@@ -169,7 +169,7 @@ dcOnJobLevel
 dcOnLevel
 
 follow 0
-followCheckLOS 0
+followCheckLOS 1
 followTarget
 followEmotion 1
 followEmotion_distance 4

--- a/plugins/needs-review/autowarp/trunk/autowarpn.pl
+++ b/plugins/needs-review/autowarp/trunk/autowarpn.pl
@@ -116,7 +116,7 @@ sub getEmptyPos {
          for (my $k = 0; $k < ($i*2); $k++) {
             if ($field->isWalkable($posx, $posy) && !$pos{$posx}{$posy}) {
                my $pos = {x=>$posx, y=>$posy};
-               return $pos if ($field->checkLineWalkable($obj->{pos_to}, $pos));
+               return $pos if ($field->canMove($pos, $obj->{pos_to}));
             }
 
             $posx += $vectors[$vecx];

--- a/plugins/needs-review/freeCast/trunk/freeCast.pl
+++ b/plugins/needs-review/freeCast/trunk/freeCast.pl
@@ -118,7 +118,7 @@ sub cast {
 					next;
 				}
 
-				delete $blocks[$i] unless ($field->checkLineSnipable($blocks[$i], $realMonsterPos) || $field->checkLineWalkable($blocks[$i], $realMonsterPos));
+				delete $blocks[$i] unless ($field->checkLOS($blocks[$i], $realMonsterPos, 1));
 			}
 
 			my $largestDist;
@@ -144,8 +144,8 @@ sub cast {
 			my $best_dist;
 			for my $spot (@blocks) {
 				if (
-				(($config{attackCanSnipe} && $field->checkLineSnipable($spot, $realMonsterPos)) || $field->checkLineWalkable($spot, $realMonsterPos))
-				&& $field->isWalkable($spot->{x}, $spot->{y})
+					$field->isWalkable($spot->{x}, $spot->{y}) &&
+					$field->checkLOS($spot, $realMonsterPos, $config{attackCanSnipe})
 				) {
 					my $dist = distance($realMyPos, $spot);
 					if (!defined($best_dist) || $dist < $best_dist) {

--- a/src/AI.pm
+++ b/src/AI.pm
@@ -263,9 +263,9 @@ sub ai_partyfollow {
 		return unless ($master{map} ne $field->name || exists $master{x}); # Compare including InstanceID
 
 		# Compare map names including InstanceID
-		if ((exists $ai_v{master} && distance(\%master, $ai_v{master}) > 15)
+		if ((exists $ai_v{master} && blockDistance(\%master, $ai_v{master}) > 15)
 			|| $master{map} != $ai_v{master}{map}
-			|| (timeOut($ai_v{master}{time}, 15) && distance(\%master, $char->{pos_to}) > $config{followDistanceMax})) {
+			|| (timeOut($ai_v{master}{time}, 15) && blockDistance(\%master, $char->{pos_to}) > $config{followDistanceMax})) {
 
 			$ai_v{master}{x} = $master{x};
 			$ai_v{master}{y} = $master{y};
@@ -275,7 +275,7 @@ sub ai_partyfollow {
 
 			if ($ai_v{master}{map} ne $field->name) {
 				message TF("Calculating route to find master: %s\n", $ai_v{master}{map_name}), "follow";
-			} elsif (distance(\%master, $char->{pos_to}) > $config{followDistanceMax} ) {
+			} elsif (blockDistance(\%master, $char->{pos_to}) > $config{followDistanceMax} ) {
 				message TF("Calculating route to find master: %s (%s,%s)\n", $ai_v{master}{map_name}, $ai_v{master}{x}, $ai_v{master}{y}), "follow";
 			} else {
 				return;

--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -61,8 +61,6 @@ sub process {
 		# We're on route to the monster; check whether the monster has moved
 		my $ID = $args->{attackID};
 		my $attackSeq = (AI::action eq "route") ? AI::args(1) : AI::args(2);
-		my $routeSeqindex = AI::findAction("route");
-		my $routeArgs = AI::args($routeSeqindex) if (defined $routeSeqindex);
 		my $target = Actor::get($ID);
 		my $realMyPos = calcPosition($char);
 		my $realMonsterPos = calcPosition($target);

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2382,32 +2382,15 @@ sub processFollow {
 				my $dist = blockDistance($char->{pos_to}, $player->{pos_to});
 				if ($dist > $config{followDistanceMax} && timeOut($args->{move_timeout}, 0.25)) {
 					$args->{move_timeout} = time;
-					if ($config{followCheckLOS} && !$field->canMove($char->{pos_to}, $player->{pos_to})) {
-						ai_route($field->baseName, $player->{pos_to}{x}, $player->{pos_to}{y},
-							attackOnRoute => 1,
-							distFromGoal => $config{followDistanceMin});
-					} else {
-						my (%vec, %pos);
-
-						stand() if ($char->{sitting});
-						getVector(\%vec, $player->{pos_to}, $char->{pos_to});
-						moveAlongVector(\%pos, $char->{pos_to}, \%vec, $dist - $config{followDistanceMin});
-						$timeout{ai_sit_idle}{time} = time;
-
-						if($config{followRandom}) {
-							if(int(rand(2))) {
-								$pos{x} += int(rand($config{followRandomDistance})); }
-							else {
-								$pos{x} -= int(rand($config{followRandomDistance})); }
-
-							if(int(rand(2))) {
-								$pos{y} += int(rand($config{followRandomDistance})); }
-							else {
-								$pos{y} -= int(rand($config{followRandomDistance})); }
-						}
-
-						$char->sendMove(@pos{qw(x y)});
-					}
+					$args->{masterLastMoveTime} = $player->{time_move};
+					
+					ai_route(
+						$field->baseName,
+						$player->{pos_to}{x},
+						$player->{pos_to}{y},
+						attackOnRoute => 1,
+						distFromGoal => $config{followDistanceMin}
+					);
 				}
 			}
 
@@ -2424,6 +2407,32 @@ sub processFollow {
 					lookAtPosition($players{$args->{'ID'}}{'pos_to'}) if ($config{'followFaceDirection'});
 				}
 			}
+		}
+	} elsif (((AI::action eq "route" && AI::action(1) eq "follow") || (AI::action eq "move" && AI::action(2) eq "follow")) && !$args->{ai_follow_lost}) {
+		my $ID = $args->{ID};
+		my $player = $players{$ID};
+		if (
+			$args->{following} &&
+			$player &&
+			%{$player} &&
+			$player->{pos_to} &&
+			$args->{masterLastMoveTime} &&
+			$args->{masterLastMoveTime} != $player->{time_move}
+		) {
+			debug "Master $player has moved since we started routing to it - Adjusting route\n", "ai_attack";
+			AI::dequeue;
+			AI::dequeue if (AI::action eq "route");
+
+			$args->{move_timeout} = time;
+			$args->{masterLastMoveTime} = $player->{time_move};
+			
+			ai_route(
+				$field->baseName,
+				$player->{pos_to}{x},
+				$player->{pos_to}{y},
+				attackOnRoute => 1,
+				distFromGoal => $config{followDistanceMin}
+			);
 		}
 	}
 
@@ -2545,7 +2554,6 @@ sub processFollow {
 				stand() if ($char->{sitting});
 				getVector(\%vec, $pos, $char->{pos_to});
 				moveAlongVector(\%pos_to, $char->{pos_to}, \%vec, $dist);
-				$timeout{ai_sit_idle}{time} = time;
 				$char->move(@pos_to{qw(x y)});
 				$pos->{x} = int $pos_to{x};
 				$pos->{y} = int $pos_to{y};
@@ -2592,7 +2600,7 @@ sub processFollow {
 ##### SITAUTO-IDLE #####
 sub processSitAutoIdle {
 	if ($config{sitAuto_idle}) {
-		if (!AI::isIdle && AI::action ne "follow") {
+		if (!AI::isIdle) {
 			$timeout{ai_sit_idle}{time} = time;
 		}
 

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2382,7 +2382,7 @@ sub processFollow {
 				my $dist = blockDistance($char->{pos_to}, $player->{pos_to});
 				if ($dist > $config{followDistanceMax} && timeOut($args->{move_timeout}, 0.25)) {
 					$args->{move_timeout} = time;
-					if ( $dist > 15 || ($config{followCheckLOS} && !$field->checkLineWalkable($char->{pos_to}, $player->{pos_to})) ) {
+					if ($config{followCheckLOS} && !$field->canMove($char->{pos_to}, $player->{pos_to})) {
 						ai_route($field->baseName, $player->{pos_to}{x}, $player->{pos_to}{y},
 							attackOnRoute => 1,
 							distFromGoal => $config{followDistanceMin});
@@ -2535,7 +2535,7 @@ sub processFollow {
 		} elsif ($args->{'ai_follow_lost_warped'} && $ai_v{'temp'}{'warp_pos'} && %{$ai_v{'temp'}{'warp_pos'}}) {
 			my $pos = $ai_v{'temp'}{'warp_pos'};
 
-			if ($config{followCheckLOS} && !$field->checkLineWalkable($char->{pos_to}, $pos)) {
+			if ($config{followCheckLOS} && !$field->canMove($char->{pos_to}, $pos)) {
 				ai_route($field->baseName, $pos->{x}, $pos->{y},
 					attackOnRoute => 0); #distFromGoal => 0);
 			} else {
@@ -3316,9 +3316,9 @@ sub processAutoTeleport {
 			} elsif ($teleAuto < 0 && !$char->{dead}) {
 				my $pos = calcPosition($monsters{$_});
 				my $myPos = calcPosition($char);
-				my $dist = distance($pos, $myPos);
+				my $dist = blockDistance($pos, $myPos);
 				if ($dist <= abs($teleAuto)) {
-					if($field->checkLineWalkable($myPos, $pos) || $field->checkLineSnipable($myPos, $pos)) {
+					if($field->canMove($myPos, $pos)) {
 						message TF("Teleporting due to monster being too close %s\n", $monsters{$_}{name}), "teleport";
 						$ai_v{temp}{clear_aiQueue} = 1 if (useTeleport(1));
 						$timeout{ai_teleport_away}{time} = time;

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -220,7 +220,7 @@ sub processFollow {
 		&& (!defined $slave->findAction('route') || !$slave->args($slave->findAction('route'))->{isFollow})
 	) {
 		$slave->clear('move', 'route');
-		if (!$field->checkLineWalkable($slave->{pos_to}, $char->{pos_to})) {
+		if (!$field->canMove($slave->{pos_to}, $char->{pos_to})) {
 			$slave->route(undef, @{$char->{pos_to}}{qw(x y)}, isFollow => 1);
 			debug TF("%s follow route (distance: %d)\n", $slave, $slave->{master_dist}), 'slave';
 

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -305,8 +305,6 @@ sub processAttack {
 		# We're on route to the monster; check whether the monster has moved
 		my $ID = $slave->args->{attackID};
 		my $attackSeq = ($slave->action eq "route") ? $slave->args (1) : $slave->args (2);
-		my $routeSeqindex = $slave->findAction("route");
-		my $routeArgs = $slave->args($routeSeqindex) if (defined $routeSeqindex);
 		my $target = Actor::get($ID);
 		my $realMyPos = calcPosition($slave);
 		my $realMonsterPos = calcPosition($target);

--- a/src/Actor.pm
+++ b/src/Actor.pm
@@ -458,16 +458,6 @@ sub blockDistance {
 }
 
 ##
-# boolean $Actor->snipable()
-#
-# Returns whether or not you have snipable LOS to the actor.
-sub snipable {
-	my ($self) = @_;
-
-	return $field->checkLineSnipable($char->position, $self->position);
-}
-
-##
 # Actor $Actor->deepCopy()
 # Ensures: defined(result)
 #

--- a/src/Field.pm
+++ b/src/Field.pm
@@ -416,128 +416,35 @@ sub checkLOS {
 	return 1;
 }
 
-##
-# $Field->checkLineSnipable(from, to)
-# from, to: references to position hashes.
-#
-# Check whether you can snipe a target standing at $to,
-# from the position $from, without being blocked by any
-# obstacles.
-sub checkLineSnipable {
+sub canMove {
 	my ($self, $from, $to) = @_;
-
-	# Simulate tracing a line to the location (modified Bresenham's algorithm)
-	my ($X0, $Y0, $X1, $Y1) = ($from->{x}, $from->{y}, $to->{x}, $to->{y});
-
-	my $steep;
-	my $posX = 1;
-	my $posY = 1;
-	if ($X1 - $X0 < 0) {
-		$posX = -1;
+	
+	my $dist = blockDistance($from, $to);
+	if ($dist > 17) {
+		return -1;
 	}
-	if ($Y1 - $Y0 < 0) {
-		$posY = -1;
-	}
-	if (abs($Y0 - $Y1) < abs($X0 - $X1)) {
-		$steep = 0;
-	} else {
-		$steep = 1;
-	}
-	if ($steep == 1) {
-		my $Yt = $Y0;
-		$Y0 = $X0;
-		$X0 = $Yt;
-
-		$Yt = $Y1;
-		$Y1 = $X1;
-		$X1 = $Yt;
-	}
-	if ($X0 > $X1) {
-		my $Xt = $X0;
-		$X0 = $X1;
-		$X1 = $Xt;
-
-		my $Yt = $Y0;
-		$Y0 = $Y1;
-		$Y1 = $Yt;
-	}
-	my $dX = $X1 - $X0;
-	my $dY = abs($Y1 - $Y0);
-	my $E = 0;
-	my $dE;
-	if ($dX) {
-		$dE = $dY / $dX;
-	} else {
-		# Delta X is 0, it only occures when $from is equal to $to
+	
+	my $LOS = $self->checkLOS($from, $to, 0);
+	if ($LOS) {
 		return 1;
 	}
-	my $stepY;
-	if ($Y0 < $Y1) {
-		$stepY = 1;
-	} else {
-		$stepY = -1;
-	}
-	my $Y = $Y0;
-	my $Erate = 0.99;
-	if (($posY == -1 && $posX == 1) || ($posY == 1 && $posX == -1)) {
-		$Erate = 0.01;
-	}
-	for (my $X=$X0;$X<=$X1;$X++) {
-		$E += $dE;
-		if ($steep == 1) {
-			return 0 if (!$self->isSnipable($Y, $X));
-		} else {
-			return 0 if (!$self->isSnipable($X, $Y));
-		}
-		if ($E >= $Erate) {
-			$Y += $stepY;
-			$E -= 1;
-		}
-	}
-	return 1;
-}
-
-##
-# $Field->checkLineWalkable(from, to, [min_obstacle_size = 5])
-# from, to: references to position hashes.
-#
-# Check whether you can walk from $from to $to in an (almost)
-# straight line, without obstacles that are too large.
-# Obstacles are considered too large, if they are at least
-# the size of a rectangle with "radius" $min_obstacle_size.
-sub checkLineWalkable {
-	my ($self, $from, $to, $min_obstacle_size) = @_;
 	
-	$min_obstacle_size = 5 if (!defined $min_obstacle_size);
-
-	my $dist = round(distance($from, $to));
-	my %vec;
-
-	getVector(\%vec, $to, $from);
-	# Simulate walking from $from to $to
-	for (my $i = 1; $i < $dist; $i++) {
-		my %p;
-		moveAlongVector(\%p, $from, \%vec, $i);
-		$p{x} = int $p{x};
-		$p{y} = int $p{y};
-
-		if ( !$self->isWalkable($p{x}, $p{y}) ) {
-			# The current spot is not walkable. Check whether
-			# this the obstacle is small enough.
-			if (
-				$self->checkWallLength(\%p, -1,  0, $min_obstacle_size) ||
-				$self->checkWallLength(\%p,  1,  0, $min_obstacle_size) ||
-				$self->checkWallLength(\%p,  0, -1, $min_obstacle_size) ||
-				$self->checkWallLength(\%p,  0,  1, $min_obstacle_size) ||
-				$self->checkWallLength(\%p, -1, -1, $min_obstacle_size) ||
-				$self->checkWallLength(\%p,  1,  1, $min_obstacle_size) ||
-				$self->checkWallLength(\%p,  1, -1, $min_obstacle_size) ||
-				$self->checkWallLength(\%p, -1,  1, $min_obstacle_size)
-			 ) {
-				return 0;
-			}
-		}
+	my $solution = [];
+	my ($min_pathfinding_x, $min_pathfinding_y, $max_pathfinding_x, $max_pathfinding_y) = Utils::getSquareEdgesFromCoord($self, $from, 20);
+	my $dist_path = new PathFinding(
+		field => $self,
+		start => $from,
+		dest => $to,
+		avoidWalls => 0,
+		min_x => $min_pathfinding_x,
+		max_x => $max_pathfinding_x,
+		min_y => $min_pathfinding_y,
+		max_y => $max_pathfinding_y
+	)->run($solution);
+	if ($dist_path > 14) {
+		return -2;
 	}
+	
 	return 1;
 }
 

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3026,7 +3026,7 @@ sub positionNearPlayer {
 		next if ($char->{party}{joined} && $char->{party}{users} &&
 			$char->{party}{users}{$ID});
 		next if (defined($player->{name}) && existsInList($config{tankersList}, $player->{name}));
-		return 1 if (distance($r_hash, $player->{pos_to}) <= $dist);
+		return 1 if (blockDistance($r_hash, $player->{pos_to}) <= $dist);
 	}
 	return 0;
 }
@@ -3036,7 +3036,7 @@ sub positionNearPortal {
 	my $dist = shift;
 
 	for my $portal (@$portalsList) {
-		return 1 if (distance($r_hash, $portal->{pos}) <= $dist);
+		return 1 if (blockDistance($r_hash, $portal->{pos}) <= $dist);
 	}
 	return 0;
 }
@@ -4112,7 +4112,7 @@ sub getBestTarget {
 		}
 		
 		my $name = lc $monster->{name};
-		my $dist = round(distance($myPos, $pos));
+		my $dist = adjustedBlockDistance($myPos, $pos);
 		
 		if (!defined($bestTarget) || ($priority{$name} > $highestPri)) {
 			$highestPri = $priority{$name};
@@ -4134,7 +4134,7 @@ sub getBestTarget {
 			my $monster = $monsters{$_};
 			my $pos = calcPosition($monster);
 			my $name = lc $monster->{name};
-			my $dist = round(distance($myPos, $pos));
+			my $dist = adjustedBlockDistance($myPos, $pos);
 			if (!defined($bestTarget) || ($priority{$name} > $highestPri)) {
 				$highestPri = $priority{$name};
 				$smallestDist = $dist;
@@ -5044,7 +5044,6 @@ sub checkSelfCondition {
 		return 0 if (!inRange($char->{zeny}, $config{$prefix."_zeny"}));
 	}
 
-	# not working yet
 	if ($config{$prefix."_whenWater"}) {
 		my $pos = calcPosition($char);
 		return 0 unless ($field->isWater($pos->{x}, $pos->{y}));
@@ -5074,7 +5073,7 @@ sub checkSelfCondition {
 
 		foreach my $player (@{$playersList}) {
 			next unless (exists $char->{party}{users}{$player->{ID}} && $char->{party}{users}{$player->{ID}});
-			next unless inRange(distance(calcPosition($char), calcPosition($player)), $dist);
+			next unless inRange(blockDistance(calcPosition($char), calcPosition($player)), $dist);
 
 			++$amountInRange;
 		}
@@ -5231,7 +5230,7 @@ sub checkPlayerCondition {
 	}
 
 	if ($config{$prefix."_dist"}) {
-		return 0 unless inRange(distance(calcPosition($char), calcPosition($player)), $config{$prefix."_dist"});
+		return 0 unless inRange(blockDistance(calcPosition($char), calcPosition($player)), $config{$prefix."_dist"});
 	}
 
 	if ($config{$prefix."_isNotMyDevotee"}) {
@@ -5301,7 +5300,7 @@ sub checkMonsterCondition {
 	}
 
 	if ($config{$prefix."_dist"}) {
-		return 0 unless inRange(distance(calcPosition($char), calcPosition($monster)), $config{$prefix."_dist"});
+		return 0 unless inRange(blockDistance(calcPosition($char), calcPosition($monster)), $config{$prefix."_dist"});
 	}
 
 	if ($config{$prefix."_deltaHp"}){

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -5241,7 +5241,7 @@ sub character_moves {
 
 	return unless changeToInGameState();
 	makeCoordsFromTo($char->{pos}, $char->{pos_to}, $args->{coords});
-	my $dist = sprintf("%.1f", distance($char->{pos}, $char->{pos_to}));
+	my $dist = blockDistance($char->{pos}, $char->{pos_to});
 	debug "You're moving from ($char->{pos}{x}, $char->{pos}{y}) to ($char->{pos_to}{x}, $char->{pos_to}{y}) - distance $dist\n", "parseMsg_move";
 	$char->{time_move} = time;
 	$char->{time_move_calc} = distance($char->{pos}, $char->{pos_to}) * ($char->{walk_speed} || 0.12);

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1970,7 +1970,7 @@ sub actor_display {
 	$actor->{pos_to} = {%coordsTo};
 	$actor->{walk_speed} = $args->{walk_speed} / 1000 if (exists $args->{walk_speed} && $args->{switch} ne "0086");
 	$actor->{time_move} = time;
-	$actor->{time_move_calc} = adjustedBlockDistance(\%coordsFrom, \%coordsTo) * $actor->{walk_speed};
+	$actor->{time_move_calc} = distance(\%coordsFrom, \%coordsTo) * $actor->{walk_speed};
 	$actor->{len} = $args->{len} if $args->{len};
 	# 0086 would need that?
 	$actor->{object_type} = $args->{object_type} if (defined $args->{object_type});

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1970,7 +1970,7 @@ sub actor_display {
 	$actor->{pos_to} = {%coordsTo};
 	$actor->{walk_speed} = $args->{walk_speed} / 1000 if (exists $args->{walk_speed} && $args->{switch} ne "0086");
 	$actor->{time_move} = time;
-	$actor->{time_move_calc} = distance(\%coordsFrom, \%coordsTo) * $actor->{walk_speed};
+	$actor->{time_move_calc} = adjustedBlockDistance(\%coordsFrom, \%coordsTo) * $actor->{walk_speed};
 	$actor->{len} = $args->{len} if $args->{len};
 	# 0086 would need that?
 	$actor->{object_type} = $args->{object_type} if (defined $args->{object_type});
@@ -5244,7 +5244,7 @@ sub character_moves {
 	my $dist = blockDistance($char->{pos}, $char->{pos_to});
 	debug "You're moving from ($char->{pos}{x}, $char->{pos}{y}) to ($char->{pos_to}{x}, $char->{pos_to}{y}) - distance $dist\n", "parseMsg_move";
 	$char->{time_move} = time;
-	$char->{time_move_calc} = distance($char->{pos}, $char->{pos_to}) * ($char->{walk_speed} || 0.12);
+	$char->{time_move_calc} = calcTime($char->{pos}, $char->{pos_to}, ($char->{walk_speed} || 0.12));
 
 	# Correct the direction in which we're looking
 	my (%vec, $degree);
@@ -5723,7 +5723,7 @@ sub emoticon {
 		if ($index ne "") {
 			my $masterID = AI::args($index)->{ID};
 			if ($config{'followEmotion'} && $masterID eq $args->{ID} &&
-			       distance($char->{pos_to}, $player->{pos_to}) <= $config{'followEmotion_distance'})
+			       blockDistance($char->{pos_to}, $player->{pos_to}) <= $config{'followEmotion_distance'})
 			{
 				my %args = ();
 				$args{timeout} = time + rand (1) + 0.75;
@@ -10850,7 +10850,7 @@ sub skill_cast {
 		# If $dist is positive we are in range of the attack?
 		$coords{x} = $x;
 		$coords{y} = $y;
-		$dist = judgeSkillArea($skillID) - distance($char->{pos_to}, \%coords);
+		$dist = judgeSkillArea($skillID) - blockDistance($char->{pos_to}, \%coords);
 			$targetString = "location ($x, $y)";
 		undef $targetID;
 	} else {

--- a/src/Task/FollowActor.pm
+++ b/src/Task/FollowActor.pm
@@ -115,7 +115,7 @@ sub processFollow {
 	my $actor = $self->{actor};
 
 	# Check whether the target is within acceptable distance limits.
-	my $distance = distance($char->{pos_to}, $actor->{pos_to});
+	my $distance = blockDistance($char->{pos_to}, $actor->{pos_to});
 	if ($distance > $self->{maxDistance}) {
 		$self->{withinLimits} = 0;
 
@@ -125,7 +125,7 @@ sub processFollow {
 		if ($self->{task}) {
 			# If we're already walking, check whether we need to adjust the path.
 			my $currentDestination = $self->{task}->destCoords();
-			if (distance($interceptPoint, $currentDestination) > 1.42) {
+			if (blockDistance($interceptPoint, $currentDestination) > 1) {
 				debug "FollowActor - readjusting existing route\n", "followActor";
 				$self->{task}->stop();
 				delete $self->{task};

--- a/src/Utils.pm
+++ b/src/Utils.pm
@@ -142,7 +142,7 @@ sub calcTime {
 	my $time = 0;
 	
 	my $time_needed_ortogonal = $speed;
-    my $time_needed_diagonal = sqrt(2) * $speed;
+	my $time_needed_diagonal = sqrt(2) * $speed;
 
 	return if (!$speed); # Make sure $speed actually has a non-zero value...
 


### PR DESCRIPTION
Right now even when openkore is following another player it will activate sitAuto Idle, that is not correct based on our wiki.
This pull fixes that and also fixes some wrong distance checks and walkable line checks (canMove was based on rathena/hercules checks)