### PR TITLE
Fix map change invalidate QuestActive

### DIFF
--- a/plugins/eventMacro/eventMacro/Condition/QuestActive.pm
+++ b/plugins/eventMacro/eventMacro/Condition/QuestActive.pm
@@ -87,7 +87,6 @@ sub validate_condition {
 		if ($callback_name eq 'packet_mapChange') {
 			$self->{fulfilled_ID} = undef;
 			$self->{fulfilled_member_index} = undef;
-			$self->{is_on_stand_by} = 1;
 			
 		} elsif ($callback_name eq 'inventory_ready') {
 			return $self->SUPER::validate_condition if ($self->{is_on_stand_by} == 0);


### PR DESCRIPTION
Setting is_on_stand_by = 0 after a map change was the reason that an active quest doesn't trigger QuestActive condition. Every map change ends up calling validate_condition with a new value of 0 which sets is_validated to false.

### Before:
![before](https://github.com/OpenKore/openkore/assets/6869543/5624fa04-4e01-43e6-8301-0e227eb25ae8)

### After:
![after](https://github.com/OpenKore/openkore/assets/6869543/74a3b5a2-f0cb-4b7a-9c0d-eaaa8d9dfd73)
