### PR TITLE
Add a few hooks

### DIFF
--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -1241,6 +1241,7 @@ sub cmdAttendance {
 sub cmdAutoBuy {
 	message T("Initiating auto-buy.\n");
 	AI::queue("buyAuto");
+	Plugins::callHook('AI_buy_auto_queued');
 }
 
 sub cmdAutoSell {
@@ -1269,6 +1270,7 @@ sub cmdAutoSell {
 	} elsif (!$arg) {
 		message T("Initiating auto-sell.\n");
 		AI::queue("sellAuto");
+		Plugins::callHook('AI_sell_auto_queued');
 	}
 }
 
@@ -1276,6 +1278,7 @@ sub cmdAutoStorage {
 	message T("Initiating auto-storage.\n");
 	if (ai_canOpenStorage()) {
 		AI::queue("storageAuto");
+		Plugins::callHook('AI_storage_auto_queued');
 	} else {
 		error T("Error in function 'autostorage' (Automatic storage of items)\n" .
 		"You cannot use the Storage Service. Very low level of basic skills or not enough zeny.\n");

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -4838,7 +4838,11 @@ sub npc_chat {
 	chatLog("npc", "$position $message\n") if ($config{logChat});
 	message TF("%s%s\n", $dist, $message), "npcchat";
 
-	# TODO hook
+	Plugins::callHook('npc_chat', {
+		actor => $actor,
+		ID => $args->{ID},
+		message => $message,
+	});
 }
 
 # 018d <packet len>.W { <name id>.W { <material id>.W }*3 }*
@@ -7578,6 +7582,7 @@ sub buy_result {
 	if (AI::is("buyAuto")) {
 		AI::args->{recv_buy_packet} = 1;
 	}
+	Plugins::callHook('buy_result', {fail => $args->{fail}});
 }
 
 # Presents list of items, that can be bought in an NPC MARKET shop (PACKET_ZC_NPC_MARKET_OPEN).


### PR DESCRIPTION
Hooks added for npc_chat, storage, buyauto and sellauto start/queue and buy_result.

I personally use these hooks to:
1: Clean AI queue of unwanted stuff when storage starts.
2: Block storageauto and buyauto from starting when eventMacro in in queue
3: Hook a few server-side messages that use npc_chat
4: Log items bought from buy_result