### PR TITLE
Clean route_tryToGuessMissingPortalByDistance

### DIFF
--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -323,55 +323,39 @@ sub iterate {
 				$self->initMapCalculator();	# redo MAP router
 				
 			} else {
-				if (!exists $self->{guess_portal}) {
-					my $closest_portal_binID;
-					my $closest_portal_dist;
-					for my $portal (@$portalsList) {
-						my $dist = blockDistance($self->{actor}{pos_to}, $portal->{pos});
-						next if (exists $self->{guess_skip} && exists $self->{guess_skip}{$portal->{binID}});
-						next if (defined $closest_portal_dist && $closest_portal_dist < $dist);
-						next if (portalExists($field->baseName, $portal->{pos})); # Only guess unknown portals
-						$closest_portal_binID = $portal->{binID};
-						$closest_portal_dist = $dist;
-					}
-					if (defined $closest_portal_binID) {
-						$self->{guess_portal} = $portalsList->get($closest_portal_binID);
-						warning TF("Guessing our desired portal to be  %s (%s,%s).\n", $field->baseName, $self->{guess_portal}{pos}{x}, $self->{guess_portal}{pos}{y}), "route";
-					} else {
-						my $missed = {};
-						$missed->{time} = time;
-						$missed->{name} = "$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}";
-						$missed->{portal} = $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
-						push(@portals_lut_missed, $missed);
-						delete $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
-						warning TF("Unable to use portal at %s (%s,%s).\n", $field->baseName, $self->{mapSolution}[0]{pos}{x}, $self->{mapSolution}[0]{pos}{y}), "route";
-						delete $self->{missing_portal};
-						$self->initMapCalculator();	# redo MAP router
-					}
+				my $closest_portal_binID;
+				my $closest_portal_dist;
+				for my $portal (@$portalsList) {
+					my $dist = blockDistance($self->{mapSolution}[0]{pos}, $portal->{pos});
+					next if (defined $closest_portal_dist && $closest_portal_dist < $dist);
+					next if (portalExists($field->baseName, $portal->{pos})); # Only guess unknown portals
+					next unless ( Task::Route->getRoute( \@solution, $field, $self->{actor}{pos_to}, $self->{guess_portal}{pos} ) );
+					$closest_portal_binID = $portal->{binID};
+					$closest_portal_dist = $dist;
+				}
+				
+				if (!defined $closest_portal_binID) {
+					my $missed = {};
+					$missed->{time} = time;
+					$missed->{name} = "$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}";
+					$missed->{portal} = $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
+					push(@portals_lut_missed, $missed);
+					delete $portals_lut{"$self->{mapSolution}[0]{map} $self->{mapSolution}[0]{pos}{x} $self->{mapSolution}[0]{pos}{y}"};
+					warning TF("Unable to use portal at %s (%s,%s).\n", $field->baseName, $self->{mapSolution}[0]{pos}{x}, $self->{mapSolution}[0]{pos}{y}), "route";
+					delete $self->{missing_portal};
+					$self->initMapCalculator();	# redo MAP router
 					
 				} else {
-					# Portal is reachable
-					if ( Task::Route->getRoute( \@solution, $field, $self->{actor}{pos_to}, $self->{guess_portal}{pos} ) ) {
-						my $task = new Task::Route(
-							actor => $self->{actor},
-							x => $self->{guess_portal}{pos}{x},
-							y => $self->{guess_portal}{pos}{y},
-							field => $field,
-							maxTime => $self->{maxTime},
-							avoidWalls => $self->{avoidWalls},
-							solution => \@solution,
-							isRandomWalk => $self->{isRandomWalk},
-							isSlaveRescue => $self->{isSlaveRescue},
-							LOSSubRoute => $self->{LOSSubRoute},
-							meetingSubRoute => $self->{meetingSubRoute}
-						);
-						$self->setSubtask($task);
-						
-						return;
-					} else {
-						$self->{guess_skip}{$self->{guess_portal}->{binID}} = 1;
-						delete $self->{guess_portal};
-					}
+					$self->{guess_portal} = $portalsList->get($closest_portal_binID);
+					warning TF("Guessing our desired portal to be  %s (%s,%s).\n", $field->baseName, $self->{guess_portal}{pos}{x}, $self->{guess_portal}{pos}{y}), "route";
+					my %params = (
+						field => $field,
+						solution => \@solution
+					);
+					$params{$_} = $self->{guess_portal}{pos}{$_} for qw(x y);
+					$params{$_} = $self->{$_} for qw(actor maxTime avoidWalls isRandomWalk isSlaveRescue LOSSubRoute meetingSubRoute);
+					my $task = new Task::Route(%params);
+					$self->setSubtask($task);
 				}
 			}
 			


### PR DESCRIPTION
Currently for some reason (I made it so blame myself I guess) route_tryToGuessMissingPortalByDistance will try to guess the closes portal to the player instead of the closest to the original portal, also it tests Route->getRoute in another loop and if it fails it guesses a new portal in even another loop.

This makes it so it guesses the closest to the original destination portal and does the Route->getRoute check at the same time.

Also now only use route_tryToGuessMissingPortalByDistance when there isn't another near known portal to the same destination
