### PR TITLE
added a new callHook "friend_request"

### DIFF
--- a/plugins/alertSound/README.txt
+++ b/plugins/alertSound/README.txt
@@ -1,4 +1,4 @@
-Version 10
+Version 11
 
 alertSound($event)
 $event: unique event name
@@ -10,7 +10,7 @@ The config option "alertSound_#_eventList" should have a comma seperated list of
 Supported events:
 	death, emotion, teleport, map change, monster <monster name>, player <player name>, player *, GM near, avoidGM_near,
 	avoidList_near, private GM chat, private avoidList chat (not working for ID), private chat, public GM chat, public avoidList chat,
-	public npc chat, public chat, system message, disconnected, item <item name>, item <item ID>, item cards, item *<part item name>*
+	public npc chat, public chat, system message, disconnected, item <item name>, item <item ID>, item cards, item *<part item name>*, friend
 
 example config.txt:
 	alertSound {
@@ -66,7 +66,7 @@ alertSound {
 	# other Self Conditions
 }
 alertSound {
-	eventList teleport, public chat, emotion
+	eventList teleport, public chat, emotion, friend
 	notInTown 1
 	inLockOnly 0
 	disabled 0

--- a/plugins/alertSound/alertSound.pl
+++ b/plugins/alertSound/alertSound.pl
@@ -1,7 +1,7 @@
 # alertsound plugin by joseph
-# Modified by 4epT (06.03.2021)
+# Modified by 4epT (30.04.2021)
 #
-# Alert Plugin Version 10
+# Alert Plugin Version 11
 #
 # This software is open source, licensed under the GNU General Public
 # License, ver. (2 * (2 + cos(pi)))
@@ -38,7 +38,13 @@ use Plugins;
 use Globals qw($accountID %ai_v %avoid $char %cities_lut %config $field %items_lut $itemsList %players $playersList);
 use Log qw(message);
 use Misc qw(checkSelfCondition itemName);
-use Utils::Win32;
+require Utils::Win32 if ($^O eq 'MSWin32'); #this plugin only works on OS windows
+
+if ($^O ne 'MSWin32') {
+	# We are not on Windows, Plugin can't work.
+	print "alertSound plugin only works on windows OS. Let's skip it.\n\n";
+	return 1;
+}
 
 Plugins::register('alertsound', 'plays sounds on certain events', \&Unload, \&Reload);
 my $packetHook = Plugins::addHooks (
@@ -54,7 +60,8 @@ my $packetHook = Plugins::addHooks (
 	['disconnected', \&disconnected, undef],
 	['item_appeared', \&item_appeared, undef],
 	['avoidGM_near', \&avoidGM_near, undef],
-	['avoidList_near', \&avoidList_near, undef]
+	['avoidList_near', \&avoidList_near, undef],
+	['friend_request', \&friend, undef]
 );
 sub Reload {
 	message "alertsound plugin reloading, ", 'system';
@@ -200,6 +207,12 @@ sub avoidGM_near {
 sub avoidList_near {
 # eventList avoidList_near
 	alertSound("avoidList_near");
+}
+
+sub friend {
+# eventList friend
+	my (undef, $args) = @_;
+	alertSound("friend");
 }
 
 sub exist_eventList {

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -5946,6 +5946,11 @@ sub friend_request {
 	$incomingFriend{'name'} = bytesToString($args->{name});
 	message TF("%s wants to be your friend\n", $incomingFriend{'name'});
 	message TF("Type 'friend accept' to be friend with %s, otherwise type 'friend reject'\n", $incomingFriend{'name'});
+	Plugins::callHook("friend_request", {
+		accountID => $incomingFriend{'accountID'},
+		charID => $incomingFriend{'charID'},
+		name => $incomingFriend{'name'}
+	});
 }
 
 # Notification about a friend removed (PACKET_ZC_DELETE_FRIENDS).


### PR DESCRIPTION
* added a new callHook "friend_request"
* plugin changes alertSound:
   - added audio response to friendship request
   - now the plugin works only on OS Windows

Example:
config.tx:
```
alertSound {
	eventList friend
	notInTown 1
	inLockOnly 0
	play plugins\alertSound\sounds\fuzz.wav
}
```
```
[2021.04.30 01:25:32.68] ya4ept wants to be your friend
[2021.04.30 01:25:32.68] Type 'friend accept' to be friend with ssdsdf, otherwise type 'friend reject'
[2021.04.30 01:25:32.69] Sound alert: friend
```