### PR TITLE
fixed github actions on ubuntu

### DIFF
--- a/.github/workflows/build_XSTools.yml
+++ b/.github/workflows/build_XSTools.yml
@@ -162,6 +162,7 @@ jobs:
           PERL: ${{ matrix.perl }}
           ARCHITECTURE: ${{ matrix.architecture }}
       run: |
+        sudo apt update
         sudo apt install -y libreadline6-dev libcurl4-openssl-dev
         make all
         echo "======================================================"


### PR DESCRIPTION
fixed this error:
```
 Reading package lists...
Building dependency tree...
Reading state information...
libreadline-dev is already the newest version (8.0-4).
libreadline-dev set to manually installed.
Suggested packages:
  libcurl4-doc libidn11-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev
The following NEW packages will be installed:
  libcurl4-openssl-dev
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 320 kB of archives.
After this operation, 1538 kB of additional disk space will be used.
Ign:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.4
Err:1 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.4
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.68.0-1ubuntu2.4_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```