### PR TITLE
feat: implement monstercountdist in checkselfcondition

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -550,6 +550,7 @@ attackSkillSlot {
 	monsters
 	notMonsters
 	monstersCount
+	monstersCountDist
 	maxAttempts 0
 	maxUses 0
 	target_hp
@@ -585,6 +586,7 @@ attackComboSlot {
 	monsters
 	notMonsters
 	monstersCount
+	monstersCountDist
 	whenPartyMembersNear
 	whenPartyMembersNearDist
 }
@@ -620,6 +622,7 @@ doCommand {
 	monsters
 	notMonsters
 	monstersCount
+	monstersCountDist
 	stopWhenHit 0
 	inLockOnly 0
 	notWhileSitting 0
@@ -668,6 +671,7 @@ useSelf_skill {
 	monsters
 	notMonsters
 	monstersCount
+	monstersCountDist
 	stopWhenHit 0
 	inLockOnly 0
 	notWhileSitting 0
@@ -720,6 +724,7 @@ partySkill {
 	monsters
 	notMonsters
 	monstersCount
+	monstersCountDist
 	stopWhenHit 0
 	inLockOnly 0
 	notWhileSitting 0
@@ -785,6 +790,7 @@ equipAuto {
 	monsters
 	notMonsters
 	monstersCount
+	monstersCountDist
 	weight 0
 	whileSitting 0
 	hp
@@ -857,6 +863,7 @@ useSelf_item {
 	monsters
 	notMonsters
 	monstersCount
+	monstersCountDist
 	stopWhenHit 0
 	inLockOnly 0
 	notWhileSitting 0

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -4894,7 +4894,9 @@ sub checkSelfCondition {
 			if ($nowMonsters > 0 && $config{$prefix . "_notMonsters"}) {
 				for my $monster (@$monstersList) {
 					$nowMonsters-- if (existsInList($config{$prefix . "_notMonsters"}, $monster->{name}) ||
-										existsInList($config{$prefix . "_notMonsters"}, $monster->{nameID}));
+										existsInList($config{$prefix . "_notMonsters"}, $monster->{nameID}) ||
+										($config{$prefix."_monstersCountDist"} && !inRange(blockDistance(calcPosition($char), calcPosition($monster)), $config{$prefix."_monstersCountDist"}))
+									);
                 }
             }
 		return 0 unless (inRange($nowMonsters, $config{$prefix . "_monstersCount"}));


### PR DESCRIPTION
implement monstersCount in checkSelfCondition
config.txt:
```
attackSkillSlot Judex {
	lvl 10
	dist 1
	maxDist 5
	sp > 10
	stopWhenHit 0
	inLockOnly 0
	notInTown 0
	timeout 0
	disabled 0
	monstersCount > 2
	monstersCountDist < 10
	maxAttempts 0
	maxUses 0
	isSelfSkill 0
	isStartSkill 0
	manualAI 0
}
```

result:
![image](https://user-images.githubusercontent.com/10372732/216605292-ab295cb2-1a1f-461d-bbab-bb56dc76d9ba.png)

as can be seen in image when more then 2 monster in range openkore use judex, if not it attack using weapon

this closes #3693 