### PR TITLE
new log added: playerLog

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -340,6 +340,7 @@ logConsole 1
 logAppendUsername 1
 logAppendServer 0
 monsterLog 0
+playerLog 0
 logDead 1
 
 questDisplayStyle 2

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -94,6 +94,7 @@ our @EXPORT = (
 	qw/chatLog
 	shopLog
 	monsterLog
+	playerLog
 	deadLog
 	searchStoreInfo/,
 
@@ -936,6 +937,14 @@ sub monsterLog {
 	open MONLOG, ">>:utf8", $Settings::monster_log_file;
 	print MONLOG "[".getFormattedDate(int(time))."] $crud\n";
 	close MONLOG;
+}
+
+sub playerLog {
+	my $crud = shift;
+	return if (!$config{'playerLog'});
+	open PLAYERLOG, ">>:utf8", $Settings::player_log_file;
+	print PLAYERLOG "[".getFormattedDate(int(time))."] $crud\n";
+	close PLAYERLOG;
 }
 
 sub deadLog {

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2165,6 +2165,7 @@ typedef enum <unnamed-tag> {
 			my $domain = existsInList($config{friendlyAID}, unpack("V", $actor->{ID})) ? 'parseMsg_presence' : 'parseMsg_presence/player';
 			debug "Player Exists: " . $actor->name . " ($actor->{binID}) Level $actor->{lv} $sex_lut{$actor->{sex}} $jobs_lut{$actor->{jobID}} ($coordsFrom{x}, $coordsFrom{y})\n", $domain;
 
+			playerLog("player " .$actor->{name} ." is near (" .$field->{baseName} .", lvl=" .$actor->{lv} .", job=" .$jobs_lut{$actor->{jobID}} .")") if (!$field->isCity);
 			Plugins::callHook('player', {player => $actor}); #backwards compatibility
 
 			Plugins::callHook('player_exist', {player => $actor});
@@ -2210,6 +2211,7 @@ typedef enum <unnamed-tag> {
 			my $domain = existsInList($config{friendlyAID}, unpack("V", $args->{ID})) ? 'parseMsg_presence' : 'parseMsg_presence/player';
 			debug "Player Connected: ".$actor->name." ($actor->{binID}) Level $args->{lv} $sex_lut{$actor->{sex}} $jobs_lut{$actor->{jobID}} ($coordsTo{x}, $coordsTo{y})\n", $domain;
 
+			playerLog("player " .$actor->{name} ." is near (" .$field->{baseName} .", lvl=" .$actor->{lv} .", job=" .$jobs_lut{$actor->{jobID}} .")") if (!$field->isCity);
 			Plugins::callHook('player', {player => $actor}); #backwards compatibailty
 
 			Plugins::callHook('player_connected', {player => $actor});
@@ -2628,6 +2630,7 @@ sub actor_info {
 		$player->{title}{ID} = $args->{titleID} if defined $args->{titleID};
 		message "Player Info: " . $player->nameIdx . "\n", "parseMsg_presence", 2;
 		updatePlayerNameCache($player);
+		playerLog("player " .$player->{name} ." is near (" .$field->{baseName} .", lvl=" .$player->{lv} .", job=" .$jobs_lut{$player->{jobID}} .")") if (!$field->isCity);
 		Plugins::callHook('charNameUpdate', {player => $player});
 	}
 

--- a/src/Settings.pm
+++ b/src/Settings.pm
@@ -112,6 +112,7 @@ our $base_console_log_file;
 our $base_storage_log_file;
 our $base_shop_log_file;
 our $base_monster_log_file;
+our $base_player_log_file;
 our $base_item_log_file;
 our $base_dead_log_file;
 
@@ -121,6 +122,7 @@ our $console_log_file;
 our $storage_log_file;
 our $shop_log_file;
 our $monster_log_file;
+our $player_log_file;
 our $item_log_file;
 our $dead_log_file;
 
@@ -231,6 +233,7 @@ sub parseArguments {
 	$base_storage_log_file ||= File::Spec->catfile($logs_folder, "storage.txt");
 	$base_shop_log_file = File::Spec->catfile($logs_folder, "shop_log.txt");
 	$base_monster_log_file = File::Spec->catfile($logs_folder, "monster_log.txt");
+	$base_player_log_file = File::Spec->catfile($logs_folder, "player_log.txt");
 	$base_item_log_file = File::Spec->catfile($logs_folder, "item_log.txt");
 	$base_dead_log_file = File::Spec->catfile($logs_folder, "dead_log.txt");
 	update_log_filenames();
@@ -270,6 +273,7 @@ sub update_log_filenames {
 	$storage_log_file = substr( $base_storage_log_file, 0, length( $base_storage_log_file ) - 4 ) . "$logAppend.txt";
 	$shop_log_file    = substr( $base_shop_log_file,    0, length( $base_shop_log_file ) - 4 ) . "$logAppend.txt";
 	$monster_log_file = substr( $base_monster_log_file, 0, length( $base_monster_log_file ) - 4 ) . "$logAppend.txt";
+	$player_log_file = substr( $base_player_log_file,   0, length( $base_player_log_file ) - 4 ) . "$logAppend.txt";
 	$item_log_file    = substr( $base_item_log_file,    0, length( $base_item_log_file ) - 4 ) . "$logAppend.txt";
 	$dead_log_file    = substr( $base_dead_log_file,    0, length( $base_dead_log_file ) - 4 ) . "$logAppend.txt";
 }


### PR DESCRIPTION
Now openkore can log all users that are nearby (just not in the city).
Report example:
```
[2023.04.14 02:01:42] player test1 is near (new_1-4, lvl=4, job=Novice)
[2023.04.14 02:11:25] player test3 is near (new_1-4, lvl=4, job=Novice)
[2023.04.14 02:11:26] player test3 is near (new_1-4, lvl=4, job=Novice)
[2023.04.15 02:43:22] player SILEE is near (lasa_fild01, lvl=5, job=High Thief)
```