### PR TITLE
if rodex already remove

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -8331,14 +8331,16 @@ sub rodex_remove_item {
 	}
 
 	my $rodex_item = $rodexWrite->{items}->getByID($args->{ID});
+	# if rodex already remove
+	if (defined $rodex_item) {
+		my $disp = TF("Item removed from rodex mail message: %s (%d) x %d - %s",
+				$rodex_item->{name}, $rodex_item->{binID}, $args->{amount}, $itemTypes_lut{$rodex_item->{type}});
+		message "$disp\n", "drop";
 
-	my $disp = TF("Item removed from rodex mail message: %s (%d) x %d - %s",
-			$rodex_item->{name}, $rodex_item->{binID}, $args->{amount}, $itemTypes_lut{$rodex_item->{type}});
-	message "$disp\n", "drop";
-
-	$rodex_item->{amount} -= $args->{amount};
-	if ($rodex_item->{amount} <= 0) {
-		$rodexWrite->{items}->remove($rodex_item);
+		$rodex_item->{amount} -= $args->{amount};
+		if ($rodex_item->{amount} <= 0) {
+			$rodexWrite->{items}->remove($rodex_item);
+		}
 	}
 }
 


### PR DESCRIPTION
```
Error message:
Can't call method "getByID" on an undefined value at src/Network/Receive.pm line 8273.

Stack trace:
Can't call method "getByID" on an undefined value at src/Network/Receive.pm line 8273.
 at src/Network/Receive.pm line 8273
	Network::Receive::rodex_remove_item('Network::Receive::tRO=HASH(0xb1ec6c4)', 'HASH(0xa3c01b4)') called at src/Network/PacketParser.pm line 276
	Network::PacketParser::parse('Network::Receive::tRO=HASH(0xb1ec6c4)', '\x{7}\x{a}Q\x{4}\x{0}\x{0}\x{5}\x{0} ', 'Network::Receive::tRO=HASH(0xb1ec6c4)') called at src/Network/Receive.pm line 554
	Network::Receive::parse('Network::Receive::tRO=HASH(0xb1ec6c4)', '\x{7}\x{a}Q\x{4}\x{0}\x{0}\x{5}\x{0} ', 'Network::Receive::tRO=HASH(0xb1ec6c4)') called at src/Network/PacketParser.pm line 410
	Network::PacketParser::process('Network::Receive::tRO=HASH(0xb1ec6c4)', 'Network::MessageTokenizer=HASH(0xb1d0dd4)', 'Network::Receive::tRO=HASH(0xb1ec6c4)') called at src/functions.pl line 758
	main::mainLoop_initialized() called at src/functions.pl line 75
	main::mainLoop() called at src/Interface.pm line 75
	Interface::mainLoop('Interface::Console::Win32=HASH(0x8dbc3bc)') called at openkore.pl line 97
	main::__start() called at start.pl line 139

Died at this line:
  
* 	my $rodex_item = $rodexWrite->{items}->getByID($args->{ID});
  

```