### PR TITLE
alertSound fix

### DIFF
--- a/plugins/alertSound/README.txt
+++ b/plugins/alertSound/README.txt
@@ -1,4 +1,4 @@
-Version 11
+Version 12
 
 alertSound($event)
 $event: unique event name


### PR DESCRIPTION
- replaced the old "player" hook with new ones  (player_exist, player_connected)
- added a new hook "player_moved", now alertSound will trigger more often on the "player" condition (don't forget to use a timeout)

- fixed a bug when, under the condition "notParty 1", the hash "$char->{party}{users}" was filled with unnecessary values:
1) hash composition before meeting new player (the party consists of 2 players)
![image](https://user-images.githubusercontent.com/7117363/123561319-4c584000-d7b0-11eb-9977-876acc31adf9.png)

2) hash composition after player meeting (some third player appeared):
![image](https://user-images.githubusercontent.com/7117363/123561355-90e3db80-d7b0-11eb-835f-96ca257b8555.png)
