### PR TITLE
Add missing casting key deletion

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -11534,6 +11534,8 @@ sub skill_use_failed {
 	} else {
 		$errorMessage = T('Unknown error');
 	}
+	
+	delete $char->{casting};
 
 	warning TF("Skill %s failed: %s (error number %s)\n", Skill->new(idn => $skillID)->getName(), $errorMessage, $type), "skill";
 	Plugins::callHook('packet_skillfail', {

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -1348,6 +1348,8 @@ sub skill_use_location {
 	my $source = Actor::get($sourceID);
 	my $skillName = Skill->new(idn => $skillID)->getName();
 	my $disp = skillUseLocation_string($source, $skillName, $args);
+	
+	delete $source->{casting};
 
 	# Print skill use message
 	my $domain = ($sourceID eq $accountID) ? "selfSkill" : "skill";

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -1323,6 +1323,8 @@ sub skill_use_location {
 	my $source = Actor::get($sourceID);
 	my $skillName = Skill->new(idn => $skillID)->getName();
 	my $disp = skillUseLocation_string($source, $skillName, $args);
+	
+	delete $source->{casting};
 
 	# Print skill use message
 	my $domain = ($sourceID eq $accountID) ? "selfSkill" : "skill";


### PR DESCRIPTION
Currently skill location use and skill failed do not delete the {casting} key.

This adds the deletion.