### PR TITLE
Fix memory write violation in Benchmark.xs

### DIFF
--- a/src/auto/XSTools/utils/perl/Benchmark.xs
+++ b/src/auto/XSTools/utils/perl/Benchmark.xs
@@ -55,7 +55,7 @@ public:
 			delete *it;
 		}
 		for (it2 = domains.begin(); it2 != domains.end(); it2++) {
-			free(*it2);
+			delete *it2;
 		}
 	}
 


### PR DESCRIPTION
Debugging using Visual Studio 2019 bring me to this line when exiting Openkore.