### PR TITLE
fixed party user

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -8022,7 +8022,7 @@ sub party_join {
 			$char->{party}{joined} = 1;
 			Plugins::callHook('packet_partyJoin', { partyName => bytesToString($info->{name}) });
 		} else {
-			message TF("%s joined your party '%s'\n", $info->{user}, bytesToString($info->{name})), undef, 1;
+			message TF("%s joined your party '%s'\n", bytesToString($info->{user}), bytesToString($info->{name})), undef, 1;
 		}
 	}
 


### PR DESCRIPTION
- added support for non-english names

before:
`êàðàì1 joined your party 'bg1'`

after:
`карам1 joined your party 'bg1'`