### PR TITLE
Reset ai_attack_failed_give_up on attack success

### DIFF
--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -387,8 +387,10 @@ sub main {
 
 	Benchmark::end("ai_attack (part 1.2)") if DEBUG;
 	Benchmark::end("ai_attack (part 1)") if DEBUG;
-
-
+	
+	if (defined $args->{attackMethod}{type} && exists $args->{ai_attack_failed_give_up} && defined $args->{ai_attack_failed_give_up}{time}) {
+		delete $args->{ai_attack_failed_give_up}{time};
+	}
 
 	if ($char->{sitting}) {
 		ai_setSuspend(0);


### PR DESCRIPTION
If openkore fails to attack a mob when all his skills are on timeout after 6s it will drop the target, however this timeout won't reset after another skill is cast.
This fixes that.