### PR TITLE
Fix ranged attack distance

### DIFF
--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -298,7 +298,7 @@ sub main {
 	my ($realMyPos, $realMonsterPos, $realMonsterDist, $hitYou);
 	my $realMyPos = calcPosition($char);
 	my $realMonsterPos = calcPosition($target);
-	my $realMonsterDist = blockDistance($realMyPos, $realMonsterPos);
+	my $realMonsterDist = distance($realMyPos, $realMonsterPos);
 
 	my $cleanMonster = checkMonsterCleanness($ID);
 

--- a/src/Actor/You.pm
+++ b/src/Actor/You.pm
@@ -288,7 +288,7 @@ sub attack {
 
 		my $i = 0;
 		my $Lequip = 0;
-		my $Runeq =0;
+		my $Runeq = 0;
 		my (%eq_list,$Req,$Leq,$arrow,$j);
 		while (exists $config{"autoSwitch_$i"}) {
 			if (!$config{"autoSwitch_$i"}) {
@@ -309,7 +309,7 @@ sub attack {
 					$Req = $char->inventory->getByName($config{"autoSwitch_${i}_rightHand"});
 					if ($Req && !$Req->{equipped}){
 						message TF("Auto Equiping [R]: %s\n", $config{"autoSwitch_$i"."_rightHand"}), "equip";
-						%eq_list = (rightHand => $Req->{binID});
+						%eq_list = (rightHand => $config{"autoSwitch_$i"."_rightHand"});
 					}
 
 				}
@@ -335,7 +335,7 @@ sub attack {
 
 						if ($Leq) {
 							message TF("Auto Equiping [L]: %s (%s)\n", $config{"autoSwitch_$i"."_leftHand"}, $Leq), "equip";
-							$eq_list{leftHand} = $Leq->{binID};
+							$eq_list{leftHand} = $config{"autoSwitch_${i}_leftHand"};
 						}
 					}
 				}
@@ -377,7 +377,7 @@ sub attack {
 			$Req = $char->inventory->getByName($config{"autoSwitch_default_rightHand"});
 			if ($Req && !$Req->{equipped}){
 				message TF("Auto Equiping [R]: %s\n", $config{"autoSwitch_default_rightHand"}), "equip";
-				%eq_list = (rightHand => $Req->{binID});
+				%eq_list = (rightHand => $config{"autoSwitch_default_rightHand"});
 			}
 
 		}
@@ -404,7 +404,7 @@ sub attack {
 
 				if ($Leq) {
 					message TF("Auto Equiping [L]: %s\n", $config{"autoSwitch_default_leftHand"}), "equip";
-					$eq_list{leftHand} = $Leq->{binID};
+					$eq_list{leftHand} = $config{"autoSwitch_default_leftHand"};
 				}
 			}
 		}

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -2799,7 +2799,7 @@ sub meetingPosition {
 				# 1. It must be walkable
 				next unless ($field->isWalkable($spot->{x}, $spot->{y}));
 
-				my $dist_to_target = blockDistance($spot, $possible_target_pos->{targetPosInStep});
+				my $dist_to_target = distance($spot, $possible_target_pos->{targetPosInStep});
 				next unless ($dist_to_target <= $attackMaxDistance);
 				next unless ($dist_to_target >= $min_destination_dist);
 


### PR DESCRIPTION
My ranged bots were constantly getting stuck trying to attack immovable enemies with range 9 skills unless their attack distance was 6 or below. This behavior is very prevalent when attacking at a diagonal angle to the monster. With an attack distance of 9, bot would stand 9 horizontal AND vertical blocks away but the monster list would show the distance as around 12. The issue is that the block distance calculation does not do well with angles and keeps them out of range so the game will not let them attack.

This change fixes part of the attack and move calculation to use the more accurate distance subroutine. The change was like night and day and now my bots can attack at the intended 9 range.

My testing on this has been limited to a soul linker with a bard and dancer using instruments.