### PR TITLE
feat: add key to avoid hidden monsters

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -152,6 +152,7 @@ avoidList_reconnect 1800
 avoidList_ignoreList
 
 avoidHiddenActors 0
+avoidHiddenMonsters 0
 
 cachePlayerNames 1
 cachePlayerNames_duration 900
@@ -288,6 +289,7 @@ teleportAuto_unstuck 0
 teleportAuto_lostTarget 0
 teleportAuto_dropTarget 0
 teleportAuto_dropTargetKS 0
+teleportAuto_dropTargetHidden 0
 teleportAuto_attackedWhenSitting 0
 teleportAuto_totalDmg 0
 teleportAuto_totalDmgInLock 0

--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -153,7 +153,25 @@ sub process {
 		main();
 	}
 
-	# Check for kill steal and mob-training while moving
+	# Check for hidden monsters
+	if (AI::inQueue("attack") && AI::is("move", "route", "attack")) {
+		my $ID = AI::args->{attackID};
+		my $monster = $monsters{$ID};
+		if (($monster->{statuses}->{EFFECTSTATE_BURROW} || $monster->{statuses}->{EFFECTSTATE_HIDING}) && 
+		$config{avoidHiddenMonsters}) {
+			message TF("Dropping target %s - will not attack hidden monsters\n", $monster), 'ai_attack';
+			$char->sendAttackStop;
+			$monster->{ignore} = 1;
+
+			AI::dequeue while (AI::inQueue("attack"));
+			if ($config{teleportAuto_dropTargetHidden}) {
+				message T("Teleport due to dropping hidden target\n");
+				useTeleport(1);
+			}
+		}
+	}
+
+	# Check for kill steal, mob-training and hiding while moving
 	if ((AI::is("move", "route") && $args->{attackID} && AI::inQueue("attack")
 		&& timeOut($args->{movingWhileAttackingTimeout}, 0.2))) {
 

--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -166,7 +166,7 @@ sub process {
 			AI::dequeue while (AI::inQueue("attack"));
 			if ($config{teleportAuto_dropTargetHidden}) {
 				message T("Teleport due to dropping hidden target\n");
-				useTeleport(1);
+				ai_useTeleport(1);
 			}
 		}
 	}

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -3170,6 +3170,8 @@ sub processAutoAttack {
 
 				# Never attack monsters that we failed to get LOS with
 				next if (!timeOut($monster->{attack_failedLOS}, $timeout{ai_attack_failedLOS}{timeout}));
+				# Avoid Hidden monsters
+				next if ($config{avoidHiddenMonsters} && ($monster->{statuses}->{EFFECTSTATE_BURROW} || $monster->{statuses}->{EFFECTSTATE_HIDING}));
 
 				OpenKoreMod::autoAttack($monster) if (defined &OpenKoreMod::autoAttack);
 


### PR DESCRIPTION
this pull make openkore avoid hidden monsters.

if  `avoidHiddenMonsters` is set openkore will not choose hidden monster to attack and will drop the target if after the attack start the monster uses Hide

new config keys:
```
avoidHiddenMonsters 
teleportAuto_dropTargetHidden 
```

screenshots:
dropping and attacking other monster
![image](https://github.com/OpenKore/openkore/assets/10372732/1e3b640e-a8da-4c9c-a033-7a6acd9008d2)

dropping and using teleport:
![image](https://github.com/OpenKore/openkore/assets/10372732/2594ecca-b73f-4184-b3ae-39e774122847)

fixes #3695



