### PR TITLE
fixed "\C no longer supported in regex" for vRO_auth plugins when run openkore from perl 5.26+

### DIFF
--- a/plugins/!deps/URI/Escape.pm
+++ b/plugins/!deps/URI/Escape.pm
@@ -202,7 +202,14 @@ sub uri_unescape {
 }
 
 sub escape_char {
-    return join '', @URI::Escape::escapes{$_[0] =~ /(\C)/g};
+    # return join '', @URI::Escape::escapes{$_[0] =~ /(\C)/g};
+    my $dummy = substr($_[0], 0, 0);
+    if (utf8::is_utf8($_[0])) {
+        my $s = shift;
+        utf8::encode($s);
+        unshift(@_, $s);
+    }
+    return join '', @URI::Escape::escapes{split //, $_[0]};
 }
 
 1;

--- a/plugins/!deps/URI/Escape.pm
+++ b/plugins/!deps/URI/Escape.pm
@@ -1,5 +1,7 @@
 package URI::Escape;
+
 use strict;
+use warnings;
 
 =head1 NAME
 
@@ -135,12 +137,11 @@ it under the same terms as Perl itself.
 
 =cut
 
-require Exporter;
-our @ISA = qw(Exporter);
+use Exporter 5.57 'import';
 our %escapes;
 our @EXPORT = qw(uri_escape uri_unescape uri_escape_utf8);
 our @EXPORT_OK = qw(%escapes);
-our $VERSION = "3.30";
+our $VERSION = "3.31";
 
 use Carp ();
 
@@ -201,14 +202,18 @@ sub uri_unescape {
     $str;
 }
 
+# XXX FIXME escape_char is buggy as it assigns meaning to the string's storage format.
 sub escape_char {
-    # return join '', @URI::Escape::escapes{$_[0] =~ /(\C)/g};
+    # Old versions of utf8::is_utf8() didn't properly handle magical vars (e.g. $1).
+    # The following forces a fetch to occur beforehand.
     my $dummy = substr($_[0], 0, 0);
+
     if (utf8::is_utf8($_[0])) {
         my $s = shift;
         utf8::encode($s);
         unshift(@_, $s);
     }
+
     return join '', @URI::Escape::escapes{split //, $_[0]};
 }
 

--- a/tables/vRO/maps.txt
+++ b/tables/vRO/maps.txt
@@ -1,4 +1,4 @@
-//-- ÃÖÁ¾°»½Å ¿ÀÀü 11:13 2013-04-23 º»¼­¹ö
+//-- ÃƒÃ–ÃÂ¾Â°Â»Â½Ã… Â¿Ã€Ã€Ã¼ 11:13 2013-04-23 ÂºÂ»Â¼Â­Â¹Ã¶
 
 
 // Izlude tutorial map
@@ -859,7 +859,7 @@ morocc_mem.rsw#Memory of Morroc#
 payon_mem.rsw#Memory of Payon#
 moc_paraup.rsw#Inside of Paradise Group Building in Morroc 2nd floor#
 
-//°ø¼ºÀü TE º¹»ç¸Ê 
+//Â°Ã¸Â¼ÂºÃ€Ã¼ TE ÂºÂ¹Â»Ã§Â¸ÃŠ 
 te_prt_gld.rsw#Gloria#
 te_prtcas01.rsw#Gaebolg#
 te_prtcas02.rsw#Richard#
@@ -875,7 +875,7 @@ te_aldecas4.rsw#Roxie#
 te_aldecas5.rsw#Curly Sue#
 teg_dun02.rsw#Subterranean Guild Dungeon#
 
-//°í¼º¸Ş¸ğ¸®¾ó´øÀü
+//Â°Ã­Â¼ÂºÂ¸ÃÂ¸Ã°Â¸Â®Â¾Ã³Â´Ã¸Ã€Ã¼
 gl_cas02_.rsw#2nd Hall#
 gl_chyard_.rsw#Churchyard#
 2@gl_k.rsw#1st floor of Old Glast Heim Chivalry#
@@ -886,7 +886,7 @@ gl_chyard_.rsw#Churchyard#
 1@sara.rsw#Sara's Memory#
 dali.rsw#Dimensional Gap#
 
-//¿µ¿õÀÇÈçÀû
+//Â¿ÂµÂ¿ÃµÃ€Ã‡ÃˆÃ§Ã€Ã»
 dali02.rsw#Dimensional Gap#
 1@tnm1.rsw#Masin Tower Top floor#
 1@tnm2.rsw#Masin Tower Top floor#
@@ -898,7 +898,7 @@ dali02.rsw#Dimensional Gap#
 
 1@def01.rsw#Wave Dungeon - forest#
 
-//½Ã°èÅ¾³ªÀÌÆ®¸Ş¾î´øÀü
+//Â½ÃƒÂ°Ã¨Ã…Â¾Â³ÂªÃ€ÃŒÃ†Â®Â¸ÃÂ¾Ã®Â´Ã¸Ã€Ã¼
 c_tower2_.rsw#Clock Town of twisted time 2nd floor#
 c_tower3_.rsw#Clock Town of twisted time 3rd floor#
 
@@ -912,12 +912,12 @@ moro_cav.rsw#Flame cave#
 1@eom.rsw#Masin war#
 1@jtb.rsw#Jitterbug of Nightmare#
 
-// ¿µ¿õÀÇ ÈçÀû3
+// Â¿ÂµÂ¿ÃµÃ€Ã‡ ÃˆÃ§Ã€Ã»3
 1@glast.rsw#Old Glastheim#
 1@air1.rsw#Aircraft#
 1@air2.rsw#Aircraft#
 
-// ep15.1 ÆÇÅ¸½º¸¶°í¸®Ä«
+// ep15.1 Ã†Ã‡Ã…Â¸Â½ÂºÂ¸Â¶Â°Ã­Â¸Â®Ã„Â«
 ver_eju.rsw#Yuperos Eastern Ruin#
 ver_tunn.rsw#Verus Outter tunnel#
 verus04.rsw#Verus Findspot#
@@ -925,7 +925,7 @@ verus03.rsw#Verus Center Square#
 
 1@mcd.rsw#Charlston Factory#
 
-// ep15.2 ÆÇÅ¸½º¸¶°í¸®Ä«
+// ep15.2 Ã†Ã‡Ã…Â¸Â½ÂºÂ¸Â¶Â°Ã­Â¸Â®Ã„Â«
 verus01.rsw#Lab-OPTATIO#
 verus02.rsw#R&D-WISH#
 un_bk_q.rsw#Under Bunker#
@@ -945,9 +945,9 @@ conch_in.rsw#Inside the Kon-Kilina#
 lasa_in01.rsw#Inside Lasagna#
 lasa_dun_q.rsw#Dragon's Nest#
 
-//-- ÃÖÁ¾°»½Å ¿ÀÈÄ 3:58 2015-02-23 º»¼­¹ö
+//-- ÃƒÃ–ÃÂ¾Â°Â»Â½Ã… Â¿Ã€ÃˆÃ„ 3:58 2015-02-23 ÂºÂ»Â¼Â­Â¹Ã¶
 
-// ep16.1 ¿µ¿õÀ» À§ÇÑ ¿¬È¸ + ÇÁ·ĞÅ×¶ó ¸®´º¾ó
+// ep16.1 Â¿ÂµÂ¿ÃµÃ€Â» Ã€Â§Ã‡Ã‘ Â¿Â¬ÃˆÂ¸ + Ã‡ÃÂ·ÃÃ…Ã—Â¶Ã³ Â¸Â®Â´ÂºÂ¾Ã³
 1@mir.rsw#Ritual Room#
 2@mir.rsw#Ritual Room#
 1@sthb.rsw#Inside Air Portress#
@@ -971,10 +971,10 @@ rockmi2.rsw#Rock Ridge Mine#
 rockrdg1.rsw#Kiwawa Desert#
 rockrdg2.rsw#Kiwawa Desert#
 
-// »ıÃ¼´øÀü ½Å±Ô¸Ê ¿ÀÀü 2013-12-18
+// Â»Ã½ÃƒÂ¼Â´Ã¸Ã€Ã¼ Â½Ã…Â±Ã”Â¸ÃŠ Â¿Ã€Ã€Ã¼ 2013-12-18
 lhz_dun_n.rsw#The Bed of Honor#
 
-// 16.2 (ÃßÄ« ÄÁÅÙÃ÷ ¾øÀ½)
+// 16.2 (ÃƒÃŸÃ„Â« Ã„ÃÃ…Ã™ÃƒÃ· Â¾Ã¸Ã€Â½)
 1@slw.rsw#Werner_Laboratory central_room#
 1@swat.rsw#Heart_Hunter War_Base#
 que_swat.rsw#Heart_Hunter War_Base#

--- a/tables/vRO/maps.txt
+++ b/tables/vRO/maps.txt
@@ -1,4 +1,4 @@
-//-- ÃÖÁ¾°»½Å ¿ÀÀü 11:13 2013-04-23 º»¼­¹ö
+//-- 최종갱신 오전 11:13 2013-04-23 본서버
 
 
 // Izlude tutorial map
@@ -859,7 +859,7 @@ morocc_mem.rsw#Memory of Morroc#
 payon_mem.rsw#Memory of Payon#
 moc_paraup.rsw#Inside of Paradise Group Building in Morroc 2nd floor#
 
-//°ø¼ºÀü TE º¹»ç¸Ê 
+//공성전 TE 복사맵 
 te_prt_gld.rsw#Gloria#
 te_prtcas01.rsw#Gaebolg#
 te_prtcas02.rsw#Richard#
@@ -875,7 +875,7 @@ te_aldecas4.rsw#Roxie#
 te_aldecas5.rsw#Curly Sue#
 teg_dun02.rsw#Subterranean Guild Dungeon#
 
-//°í¼º¸Þ¸ð¸®¾ó´øÀü
+//고성메모리얼던전
 gl_cas02_.rsw#2nd Hall#
 gl_chyard_.rsw#Churchyard#
 2@gl_k.rsw#1st floor of Old Glast Heim Chivalry#
@@ -886,7 +886,7 @@ gl_chyard_.rsw#Churchyard#
 1@sara.rsw#Sara's Memory#
 dali.rsw#Dimensional Gap#
 
-//¿µ¿õÀÇÈçÀû
+//영웅의흔적
 dali02.rsw#Dimensional Gap#
 1@tnm1.rsw#Masin Tower Top floor#
 1@tnm2.rsw#Masin Tower Top floor#
@@ -898,7 +898,7 @@ dali02.rsw#Dimensional Gap#
 
 1@def01.rsw#Wave Dungeon - forest#
 
-//½Ã°èÅ¾³ªÀÌÆ®¸Þ¾î´øÀü
+//시계탑나이트메어던전
 c_tower2_.rsw#Clock Town of twisted time 2nd floor#
 c_tower3_.rsw#Clock Town of twisted time 3rd floor#
 
@@ -912,12 +912,12 @@ moro_cav.rsw#Flame cave#
 1@eom.rsw#Masin war#
 1@jtb.rsw#Jitterbug of Nightmare#
 
-// ¿µ¿õÀÇ ÈçÀû3
+// 영웅의 흔적3
 1@glast.rsw#Old Glastheim#
 1@air1.rsw#Aircraft#
 1@air2.rsw#Aircraft#
 
-// ep15.1 ÆÇÅ¸½º¸¶°í¸®Ä«
+// ep15.1 판타스마고리카
 ver_eju.rsw#Yuperos Eastern Ruin#
 ver_tunn.rsw#Verus Outter tunnel#
 verus04.rsw#Verus Findspot#
@@ -925,7 +925,7 @@ verus03.rsw#Verus Center Square#
 
 1@mcd.rsw#Charlston Factory#
 
-// ep15.2 ÆÇÅ¸½º¸¶°í¸®Ä«
+// ep15.2 판타스마고리카
 verus01.rsw#Lab-OPTATIO#
 verus02.rsw#R&D-WISH#
 un_bk_q.rsw#Under Bunker#
@@ -945,9 +945,9 @@ conch_in.rsw#Inside the Kon-Kilina#
 lasa_in01.rsw#Inside Lasagna#
 lasa_dun_q.rsw#Dragon's Nest#
 
-//-- ÃÖÁ¾°»½Å ¿ÀÈÄ 3:58 2015-02-23 º»¼­¹ö
+//-- 최종갱신 오후 3:58 2015-02-23 본서버
 
-// ep16.1 ¿µ¿õÀ» À§ÇÑ ¿¬È¸ + ÇÁ·ÐÅ×¶ó ¸®´º¾ó
+// ep16.1 영웅을 위한 연회 + 프론테라 리뉴얼
 1@mir.rsw#Ritual Room#
 2@mir.rsw#Ritual Room#
 1@sthb.rsw#Inside Air Portress#
@@ -971,10 +971,10 @@ rockmi2.rsw#Rock Ridge Mine#
 rockrdg1.rsw#Kiwawa Desert#
 rockrdg2.rsw#Kiwawa Desert#
 
-// »ýÃ¼´øÀü ½Å±Ô¸Ê ¿ÀÀü 2013-12-18
+// 생체던전 신규맵 오전 2013-12-18
 lhz_dun_n.rsw#The Bed of Honor#
 
-// 16.2 (ÃßÄ« ÄÁÅÙÃ÷ ¾øÀ½)
+// 16.2 (추카 컨텐츠 없음)
 1@slw.rsw#Werner_Laboratory central_room#
 1@swat.rsw#Heart_Hunter War_Base#
 que_swat.rsw#Heart_Hunter War_Base#


### PR DESCRIPTION
Minor:
- encoded UTF8 for vRO/maps.txt