### PR TITLE
sendCryptKeys fix

### DIFF
--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -45,7 +45,7 @@ sub new {
 	my $self = $class->SUPER::new( @_ );
 
 	my $cryptKeys = $masterServer->{sendCryptKeys};
-	if ( $cryptKeys && $cryptKeys =~ /^(0x[0-9A-F]{8})\s*,\s*(0x[0-9A-F]{8})\s*,\s*(0x[0-9A-F]{8})$/ ) {
+	if ( $cryptKeys && $cryptKeys =~ /^(0x[0-9A-Fa-f]{8})\s*,\s*(0x[0-9A-Fa-f]{8})\s*,\s*(0x[0-9A-Fa-f]{8})$/ ) {
 		$self->cryptKeys( hex $1, hex $2, hex $3 );
 	}
 


### PR DESCRIPTION
Added lowercase characters to the verification template.

Encryption keys in the [Hercules source](https://github.com/HerculesWS/Hercules/blob/stable/src/map/packets_keys_main.h) are low case, but OpenKore only supports upper case.
This PR fixes this behavior.