### PR TITLE
Move run from target to meeting position

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -63,7 +63,6 @@ allowedMaps
 allowedMaps_reaction 1
 
 attackAuto 2
-attackBeyondMaxDistance_waitForAgressive 1
 attackAuto_party 1
 attackAuto_onlyWhenSafe 0
 attackAuto_followTarget 1
@@ -72,6 +71,7 @@ attackAuto_notInTown 1
 attackAuto_notWhile_storageAuto 1
 attackAuto_notWhile_buyAuto 1
 attackAuto_notWhile_sellAuto 1
+attackBeyondMaxDistance_waitForAgressive 1
 attackDistance 1
 attackDistanceAuto 0
 attackMaxDistance 1
@@ -224,7 +224,6 @@ runFromTarget 0
 runFromTarget_inAdvance 0
 runFromTarget_dist 5
 runFromTarget_minStep 7
-runFromTarget_maxStep 11
 runFromTarget_maxPathDistance 13
 
 saveMap
@@ -398,8 +397,7 @@ mercenary_runFromTarget 0
 mercenary_runFromTarget_inAdvance 0
 mercenary_runFromTarget_dist 5
 mercenary_runFromTarget_minStep 7
-mercenary_runFromTarget_maxStep 11
-mercenary_runFromTarget_maxPathDistance 13
+mercenary_runFromTarget_maxPathDistance 20
 
 mercenary_followDistanceMax 12
 mercenary_followDistanceMin 3
@@ -454,8 +452,7 @@ homunculus_route_randomWalk_waitMinDistance 0
 homunculus_runFromTarget 0
 homunculus_runFromTarget_dist 5
 homunculus_runFromTarget_minStep 7
-homunculus_runFromTarget_maxStep 11
-homunculus_runFromTarget_maxPathDistance 13
+homunculus_runFromTarget_maxPathDistance 20
 
 homunculus_followDistanceMax 12
 homunculus_followDistanceMin 3

--- a/control/config.txt
+++ b/control/config.txt
@@ -63,6 +63,7 @@ allowedMaps
 allowedMaps_reaction 1
 
 attackAuto 2
+attackBeyondMaxDistance_waitForAgressive 1
 attackAuto_party 1
 attackAuto_onlyWhenSafe 0
 attackAuto_followTarget 1

