### PR TITLE
Rework AI clear

### DIFF
--- a/src/AI.pm
+++ b/src/AI.pm
@@ -126,25 +126,30 @@ sub queue {
 sub clear {
 	my $total = scalar @_;
 	
+	# If no arg was given clear all AI queue
 	if ($total == 0) {
 		undef @ai_seq;
 		undef @ai_seq_args;
 		undef %ai_v;
-		
+	
+	# If 1 arg was given find it in the queue
 	} elsif ($total == 1) {
-		my $wanted = shift;
-		my $found_i;
-		foreach my $seq_i (0..$#ai_seq) {
-			if ($wanted eq $ai_seq[$seq_i]) {
-				$found_i = $seq_i;
-				last;
-			}
+		my $wanted_action = shift;
+		my $seq_index;
+		foreach my $i (0..$#ai_seq) {
+			next unless ($ai_seq[$i] eq $wanted_action);
+			$seq_index = $i;
+			last;
 		}
-		if (defined $found_i) {
-			splice(@ai_seq, $found_i , 1);
-			splice(@ai_seq_args, $found_i , 1);
-		}
+		return unless (defined $seq_index); # return unless we found the action in the queue
 		
+		splice(@ai_seq, $seq_index , 1); # Splice it out of @ai_seq
+		splice(@ai_seq_args, $seq_index , 1);  # Splice it out of @ai_seq_args
+		# When there are multiple of the same action (route, attack, route) the splices of remove the first one
+		# So recursively call AI::clear again with the same action until none is found
+		AI::clear($wanted_action);
+	
+	# If more than 1 arg was given recursively call AI::clear for each one
 	} else {
 		foreach (@_) {
 			AI::clear($_);

--- a/src/AI.pm
+++ b/src/AI.pm
@@ -117,38 +117,38 @@ sub dequeue {
 }
 
 sub queue {
-	unshift @ai_seq, shift;
+	my $action = shift;
 	my $args = shift;
+	unshift(@ai_seq, $action);
 	unshift @ai_seq_args, ((defined $args) ? $args : {});
 }
 
 sub clear {
-	if (@_) {
-		my $changed;
-		for (my $i = 0; $i < @ai_seq; $i++) {
-			if (defined binFind(\@_, $ai_seq[$i])) {
-				delete $ai_seq[$i];
-				delete $ai_seq_args[$i];
-				$changed = 1;
-			}
-		}
-
-		if ($changed) {
-			my (@new_seq, @new_args);
-			for (my $i = 0; $i < @ai_seq; $i++) {
-				if (defined $ai_seq[$i]) {
-					push @new_seq, $ai_seq[$i];
-					push @new_args, $ai_seq_args[$i];
-				}
-			}
-			@ai_seq = @new_seq;
-			@ai_seq_args = @new_args;
-		}
-
-	} else {
+	my $total = scalar @_;
+	
+	if ($total == 0) {
 		undef @ai_seq;
 		undef @ai_seq_args;
 		undef %ai_v;
+		
+	} elsif ($total == 1) {
+		my $wanted = shift;
+		my $found_i;
+		foreach my $seq_i (0..$#ai_seq) {
+			if ($wanted eq $ai_seq[$seq_i]) {
+				$found_i = $seq_i;
+				last;
+			}
+		}
+		if (defined $found_i) {
+			splice(@ai_seq, $found_i , 1);
+			splice(@ai_seq_args, $found_i , 1);
+		}
+		
+	} else {
+		foreach (@_) {
+			AI::clear($_);
+		}
 	}
 }
 


### PR DESCRIPTION
For some strange reason sometimes AI::clear leaves @ai_seq and @ai_seq with different sizes with causes a critical error, very hard to reproduce however we never really should use delete on arrays, this is still unfinished.