### PR TITLE
feat: use distance in itemsgatherauto

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -189,6 +189,8 @@ itemsTakeAuto 2
 itemsTakeAuto_party 0
 itemsGatherAuto 2
 itemsGatherAuto_notInTown 0
+itemsGatherAutoMinPlayerDistance 6
+itemsGatherAutoMinPortalDistance 5
 itemsMaxWeight 89
 itemsMaxWeight_sellOrStore 48
 itemsMaxNum_sellOrStore 99


### PR DESCRIPTION
use distance to gather items.

Now openkore dont spam route in AI or try to get items far away while other items are closer

new config keys:
```
itemsGatherAutoMinPlayerDistance
itemsGatherAutoMinPortalDistance
```