--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -453,8 +453,17 @@ sub main {
 		$config{"attackBeyondMaxDistance_waitForAgressive"} &&
 		$target->{dmgFromYou} > 0
 	) {
-		warning TF("[Out of Range - Waiting] %s (%d %d), target %s (%d %d), distance %d, maxDistance %d, dmgFromYou %d.\n", $char, $realMyPos->{x}, $realMyPos->{y}, $target, $realMonsterPos->{x}, $realMonsterPos->{y}, $realMonsterDist, $args->{attackMethod}{maxDistance}, $target->{dmgFromYou}), 'ai_attack';
-
+		$args->{ai_attack_failed_waitForAgressive_give_up}{timeout} = 6 if !$args->{ai_attack_failed_waitForAgressive_give_up}{timeout};
+		$args->{ai_attack_failed_waitForAgressive_give_up}{time} = time if !$args->{ai_attack_failed_waitForAgressive_give_up}{time};
+		
+		if (timeOut($args->{ai_attack_failed_waitForAgressive_give_up})) {
+			delete $args->{ai_attack_failed_waitForAgressive_give_up}{time};
+			message T("[Out of Range] Waited too long for target to get closer, dropping target\n"), "ai_attack";
+			giveUp();
+		} else {
+			warning TF("[Out of Range - Waiting] %s (%d %d), target %s (%d %d), distance %d, maxDistance %d, dmgFromYou %d.\n", $char, $realMyPos->{x}, $realMyPos->{y}, $target, $realMonsterPos->{x}, $realMonsterPos->{y}, $realMonsterDist, $args->{attackMethod}{maxDistance}, $target->{dmgFromYou}), 'ai_attack';
+		}
+		
 	} elsif (
 		# We are out of range
 		($args->{attackMethod}{maxDistance} == 1 && !canReachMeleeAttack($realMyPos, $realMonsterPos)) ||

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -484,7 +484,7 @@ sub processAttack {
 			}
 
 		} elsif ($config{$slave->{configPrefix}.'runFromTarget'} && ($realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_dist'} || $hitYou)) {
-			my $cell = get_kite_position($slave, 2, $target);
+			my $cell = meetingPosition($slave, 1, $target, $args->{attackMethod}{maxDistance}, 1);
 			if ($cell) {
 				debug TF("%s kiteing from (%d %d) to (%d %d), mob at (%d %d).\n", $slave, $realMyPos->{x}, $realMyPos->{y}, $cell->{x}, $cell->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'slave';
 				$slave->args->{avoiding} = 1;
@@ -621,7 +621,7 @@ sub processAttack {
 						$slave->sendMove ($realMyPos->{x},$realMyPos->{y});
 						$slave->sendAttack ($ID);
 						if ($config{$slave->{configPrefix}.'runFromTarget'} && $config{$slave->{configPrefix}.'runFromTarget_inAdvance'} && $realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_minStep'}) {
-							my $cell = get_kite_position($slave, 1, $target);
+							my $cell = meetingPosition($slave, 1, $target, $args->{attackMethod}{maxDistance}, 1);
 							if ($cell) {
 								debug TF("%s kiting in advance (%d %d) to (%d %d), mob at (%d %d).\n", $slave, $realMyPos->{x}, $realMyPos->{y}, $cell->{x}, $cell->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'ai_attack';
 								$args->{avoiding} = 1;
@@ -637,7 +637,7 @@ sub processAttack {
 					if (timeOut($timeout{$slave->{ai_attack_timeout}})) {
 						$slave->sendAttack ($ID);
 						if ($config{$slave->{configPrefix}.'runFromTarget'} && $config{$slave->{configPrefix}.'runFromTarget_inAdvance'} && $realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_minStep'}) {
-							my $cell = get_kite_position($slave, 1, $target);
+							my $cell = meetingPosition($slave, 1, $target, $args->{attackMethod}{maxDistance}, 1);
 							if ($cell) {
 								debug TF("%s kiting in advance (%d %d) to (%d %d), mob at (%d %d).\n", $slave, $realMyPos->{x}, $realMyPos->{y}, $cell->{x}, $cell->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'ai_attack';
 								$args->{avoiding} = 1;

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -484,7 +484,7 @@ sub processAttack {
 			}
 
 		} elsif ($config{$slave->{configPrefix}.'runFromTarget'} && ($realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_dist'} || $hitYou)) {
-			my $cell = meetingPosition($slave, 1, $target, $args->{attackMethod}{maxDistance}, 1);
+			my $cell = meetingPosition($slave, 2, $target, $args->{attackMethod}{maxDistance}, 1);
 			if ($cell) {
 				debug TF("%s kiteing from (%d %d) to (%d %d), mob at (%d %d).\n", $slave, $realMyPos->{x}, $realMyPos->{y}, $cell->{x}, $cell->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'slave';
 				$slave->args->{avoiding} = 1;
@@ -621,7 +621,7 @@ sub processAttack {
 						$slave->sendMove ($realMyPos->{x},$realMyPos->{y});
 						$slave->sendAttack ($ID);
 						if ($config{$slave->{configPrefix}.'runFromTarget'} && $config{$slave->{configPrefix}.'runFromTarget_inAdvance'} && $realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_minStep'}) {
-							my $cell = meetingPosition($slave, 1, $target, $args->{attackMethod}{maxDistance}, 1);
+							my $cell = meetingPosition($slave, 2, $target, $args->{attackMethod}{maxDistance}, 1);
 							if ($cell) {
 								debug TF("%s kiting in advance (%d %d) to (%d %d), mob at (%d %d).\n", $slave, $realMyPos->{x}, $realMyPos->{y}, $cell->{x}, $cell->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'ai_attack';
 								$args->{avoiding} = 1;
@@ -637,7 +637,7 @@ sub processAttack {
 					if (timeOut($timeout{$slave->{ai_attack_timeout}})) {
 						$slave->sendAttack ($ID);
 						if ($config{$slave->{configPrefix}.'runFromTarget'} && $config{$slave->{configPrefix}.'runFromTarget_inAdvance'} && $realMonsterDist < $config{$slave->{configPrefix}.'runFromTarget_minStep'}) {
-							my $cell = meetingPosition($slave, 1, $target, $args->{attackMethod}{maxDistance}, 1);
+							my $cell = meetingPosition($slave, 2, $target, $args->{attackMethod}{maxDistance}, 1);
 							if ($cell) {
 								debug TF("%s kiting in advance (%d %d) to (%d %d), mob at (%d %d).\n", $slave, $realMyPos->{x}, $realMyPos->{y}, $cell->{x}, $cell->{y}, $realMonsterPos->{x}, $realMonsterPos->{y}), 'ai_attack';
 								$args->{avoiding} = 1;


### PR DESCRIPTION
Removes get_kite_position, uses meetingPosition instead.

Also changes another attacking behavior for the situation that a ranged character has already damaged its target but curently is out range 
Right now openkore will use meetingposition to get closer at attackMaxDist range
But if we already damaged the mob that means it is coming at us
So more often than not we will get closer to the mob while it is getting closer to us
This adds a config key that if '1' will make the bot wait for the target instad of going to it.

Video showcasing the branch: https://www.youtube.com/watch?v=ig9J9NiGgp8