### PR TITLE
added new option "itemsGatherAuto_notInTown"

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -184,6 +184,7 @@ followBot 0
 itemsTakeAuto 2
 itemsTakeAuto_party 0
 itemsGatherAuto 2
+itemsGatherAuto_notInTown 0
 itemsMaxWeight 89
 itemsMaxWeight_sellOrStore 48
 itemsMaxNum_sellOrStore 99

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -3169,6 +3169,7 @@ sub processItemsAutoGather {
 	if ( (AI::isIdle || AI::action eq "follow"
 		|| ( AI::is("route", "mapRoute", "checkMonsters") && (!AI::args->{ID} || $config{'itemsGatherAuto'} >= 2)  && !$config{itemsTakeAuto_new}))
 	  && $config{'itemsGatherAuto'}
+	  && (!$config{itemsGatherAuto_notInTown} || !$field->isCity)
 	  && !$ai_v{sitAuto_forcedBySitCommand}
 	  && ($config{'itemsGatherAuto'} >= 2 || !ai_getAggressives())
 	  && percent_weight($char) < $config{'itemsMaxWeight'}

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -6711,6 +6711,7 @@ sub item_appeared {
 	# Take item as fast as possible
 	if (AI::state == AI::AUTO && pickupitems($item->{name}, $item->{nameID}) == 2
 	 && ($config{'itemsTakeAuto'} || $config{'itemsGatherAuto'})
+	 && (!$config{itemsGatherAuto_notInTown} || !$field->isCity)
 	 && (percent_weight($char) < $config{'itemsMaxWeight'})
 	 && distance($item->{pos}, $char->{pos_to}) <= 5) {
 		$messageSender->sendTake($args->{ID});


### PR DESCRIPTION
now we can ignore objects on the ground only in the city

```
itemsGatherAuto_notInTown <boolean>
If this option is set, disables item gathering when in a city.
```