### PR TITLE
fix SimpleHookEvent in eventMacro

### DIFF
--- a/plugins/eventMacro/eventMacro/Condition/SimpleHookEvent.pm
+++ b/plugins/eventMacro/eventMacro/Condition/SimpleHookEvent.pm
@@ -4,12 +4,12 @@ use strict;
 
 use base 'eventMacro::Condition';
 
-use eventMacro::Data qw( EVENT_TYPE );
+use eventMacro::Data qw( $eventMacro EVENT_TYPE );
 use eventMacro::Utilities qw( find_variable );
 
 sub _parse_syntax {
 	my ( $self, $condition_code ) = @_;
-	
+
 	foreach my $member (split(/\s*,\s*/, $condition_code)) {
 		if (find_variable($member)) {
 			$self->{error} = "In this condition no variables are accepted";
@@ -17,7 +17,7 @@ sub _parse_syntax {
 		}
 		push (@{$self->{hooks}}, $member);
 	}
-	
+
 	return 1;
 }
 
@@ -27,29 +27,30 @@ sub _hooks {
 
 sub validate_condition {
 	my ( $self, $callback_type, $callback_name, $args ) = @_;
-	
+
 	#always true
 	$self->{last_hook} = $callback_name;
 	$self->{vars} = \%$args;
-	
+
 	return $self->SUPER::validate_condition( 1 );
 }
 
 sub get_new_variable_list {
 	my ($self) = @_;
 	my $new_variables;
-	
+
 	$new_variables->{".".$self->{name}."Last"} = $self->{last_hook};
-	while( my( $key, $value ) = each %{$self->{vars}} ){
+
+	while ( my( $key, $value ) = each %{$self->{vars}} ) {
 		if (ref($value) eq 'ARRAY') {
-			for (my $i; $i < @{$value}.length ; $i++) {
-				$new_variables->{".".$self->{name}."Last".ucfirst($key).$i} = $value->[$i];
-			}
-		} else{
+			$eventMacro->set_full_array(".".$self->{name}."Last".ucfirst($key), \@{$value});
+		} elsif (ref($value) eq "HASH") {
+			$eventMacro->set_full_hash(".".$self->{name}."Last".ucfirst($key), \%{$value});
+		} else {
 			$new_variables->{".".$self->{name}."Last".ucfirst($key)} = $value;
 		}
 	}
-	
+
 	return $new_variables;
 }
 

--- a/plugins/eventMacro/eventMacro/Data.pm
+++ b/plugins/eventMacro/eventMacro/Data.pm
@@ -9,7 +9,7 @@ our @EXPORT = qw($eventMacro @perl_name $valid_var_characters $general_variable_
 our $eventMacro;
 our @perl_name;
 
-our $valid_var_characters = qr/\.?[a-zA-Z][a-zA-Z\d]*/;
+our $valid_var_characters = qr/\.?[a-zA-Z][a-zA-Z\d_]*/;
 
 our $general_variable_qr = qr/(?:\$$valid_var_characters(?:\[\d+\]|\{[a-zA-Z\d]+\})?|\@$valid_var_characters|\%$valid_var_characters)/;
 


### PR DESCRIPTION
Hook arguments (arrays and hashes) are now passed to eventMacro as arrays and hashes.

this fix also applies to #1261

For example, we have a hook:
```
my %hash = (
	key1 => "vol-1",
	key2 => "vol-2"
);

my @arr = ('arr1', 'arr2');

Plugins::callHook($hook, {switch => $switch, hash => \%hash, arr => \@arr});
```
Before fix:
![image](https://user-images.githubusercontent.com/7117363/209483975-4a5f5202-5f9d-41a7-a045-607c34ffe98a.png)

After fix:
![image](https://user-images.githubusercontent.com/7117363/209483983-56e51eb2-1a9e-4ac0-8bcb-c401ada4aecf.png)
