### PR TITLE
Prevent GCC from writing to Windows install directory

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -46,7 +46,14 @@ READLINE_LIB = 'readline'
 perlconfig = {}
 env = Environment()
 if win32:
-	env = Environment(ENV = {'PATH' : os.environ['PATH']}, tools = ['mingw', 'gcc', 'cc', 'g++', 'c++'])
+	env = Environment(
+		ENV = {
+			'PATH' : os.environ['PATH'], 
+			'TEMP' : os.environ['TEMP'],
+			'TMP' : os.environ['TMP'],
+		}, 
+		tools = ['mingw', 'gcc', 'cc', 'g++', 'c++'],
+	)
 
 if darwin:
 	env['LIBPATH'] = DARWIN_LIBRARY_DIRECTORIES


### PR DESCRIPTION
On certain gcc distribuitions, if TEMP/TMP are unset, it defaults to writing to the root Windows OS directory (C:/Windows)

https://github.com/msys2/MSYS2-packages/issues/235