### PR TITLE
add clientSight_removeBeyond

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -157,6 +157,7 @@ cachePlayerNames_duration 900
 cachePlayerNames_maxSize 100
 
 clientSight 15
+clientSight_removeBeyond 2
 
 dcPause 1
 dcOnDeath 0

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1796,17 +1796,6 @@ sub actor_display {
 		warning TF("Removed actor with off map coordinates: (%d,%d)->(%d,%d), field max: (%d,%d)\n",$coordsFrom{x},$coordsFrom{y},$coordsTo{x},$coordsTo{y},$field->width(),$field->height());
 		return;
 	}
-
-	# Remove actors with a distance greater than clientSight. Useful for vending (so you don't spam
-	# too many packets in prontera and cause server lag). As a side effect, you won't be able to "see" actors
-	# beyond clientSight.
-	if ($config{clientSight}) {
-		if ((my $block_dist = blockDistance($char->{pos_to}, \%coordsTo)) >= ($config{clientSight})) {
-			my $nameIdTmp = unpack("V", $args->{ID});
-			debug "Removed out of sight actor $nameIdTmp at ($coordsTo{x}, $coordsTo{y}) (distance: $block_dist)\n";
-			return;
-		}
-	}
 =pod
 	# Zealotus bug
 	if ($args->{type} == 1200) {
@@ -1994,6 +1983,25 @@ sub actor_display {
 	$actor->{len} = $args->{len} if $args->{len};
 	# 0086 would need that?
 	$actor->{object_type} = $args->{object_type} if (defined $args->{object_type});
+
+	# Remove actors with a distance greater than clientSight. Useful for vending (so you don't spam
+	# too many packets in prontera and cause server lag). As a side effect, you won't be able to "see" actors
+	# beyond clientSight.
+	if ($config{clientSight}) {
+		my $realMyPos = calcPosition($char);
+		my $realActorPos = calcPosition($actor);
+		my $realActorDist = blockDistance($realMyPos, $realActorPos);
+		
+		my $max_sight_base = $config{clientSight} + 2;
+		my $max_sight_extra = $config{clientSight_removeBeyond};
+		
+		my $max_sight = $max_sight_base + $max_sight_extra;
+		
+		if ($realActorDist >= $max_sight) {
+			Log::warning "Removed out of sight actor $actor->{name} at ($actor->{pos_to}{x}, $actor->{pos_to}{y}) (distance: $realActorDist > max $max_sight)\n";
+			return;
+		}
+	}
 
 	if (UNIVERSAL::isa($actor, "Actor::Player")) {
 		# None of this stuff should matter if the actor isn't a player... => does matter for a guildflag npc!


### PR DESCRIPTION
Currently openkore removes (actully just never adds) actors that are sent by the server with a distance greater than clientSight, however this comparison is made using {pos_to} and not actual position which can sometimes be greater than clientSight even when close.

This change actually calculates the position of both actors and compares them.
The second issue is that calcPosition is not perfect and usually gets 1 cell wrong, accounting for both actors the distance could be 2 greater of lower than the real one, so I added a config key to account for that.

Now only removes actors that are at least clientSight_removeBeyond beyong the clientSight limit.