### PR TITLE
code cleanup

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -3412,7 +3412,8 @@ sub cmdGuild {
 
 			$job   = $jobs_lut{$guild{member}[$i]{jobID}};
 			$lvl   = $guild{member}[$i]{lv};
-			$title = $guild{member}[$i]{title};
+			$title = $guild{positions}[ $guild{member}[$i]{position} ]{title};
+
  			# Translation Comment: Guild member online
 			$online = $guild{member}[$i]{online} ? T("Yes") : T("No");
 			$ID = unpack("V",$guild{member}[$i]{ID});

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -6204,8 +6204,6 @@ sub guild_members_list {
 	for (my $i = 0; $i < length($args->{member_list}); $i += $guild_member_info->{len}) {
 		@{$guild{member}[$index]}{@{$guild_member_info->{keys}}} = unpack($guild_member_info->{types}, substr($args->{member_list}, $i, $guild_member_info->{len}));
 
-		# TODO: we shouldn't store the guildtitle of a guildmember both in $guild{positions} and $guild{member}, instead we should just store the rank index of the guildmember and get the title from the $guild{positions}
-		$guild{member}[$index]{title} = $guild{positions}[$guild{member}[$index]{position}]{title};
 		$guild{member}[$index]{name} = bytesToString($guild{member}[$index]{name}) if ($guild{member}[$index]{name});
 		$messageSender->sendGetCharacterName($guild{member}[$index]{charID}) if ($args->{switch} eq "0AA5");
 		$index++;
@@ -6312,9 +6310,8 @@ sub guild_update_member_position {
 		@{$position_info}{@{$guild_position_info->{keys}}} = unpack($guild_position_info->{types}, substr($args->{member_list}, $i, $guild_position_info->{len}));
 		foreach my $guildmember (@{$guild{member}}) {
 			if ($guildmember->{charID} eq $position_info->{charID}) {
-				message TF("Guild Member (%s) has the title changed from %s to %s\n",$guildmember->{name},$guildmember->{title}, $guild{positions}[$position_info->{position}]{title});
+				message TF("Guild Member (%s) has the title changed from %s to %s\n",$guildmember->{name}, $guild{positions}[ $guildmember->{position} ]{title}, $guild{positions}[$position_info->{position}]{title});
 				$guildmember->{position} = $position_info->{position};
-				$guildmember->{title} = $guild{positions}[$position_info->{position}]{title};
 				last;
 			}
 		}
@@ -6511,7 +6508,6 @@ sub guild_member_add {
 		foreach (@{$args->{KEYS}}) {
 			$guild{member}[$index]{$_} = $_;
 		}
-		$guild{member}[$index]{title} = $guild{positions}[$guild{member}[$index]{position}]{title};
 		$guild{member}[$index]{name} = bytesToString($guild{member}[$index]{name}) if ($guild{member}[$index]{name});
 	}
 


### PR DESCRIPTION
removed the extra hash element: `$guild{member}[$i]{title}`
instead one should use: `$guild{positions}[ $guild{member}[$i]{position} ]{title}`

> we shouldn't store the guildtitle of a guildmember both in $guild{positions} and $guild{member}, instead we should just store the rank index of the guildmember and get the title from the $guild{positions}


`eval Log::warning Data::Dumper::Dumper \%guild` before:
```
$VAR1 = {
          'name' => 'koreopen',
...
         'positions' => [
                           {
                             'gstorage' => 1,
                             'title' => 'Master',
                             'invite' => 1,
                             'feeEXP' => 0,
                             'punish' => 1
                           },
...
                         ],
          'member' => [
                        {
 ...
                          'position' => 0,
                          'title' => 'Master',
...
                        },
```

`eval Log::warning Data::Dumper::Dumper \%guild` after:
```
$VAR1 = {
          'name' => 'koreopen',
...
         'positions' => [
                           {
                             'gstorage' => 1,
                             'title' => 'Master',
                             'invite' => 1,
                             'feeEXP' => 0,
                             'punish' => 1
                           },
...
                         ],
          'member' => [
                        {
 ...
                        'position' => 0,
...
                        },

```