### PR TITLE
[alertSound] fixed eventList item

### DIFF
--- a/plugins/alertSound/README.txt
+++ b/plugins/alertSound/README.txt
@@ -1,4 +1,4 @@
-Version 9
+Version 10
 
 alertSound($event)
 $event: unique event name

--- a/plugins/alertSound/alertSound.pl
+++ b/plugins/alertSound/alertSound.pl
@@ -1,7 +1,7 @@
 # alertsound plugin by joseph
-# Modified by 4epT (18.04.2020)
+# Modified by 4epT (06.03.2021)
 #
-# Alert Plugin Version 9
+# Alert Plugin Version 10
 #
 # This software is open source, licensed under the GNU General Public
 # License, ver. (2 * (2 + cos(pi)))
@@ -101,7 +101,7 @@ sub item_appeared {
 		my $eventList = $config{"alertSound_".$i."_eventList"};
 		next if (!$eventList or $eventList !~ /item /i);
 		foreach (split /\,/, $eventList) {
-			my ($part_itemName) = $eventList =~ /item (\*\w+\*)$/;
+			my ($part_itemName) = $_ =~ /item (\*\w+\*)$/;
 			next if (!$part_itemName);
 			if ($item->{name} =~ /^$part_itemName/i) {
 				alertSound("item $part_itemName");


### PR DESCRIPTION
Fixed a bug in alertSound in which the conditions "eventList item name1, item name2" did not work.

```
eventList  item Red Potion, item cards, item *Card*, item *cotton*, item *potion*
```
the `item *cotton*` condition does not work, since parsed incorrectly:
```
foreach (split /\,/, $eventList) {
```