### PR TITLE
Fix clearing timeouts after auto teleport

### DIFF
--- a/src/AI.pm
+++ b/src/AI.pm
@@ -134,7 +134,6 @@ sub clear {
 	if ($total == 0) {
 		undef @ai_seq;
 		undef @ai_seq_args;
-		undef %ai_v;
 
 	# If 1 arg was given find it in the queue
 	} elsif ($total == 1) {
@@ -157,17 +156,6 @@ sub clear {
 	} else {
 		foreach (@_) {
 			AI::clear($_);
-		}
-	}
-}
-
-sub clearExceptTimeouts {
-	undef @ai_seq;
-	undef @ai_seq_args;
-
-	foreach (keys %ai_v) {
-		if ($_ !~ /_time$/m) {
-			delete $ai_v{$_};
 		}
 	}
 }

--- a/src/AI.pm
+++ b/src/AI.pm
@@ -161,6 +161,17 @@ sub clear {
 	}
 }
 
+sub clearExceptTimeouts {
+	undef @ai_seq;
+	undef @ai_seq_args;
+
+	foreach (keys %ai_v) {
+		if ($_ !~ /_time$/m) {
+			delete $ai_v{$_};
+		}
+	}
+}
+
 sub suspend {
 	my $i = (defined $_[0] ? $_[0] : 0);
 	$ai_seq_args[$i]{suspended} = time if $i < @ai_seq_args;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -7215,7 +7215,7 @@ sub map_change {
 	}
 
 	if ($ai_v{temp}{clear_aiQueue}) {
-		AI::clearExceptTimeouts;
+		AI::clear;
 		AI::SlaveManager::clear();
 	}
 

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -7215,7 +7215,7 @@ sub map_change {
 	}
 
 	if ($ai_v{temp}{clear_aiQueue}) {
-		AI::clear;
+		AI::clearExceptTimeouts;
 		AI::SlaveManager::clear();
 	}
 


### PR DESCRIPTION
Openkore sets $ai_v{temp}{clear_aiQueue} =1 when doing any form of auto teleporting. This flag in turn clears the entire ai on map change, among which %ai_v. %ai_v contains timeouts for any item, skill or command block from config.txt. If these get cleared, Openkore uses every item or skill that only has a timeout after every auto teleport. This fix still clears the ai, but keeps any timeouts in %ai_v so Openkore doesn't spam skills or items after every auto teleport.