### PR TITLE
fixed partyAuto

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -880,7 +880,6 @@ sub processPartyAuto {
 		} elsif ($config{partyAuto} == 2) {
 			message T("Auto-accepting party request\n");
 			# JOIN_ACCEPT
-			$messageSender->sendPartyJoin($incomingParty{'ID'}, 1);
 			if ($incomingParty{ACK} eq '02C7') {
 				$messageSender->sendPartyJoinRequestByNameReply($incomingParty{ID}, 1);
 			} else {

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -872,22 +872,12 @@ sub processPartyAuto {
 		if ($config{partyAuto} == 1) {
 			message T("Auto-denying party request\n");
 			# JOIN_REFUSE
-			if ($incomingParty{ACK} eq '02C7') {
-				$messageSender->sendPartyJoinRequestByNameReply($incomingParty{ID}, 0);
-			} else {
-				$messageSender->sendPartyJoin($incomingParty{ID}, 0);
-			}
+			Commands::run('party join 0');
 		} elsif ($config{partyAuto} == 2) {
 			message T("Auto-accepting party request\n");
 			# JOIN_ACCEPT
-			if ($incomingParty{ACK} eq '02C7') {
-				$messageSender->sendPartyJoinRequestByNameReply($incomingParty{ID}, 1);
-			} else {
-				$messageSender->sendPartyJoin($incomingParty{ID}, 1);
-			}
-		}
+			Commands::run('party join 1');		}
 		$timeout{'ai_partyAuto'}{'time'} = time;
-		undef %incomingParty;
 	}
 }
 


### PR DESCRIPTION
Now if "partyAuto 2" is configured in the config, then when requesting a party, the bot sends two packets to the server:
```perl
        } elsif ($config{partyAuto} == 2) {
            message T("Auto-accepting party request\n");
            # JOIN_ACCEPT
1>>>           $messageSender->sendPartyJoin($incomingParty{'ID'}, 1);
            if ($incomingParty{ACK} eq '02C7') {
2>>>            $messageSender->sendPartyJoinRequestByNameReply($incomingParty{ID}, 1);
            } else {
                $messageSender->sendPartyJoin($incomingParty{ID}, 1);
            }
        }
```
In some cases, two different packets are sent to the server:
```css
<< Received packet:      02C6 - Party Invite by Name [30 bytes]   2021.07.20 01:59:31
  0>  C6 02 B1 3C 00 00 7A 61    73 64 61 73 64 00 00 00    ...<..zasdasd...
 16>  00 00 00 00 00 00 00 00    00 00 00 00 00 00          ..............
Incoming Request to join party 'zasdasd'
Auto-accepting party request
======================================================================================
>> Sent packet: 00FF  [Party Join] [10 bytes]   2021.07.20 01:59:31
  0>  FF 00 B1 3C 00 00 01 00    00 00                      ...<......
======================================================================================
>> Sent packet: 02C7  [Party Join] [7 bytes]   2021.07.20 01:59:31
  0>  C7 02 B1 3C 00 00 01                                  ...<...
```

Because of this, the player who threw the invitation to the bot sees the following:
![image](https://user-images.githubusercontent.com/7117363/126391661-56f02aa7-d054-4c8d-908a-ecbd3d1761e6.png)
Job: Poring
Lvl: 46874