### PR TITLE
adding a new package 0AFB

### DIFF
--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -708,6 +708,7 @@ sub new {
  		'0AE5' => ['party_users_info', 'v Z24 a*', [qw(len party_name playerInfo)]],
 		'0AF0' => ['action_ui', 'C V', [qw(type data)]],
 		'0AF7' => ['character_name', 'v a4 Z24', [qw(flag ID name)]],
+		'0AFB' => ['sage_autospell', 'v a*', [qw(len autospell_list)]],
 		'0AFD' => ['sage_autospell', 'v a*', [qw(len autospell_list)]], #herc PR 2310
 		'0AFE' => ['quest_update_mission_hunt', 'v2 a*', [qw(len mission_amount message)]],
 		'0AFF' => ['quest_all_list', 'v V a*', [qw(len quest_amount message)]],


### PR DESCRIPTION
rRO Prime uses a new package for "sage_autospell"
```
[2021.04.23 19:23:04.61] Received packet: 0438 Handler: skill_use
[2021.04.23 19:23:04.64] Received packet: 07FB Handler: skill_cast
[2021.04.23 19:23:04.65] Вы кастуете умение Автозаклинание на себя (задержка: 3000 мс)
[2021.04.23 19:23:04.65] Received packet: 00B0 Handler: stat_info
[2021.04.23 19:23:04.66] Stat: 53 => 200
[2021.04.23 19:23:04.66] Received packet: 00B0 Handler: stat_info
[2021.04.23 19:23:04.67] Stat: 0 => 187
[2021.04.23 19:23:07.63] Received packet: 00B0 Handler: stat_info
[2021.04.23 19:23:07.64] Stat: 53 => 200
[2021.04.23 19:23:07.68] Received packet: 00B0 Handler: stat_info
[2021.04.23 19:23:07.68] Stat: 0 => 112
[2021.04.23 19:23:07.69] ======================================================================================
<< Received packet:      0AFB [16 bytes]   2021.04.23 19:23:07
  0>  FB 0A 10 00 13 00 00 00    0E 00 00 00 14 00 00 00    ................
[2021.04.23 19:23:07.69] Packet Parser: Unknown switch: 0AFB
[2021.04.23 19:23:08.89] Wiped old
```