### PR TITLE
add attackAuto_considerDamagedAggressive

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -71,7 +71,7 @@ attackAuto_notInTown 1
 attackAuto_notWhile_storageAuto 1
 attackAuto_notWhile_buyAuto 1
 attackAuto_notWhile_sellAuto 1
-attackAuto_considerDamagedAggresive 0
+attackAuto_considerDamagedAggressive 0
 attackDistance 1
 attackDistanceAuto 0
 attackMaxDistance 1

--- a/control/config.txt
+++ b/control/config.txt
@@ -71,6 +71,7 @@ attackAuto_notInTown 1
 attackAuto_notWhile_storageAuto 1
 attackAuto_notWhile_buyAuto 1
 attackAuto_notWhile_sellAuto 1
+attackAuto_considerDamagedAggresive 0
 attackDistance 1
 attackDistanceAuto 0
 attackMaxDistance 1

--- a/src/AI.pm
+++ b/src/AI.pm
@@ -318,11 +318,12 @@ sub ai_getAggressives {
 		next if (!timeOut($monster->{attack_failedLOS}, $timeout{ai_attack_failedLOS}{timeout}));
 		next if (!timeOut($monster->{attack_failed}, $timeout{ai_attack_unfail}{timeout}));
 
-		if (($type && ($control->{attack_auto} == 2)) ||
+		if (
+			($type && ($control->{attack_auto} == 2)) ||
 			(($monster->{dmgToYou} || $monster->{missedYou}) && Misc::checkMonsterCleanness($ID)) ||
-			($party && ($monster->{dmgToParty} || $monster->{missedToParty} || $monster->{dmgFromParty})) &&
-			timeOut($monster->{attack_failed}, $timeout{ai_attack_unfail}{timeout}))
-		{
+			($config{"attackAuto_considerDamagedAggresive"} && $monster->{dmgFromYou} > 0 && Misc::checkMonsterCleanness($ID)) ||
+			($party && ($monster->{dmgToParty} || $monster->{missedToParty} || $monster->{dmgFromParty}))
+		) {
 			# Continuing, check whether the forced Agro is really a clean monster;
 			next if (($type && $control->{attack_auto} == 2) && !Misc::checkMonsterCleanness($ID));
 

--- a/src/AI.pm
+++ b/src/AI.pm
@@ -321,7 +321,7 @@ sub ai_getAggressives {
 		if (
 			($type && ($control->{attack_auto} == 2)) ||
 			(($monster->{dmgToYou} || $monster->{missedYou}) && Misc::checkMonsterCleanness($ID)) ||
-			($config{"attackAuto_considerDamagedAggresive"} && $monster->{dmgFromYou} > 0 && Misc::checkMonsterCleanness($ID)) ||
+			($config{"attackAuto_considerDamagedAggressive"} && $monster->{dmgFromYou} > 0 && Misc::checkMonsterCleanness($ID)) ||
 			($party && ($monster->{dmgToParty} || $monster->{missedToParty} || $monster->{dmgFromParty}))
 		) {
 			# Continuing, check whether the forced Agro is really a clean monster;


### PR DESCRIPTION
Currently if the bot has damaged a monster but the monster has not yet attacked the bot it won't be considered as aggresive.

This new config key when set to 1 makes openkore consider all monster in the screen who have been damaged by the bot as aggresives

Also deleted the duplicate timeout attack_failed -> ai_attack_unfail check