### PR TITLE
Allow the AutoSwitch mod to correctly switch weapons/shields

### DIFF
--- a/src/Actor/You.pm
+++ b/src/Actor/You.pm
@@ -309,7 +309,7 @@ sub attack {
 					$Req = $char->inventory->getByName($config{"autoSwitch_${i}_rightHand"});
 					if ($Req && !$Req->{equipped}){
 						message TF("Auto Equiping [R]: %s\n", $config{"autoSwitch_$i"."_rightHand"}), "equip";
-						%eq_list = (rightHand => $Req->{binID});
+						%eq_list = (rightHand => $config{"autoSwitch_${i}_rightHand"});
 					}
 
 				}
@@ -335,7 +335,7 @@ sub attack {
 
 						if ($Leq) {
 							message TF("Auto Equiping [L]: %s (%s)\n", $config{"autoSwitch_$i"."_leftHand"}, $Leq), "equip";
-							$eq_list{leftHand} = $Leq->{binID};
+							$eq_list{leftHand} = $config{"autoSwitch_${i}_leftHand"};
 						}
 					}
 				}
@@ -377,7 +377,7 @@ sub attack {
 			$Req = $char->inventory->getByName($config{"autoSwitch_default_rightHand"});
 			if ($Req && !$Req->{equipped}){
 				message TF("Auto Equiping [R]: %s\n", $config{"autoSwitch_default_rightHand"}), "equip";
-				%eq_list = (rightHand => $Req->{binID});
+				%eq_list = (rightHand => $config{"autoSwitch_default_rightHand"});
 			}
 
 		}
@@ -404,7 +404,7 @@ sub attack {
 
 				if ($Leq) {
 					message TF("Auto Equiping [L]: %s\n", $config{"autoSwitch_default_leftHand"}), "equip";
-					$eq_list{leftHand} = $Leq->{binID};
+					$eq_list{leftHand} = $config{"autoSwitch_default_leftHand"};
 				}
 			}
 		}


### PR DESCRIPTION
Closes https://github.com/OpenKore/openkore/issues/3773

`Actor::Item::bulkEquip()` requires a list of `<slot> => <itemName|itemId>` (leftHand => 'Katar', rightHand => 10)

AutoSwitch is sadly providing a list of `<slot> => <inventoryId>`.

This results in bulkEquip not finding InventoryId 9 in its itemlist.
Forcing AutoSwitch to always pass the ItemName to BulkEquip should fix this issue without breaking any equipment functionality