### PR TITLE
Fix bugged actor moved packet again

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1802,7 +1802,7 @@ sub actor_display {
 		return;
 	}
 	
-	if (blockDistance(\%coordsFrom, \%coordsTo) > 17) {
+	if (blockDistance(\%coordsFrom, \%coordsTo) > ($config{clientSight} + $config{clientSight_removeBeyond})) {
 		warning TF("Ignoring bugged actor moved packet ($args->{switch}) ($coordsFrom{x} $coordsFrom{y})->($coordsTo{x} $coordsTo{y})\n");
 		return;
 	}
@@ -2003,7 +2003,7 @@ sub actor_display {
 		my $realActorPos = calcPosition($actor);
 		my $realActorDist = blockDistance($realMyPos, $realActorPos);
 		
-		my $max_sight_base = $config{clientSight} + 2;
+		my $max_sight_base = $config{clientSight};
 		my $max_sight_extra = $config{clientSight_removeBeyond};
 		
 		my $max_sight = $max_sight_base + $max_sight_extra;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1793,14 +1793,17 @@ sub actor_display {
 	#  - server sending us false actors
 	#  - actor packets not being parsed correctly
 	if (defined $field && ($field->isOffMap($coordsFrom{x}, $coordsFrom{y}) || $field->isOffMap($coordsTo{x}, $coordsTo{y}))) {
-		warning TF("Removed actor with off map coordinates: (%d,%d)->(%d,%d), field max: (%d,%d)\n",$coordsFrom{x},$coordsFrom{y},$coordsTo{x},$coordsTo{y},$field->width(),$field->height());
+		warning TF("Ignoring actor with off map coordinates: (%d,%d)->(%d,%d), field max: (%d,%d)\n",$coordsFrom{x},$coordsFrom{y},$coordsTo{x},$coordsTo{y},$field->width(),$field->height());
 		return;
 	}
 	
-	if (defined $field && !$field->isOffMap($coordsFrom{x}, $coordsFrom{y}) && $coordsTo{x} == 0 && $coordsTo{y} == 0) {
-		debug TF("Ignoring bugged actor moved packet to (0,0)\n");
-		$coordsTo{x} = $coordsFrom{x};
-		$coordsTo{y} = $coordsFrom{y};
+	if (($coordsFrom{x} == 0 && $coordsFrom{y} == 0) || ($coordsTo{x} == 0 && $coordsTo{y} == 0)) {
+		warning TF("Ignoring bugged actor moved packet ($args->{switch}) ($coordsFrom{x} $coordsFrom{y})->($coordsTo{x} $coordsTo{y})\n");
+		return;
+	}
+	
+	if (blockDistance(\%coordsFrom, \%coordsTo) > 15) {
+		warning TF("Ignoring bugged actor moved packet ($args->{switch}) ($coordsFrom{x} $coordsFrom{y})->($coordsTo{x} $coordsTo{y})\n");
 		return;
 	}
 	

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1802,7 +1802,7 @@ sub actor_display {
 		return;
 	}
 	
-	if (blockDistance(\%coordsFrom, \%coordsTo) > 15) {
+	if (blockDistance(\%coordsFrom, \%coordsTo) > 17) {
 		warning TF("Ignoring bugged actor moved packet ($args->{switch}) ($coordsFrom{x} $coordsFrom{y})->($coordsTo{x} $coordsTo{y})\n");
 		return;
 	}


### PR DESCRIPTION
Second check for https://github.com/HerculesWS/Hercules/issues/3154
Sometimes the pos_to coordinate might not be 0 0 but can be very far.

Like:
`Monster Moved: Spore (1) - (297, 302) -> (32, 91)`

I believe seeting the max move distance for mobs to the same clientSight + clientSight_removeBeyond used for removing actors should be safe.

Also removed a +2 I left in clientSight check by mistake.