### PR TITLE
party_bug_autovivification

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2800,10 +2800,6 @@ sub processPartySkillUse {
 						# party member should be online, otherwise it's another character on the same account (not in party)
 						next unless $char->{party}{users}{$ID} && $char->{party}{users}{$ID}{online};
 					}
-
-					# if that intended to distinguish between party members and other characters on the same accounts, then it didn't work
-					my $player = $playersList->getByID($ID);
-					next if (($char->{party}{users}{$ID} && $char->{party}{users}{$ID}{name} ne $player->{name}) && !$config{"partySkill_$i"."_notPartyOnly"});
 				}
 
 				my $player = Actor::get($ID);

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2794,17 +2794,16 @@ sub processPartySkillUse {
 					next if ((!$char->{slaves} || !$char->{slaves}{$ID}) && !$config{"partySkill_$i"."_notPartyOnly"});
 					next if (($char->{slaves}{$ID} ne $slavesList->getByID($ID)) && !$config{"partySkill_$i"."_notPartyOnly"});
 				} elsif ($playersList->getByID($ID)) {
-					my $partyUsersID = $char->{party}{users}{$ID};
 					unless ($config{"partySkill_$i"."_notPartyOnly"}) {
-						next unless $char->{party}{joined} && $partyUsersID;
+						next unless $char->{party}{joined} && $char->{party}{users}{$ID};
 
 						# party member should be online, otherwise it's another character on the same account (not in party)
-						next unless $partyUsersID->{online};
+						next unless $char->{party}{users}{$ID} && $char->{party}{users}{$ID}{online};
 					}
 
 					# if that intended to distinguish between party members and other characters on the same accounts, then it didn't work
 					my $player = $playersList->getByID($ID);
-					next if (($partyUsersID->{name} ne $player->{name}) && !$config{"partySkill_$i"."_notPartyOnly"});
+					next if (($char->{party}{users}{$ID} && $char->{party}{users}{$ID}{name} ne $player->{name}) && !$config{"partySkill_$i"."_notPartyOnly"});
 				}
 
 				my $player = Actor::get($ID);

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -2794,16 +2794,17 @@ sub processPartySkillUse {
 					next if ((!$char->{slaves} || !$char->{slaves}{$ID}) && !$config{"partySkill_$i"."_notPartyOnly"});
 					next if (($char->{slaves}{$ID} ne $slavesList->getByID($ID)) && !$config{"partySkill_$i"."_notPartyOnly"});
 				} elsif ($playersList->getByID($ID)) {
+					my $partyUsersID = $char->{party}{users}{$ID};
 					unless ($config{"partySkill_$i"."_notPartyOnly"}) {
-						next unless $char->{party}{joined} && $char->{party}{users}{$ID};
+						next unless $char->{party}{joined} && $partyUsersID;
 
 						# party member should be online, otherwise it's another character on the same account (not in party)
-						next unless $char->{party}{users}{$ID}{online};
+						next unless $partyUsersID->{online};
 					}
 
 					# if that intended to distinguish between party members and other characters on the same accounts, then it didn't work
 					my $player = $playersList->getByID($ID);
-					next if (($char->{party}{users}{$ID}{name} ne $player->{name}) && !$config{"partySkill_$i"."_notPartyOnly"});
+					next if (($partyUsersID->{name} ne $player->{name}) && !$config{"partySkill_$i"."_notPartyOnly"});
 				}
 
 				my $player = Actor::get($ID);


### PR DESCRIPTION
The "onlyWhenSafe" condition did not work correctly.
Fixed a defect when the bot considered all the people around it to be members of its party (like #3449)

Steps to reproduce the problem:

1. Use config:
```lua
doCommand pl;;eval Log::warning "I'm safe \n" {
    timeout 3
    onlyWhenSafe 1
}
partySkill 142 {
    isSelfSkill 1
    dist 3
    timeout 5
    disabled 0
    notPartyOnly 1
}
```
2. find several other players

https://user-images.githubusercontent.com/7117363/123915275-00142800-d989-11eb-9724-96185e13bb44.mp4

