### PR TITLE
suppress the output of the sprite_change message

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -4531,7 +4531,7 @@ sub sprite_change {
 	} elsif ($type == 5) {
 		message TF("%s changed Middle headgear to %s (%d)\n", $player, headgearName($value1), $value1), "parseMsg_statuslook";
 		$player->{headgear}{mid} = $value1;
-	} elsif ($args->{part} == 6) {
+	} elsif ($type == 6) {
  		message TF("%s changed Hair color to: %s (%d)\n", $player, $haircolors{$value1}, $value1), "parseMsg_statuslook";
 		$player->{hair_color} = $value1;
 	} elsif ($type == 9) {
@@ -4541,7 +4541,7 @@ sub sprite_change {
 		$player->{shoes} = $value1;
 	} elsif ($type == 12) {
  		message TF("%s changed Robe to: SPRITE_ROBE_ID=%d\n", $player, $value1, $value1), "parseMsg_statuslook", 2;
-	} elsif ($args->{part} == 7 || $args->{part} == 13) {
+	} elsif ($type== 7 || $type == 13) {
 		# Type 7 looks like body palette or body color. Type 13 looks like body2
 		debug sprintf("%s changed type= %d. value1=%d, value2=%d\n", $player, $type, $value1, $value2);
 	} else {

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -4540,7 +4540,10 @@ sub sprite_change {
 		}
 		$player->{shoes} = $value1;
 	} elsif ($type == 12) {
- 		message TF("%s changed Robe to: SPRITE_ROBE_ID=%d\n", $player, $value1, $value1), "parseMsg_statuslook";
+ 		message TF("%s changed Robe to: SPRITE_ROBE_ID=%d\n", $player, $value1, $value1), "parseMsg_statuslook", 2;
+	} elsif ($args->{part} == 7 || $args->{part} == 13) {
+		# Type 7 looks like body palette or body color. Type 13 looks like body2
+		debug sprintf("%s changed type= %d. value1=%d, value2=%d\n", $player, $type, $value1, $value2);
 	} else {
 		error TF("%s changed unknown sprite type (%d), write about it to OpenKore developer\n", $player, $type), "parseMsg_statuslook";
 	}


### PR DESCRIPTION
We don't know what type 7 and 13 are. Type 7 looks like body palette or body color. Type 13 looks like body2

fix https://github.com/OpenKore/openkore/issues/3905

https://github.com/HerculesWS/Hercules/blob/stable/src/map/map.h#L784

```
enum look {
	LOOK_BASE,
	LOOK_HAIR,
	LOOK_WEAPON,
	LOOK_HEAD_BOTTOM,
	LOOK_HEAD_TOP,
	LOOK_HEAD_MID,
	LOOK_HAIR_COLOR,
	LOOK_CLOTHES_COLOR,
	LOOK_SHIELD,
	LOOK_SHOES,
	LOOK_BODY,
	LOOK_FLOOR,
	LOOK_ROBE,
	LOOK_BODY2,

#ifndef LOOK_MAX
	LOOK_MAX
#endif
};
```