### PR TITLE
fix pauseCharLogin

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -45,7 +45,7 @@ inGameAuth 0
 
 macAddress
 
-pauseCharLogin 1
+pauseCharLogin 2
 pauseCharServer 0
 pauseMapServer 0
 ignoreInvalidLogin 0

--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -203,8 +203,5 @@ injectKeepAlive 12
 welcomeText 4
 patchserver 120
 
-# Time to wait before character connection when pauseCharLogin is active
-char_login_pause 2
-
 # Time to wait before load map in xKore mode
 ai_clientSuspend 10

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -841,7 +841,7 @@ sub received_characters {
 	} elsif ($config{pauseCharLogin}) {
 		return if($config{XKore} eq 1 || $config{XKore} eq 3);
 		if (!defined $timeout{'char_login_pause'}{'timeout'}) {
-			$timeout{'char_login_pause'}{'timeout'} = 2;
+			$timeout{'char_login_pause'}{'timeout'} = $config{pauseCharLogin};
 		}
 		$timeout{'char_login_pause'}{'time'} = time;
 
@@ -1739,7 +1739,7 @@ sub actor_display {
 	my $nameID = unpack("V", $args->{ID});
 	my $name = bytesToString($args->{name});
 	$name =~ s/^\s+|\s+$//g;
-	
+
 	if ($args->{switch} eq "0086") {
 		# Message 0086 contains less information about the actor than other similar
 		# messages. So we use the existing actor information.


### PR DESCRIPTION
- now the behavior of "pauseCharLogin" is similar to "pauseCharServer" and "pauseMapServer"
- now the "char_login_pause" timeout is configured in one place - in the config

I have not tested this change, but it seems to me that it is now easier to configure.