### PR TITLE
fix PR#3780

### DIFF
--- a/src/AI/SlaveAttack.pm
+++ b/src/AI/SlaveAttack.pm
@@ -432,7 +432,7 @@ sub main {
 		} else {
 			$target->{$slave->{ai_attack_failed_timeout}} = time;
 			$slave->dequeue while ($slave->inQueue("attack"));
-			message TF("Unable to calculate a meetingPosition to target, dropping target. Check %s in config.txt\n", $config{$slave->{configPrefix}.'attackRouteMaxPathDistance'), 'slave_attack';
+			message TF("Unable to calculate a meetingPosition to target, dropping target. Check %s in config.txt\n", $config{$slave->{configPrefix}.'attackRouteMaxPathDistance'}), 'slave_attack';
 			if ($config{$slave->{configPrefix}.'teleportAuto_dropTarget'}) {
 				message TF("Teleport due to dropping %s attack target\n", $slave), 'teleport';
 				ai_useTeleport(1);


### PR DESCRIPTION
fixed syntax error:
```
syntax error at src/AI/SlaveAttack.pm line 435, near "'attackRouteMaxPathDistance')"
Missing right curly or square bracket at src/AI/SlaveAttack.pm line 560, at end of line
Compilation failed in require at src/AI/Slave.pm line 12.
BEGIN failed--compilation aborted at src/AI/Slave.pm line 12.
Compilation failed in require at src/AI/SlaveManager.pm line 13.
BEGIN failed--compilation aborted at src/AI/SlaveManager.pm line 13.
Compilation failed in require at src/AI/CoreLogic.pm line 33.
BEGIN failed--compilation aborted at src/AI/CoreLogic.pm line 33.
Compilation failed in require at openkore.pl line 64.
BEGIN failed--compilation aborted at openkore.pl line 64.

Press ENTER to exit.
```