### PR TITLE
rodex fixes

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -7131,7 +7131,7 @@ sub cmdRodex {
 		}
 		my $msg .= center(" " . "Rodex Mail List" . " ", 79, '-') . "\n";
 		my $index = 0;
-		foreach my $mail_id (keys %{$rodexList}) {
+		foreach my $mail_id (keys %{$rodexList->{mails}}) {
 			my $mail = $rodexList->{mails}{$mail_id};
 			$msg .= swrite(sprintf("\@%s \@%s \@%s \@%s \@%s", ('>'x2), ('<'x8), ('<'x9), ('<'x28), ('<'x28)), [$index, $mail_id, $mail->{isRead} ? "read" : "not read", "From: ".$mail->{sender}, "Title: ".$mail->{title}]);
 			$index++;

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -7309,6 +7309,9 @@ sub cmdRodex {
 			error T("Syntax Error in function 'rodex settitle' (Set title of rodex mail)\n" .
 				"Usage: rodex settitle <title>\n");
 			return;
+		} elsif (length($arg2) < 4) {
+			error $msgTable[2597] ? $msgTable[2597] . "\n" : T("The title must be 4 to 24 characters long\n");
+			return;
 		}
 
 		if (exists $rodexWrite->{title}) {

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -8203,9 +8203,9 @@ sub rodex_mail_list {
 
 	if ($args->{switch} eq '0B5F') {
 		$mail_info = {
-			len => 67,
-			type => 'C V2 C2 Z24 V v Z24 v',
-			keys => [qw(openType mailID1 mailID2 isRead type sender expireDateTime Titlelength sender2 Titlelength2)],
+			len => 45,
+			types => 'C V2 C2 Z24 V v x4',
+			keys => [qw(openType mailID1 mailID2 isRead type sender expireDateTime Titlelength)],
 		};
 
 	} elsif ($args->{switch} eq '0AC2') {


### PR DESCRIPTION
- fixed package `0B5F` (rodex_mail_list)
- fixed "rodex list" command

before:
```
rodex open
-------------------------------------------------- Rodex Mail Page  ---------------------------------------------------
0    From:  zxcv35                    Read:   Yes  ID:  1925400   Title:          <MSG>3455</       Content: Text
1    From:  齎 �                       Read:   No   ID:  4081491   Title:                            Content: Text, Item
-----------------------------------------------------------------------------------------------------------------------

rodex list
------------------------------- Rodex Mail List -------------------------------
  0 mails     not read   From:                         Title: 
  1 last_page not read   From:                         Title: 
  2 current_p not read   From:                         Title: 
-------------------------------------------------------------------------------
```
after
```
rodex open
-------------------------------------------------- Rodex Mail Page  ---------------------------------------------------
0    From:  zxcv35                    Read:   Yes  ID:  1925400   Title:  tttitleeeeeeeeeeee        Content: Text
1    From:  GM                        Read:   Yes  ID:  1919470   Title:  第9天打卡獎勵已發送                Content: Text, Item
-----------------------------------------------------------------------------------------------------------------------

rodex list
------------------------------- Rodex Mail List -------------------------------
  0 1925400   read       From: zxcv35                  Title: tttitleeeeeeeeeeee
  1 1919470   read       From: GM                      Title: 第9天打卡獎勵已發送
-------------------------------------------------------------------------------
```
tested on twRO