### PR TITLE
Fix slave skills

### DIFF
--- a/src/AI.pm
+++ b/src/AI.pm
@@ -593,8 +593,12 @@ sub ai_skillUse {
 		debug "[$owner] Attempted to use skill (".$args{skillHandle}.") level ".$args{lv}." which you do not have, adjusting to level ".$lvl.".\n", "ai";
 		$args{lv} = $lvl;
 	}
-
-	AI::queue("skill_use", \%args);
+	
+	if ($skill->getOwnerType == Skill::OWNER_CHAR) {
+		AI::queue("skill_use", \%args);
+	} else {
+		$owner->queue("skill_use", \%args);
+	}
 }
 
 ##

--- a/src/AI.pm
+++ b/src/AI.pm
@@ -586,9 +586,12 @@ sub ai_skillUse {
 		delete $args{target};
 	}
 
-	if ($char->{skills}{$args{skillHandle}}{lv} < $args{lv}) {
-		debug "Attempted to use skill (".$args{skillHandle}.") level ".$args{lv}." which you do not have, adjusting to level ".$char->{skills}{$args{skillHandle}}{lv}.".\n", "ai";
-		$args{lv} = $char->{skills}{$args{skillHandle}}{lv};
+	my $skill = Skill->new(auto => $args{skillHandle});
+	my $owner = $skill->getOwner();
+	my $lvl = $owner->getSkillLevel($skill);
+	if ($lvl < $args{lv}) {
+		debug "[$owner] Attempted to use skill (".$args{skillHandle}.") level ".$args{lv}." which you do not have, adjusting to level ".$lvl.".\n", "ai";
+		$args{lv} = $lvl;
 	}
 
 	AI::queue("skill_use", \%args);

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -750,7 +750,10 @@ sub processSkillUse {
 
 				# Give an error if we don't actually possess this skill
 				my $skill = new Skill(handle => $handle);
-				if ($char->{skills}{$handle}{lv} <= 0 && (!$char->{permitSkill} || $char->{permitSkill}->getHandle() ne $handle)) {
+				my $owner = $skill->getOwner();
+				my $lvl = $owner->getSkillLevel($skill);
+
+				if ($lvl <= 0 && (!$char->{permitSkill} || $char->{permitSkill}->getHandle() ne $handle)) {
 					debug "Attempted to use skill (".$skill->getName().") which you do not have.\n";
 				}
 

--- a/src/AI/Slave.pm
+++ b/src/AI/Slave.pm
@@ -20,6 +20,16 @@ use constant MAX_DISTANCE => 17;
 
 sub checkSkillOwnership {}
 
+sub getSkillLevel {
+	my ($self, $skill) = @_;
+	my $handle = $skill->getHandle();
+	if ($self->{skills}{$handle}) {
+		return $self->{skills}{$handle}{lv};
+	} else {
+		return 0;
+	}
+}
+
 sub action {
 	my $slave = shift;
 	

--- a/src/AI/SlaveManager.pm
+++ b/src/AI/SlaveManager.pm
@@ -18,6 +18,7 @@ sub addSlave {
 	$actor->{slave_ai_seq} = [];
 	$actor->{slave_ai_seq_args} = [];
 	$actor->{slave_skillsID} = [];
+	$actor->{skills} = {};
 	$actor->{slave_AI} = AI::AUTO;
 
 	if ($actor->isa("Actor::Slave::Homunculus")) {

--- a/src/Actor/You.pm
+++ b/src/Actor/You.pm
@@ -114,6 +114,8 @@ sub nameString {
 	return T('You');
 }
 
+sub checkSkillOwnership { $_[1]->getOwnerType == Skill::OWNER_CHAR }
+
 ##
 # int $char->getSkillLevel(Skill skill)
 # Ensures: result >= 0

--- a/src/Commands.pm
+++ b/src/Commands.pm
@@ -3100,10 +3100,12 @@ sub cmdSlave {
 				T("   # Skill Name                     Lv      SP\n");
 			foreach my $handle (@{$slave->{slave_skillsID}}) {
 				my $skill = new Skill(handle => $handle);
-				my $sp = $char->{skills}{$handle}{sp} || '';
-				$msg .= swrite(
-					"@>>> @<<<<<<<<<<<<<<<<<<<<<<<<<<<< @>>    @>>>",
-					[$skill->getIDN(), $skill->getName(), $char->getSkillLevel($skill), $sp]);
+				if ($slave->checkSkillOwnership($skill)) {
+					my $sp = $slave->{skills}{$handle}{sp} || '';
+					$msg .= swrite(
+						"@>>> @<<<<<<<<<<<<<<<<<<<<<<<<<<<< @>>    @>>>",
+						[$skill->getIDN(), $skill->getName(), $slave->getSkillLevel($skill), $sp]);
+				}
 			}
 			$msg .= TF("\nSkill Points: %d\n", $slave->{points_skill}) if defined $slave->{points_skill};
 			$msg .= ('-'x46) . "\n";

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -4752,14 +4752,22 @@ sub checkSelfCondition {
 	# check skill use SP if this is a 'use skill' condition
 	if ($prefix =~ /skill|attackComboSlot/i) {
 		my $skill = Skill->new(auto => $config{$prefix});
-		return 0 unless ($char->getSkillLevel($skill)
-						|| $config{$prefix."_equip_leftAccessory"}
-						|| $config{$prefix."_equip_rightAccessory"}
-						|| $config{$prefix."_equip_leftHand"}
-						|| $config{$prefix."_equip_rightHand"}
-						|| $config{$prefix."_equip_robe"}
-						);
-		return 0 unless ($char->{sp} >= $skill->getSP($config{$prefix . "_lvl"} || $char->getSkillLevel($skill)));
+		if ($char->checkSkillOwnership ($skill)) {
+			return 0 unless ($char->getSkillLevel($skill)
+							|| $config{$prefix."_equip_leftAccessory"}
+							|| $config{$prefix."_equip_rightAccessory"}
+							|| $config{$prefix."_equip_leftHand"}
+							|| $config{$prefix."_equip_rightHand"}
+							|| $config{$prefix."_equip_robe"}
+							);
+			return 0 unless ($char->{sp} >= $skill->getSP($config{$prefix . "_lvl"} || $char->getSkillLevel($skill)));
+			
+		} elsif ($has_homunculus && $char->{homunculus}->checkSkillOwnership($skill)) {
+			return 0 unless ($char->{homunculus}->getSkillLevel($skill));
+			
+		} elsif ($has_mercenary && $char->{mercenary}->checkSkillOwnership($skill)) {
+			return 0 unless ($char->{mercenary}->getSkillLevel($skill));
+		}
 	}
 
 	if (defined $config{$prefix . "_skill"}) {

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -9309,18 +9309,25 @@ sub skills_list {
 	# TODO: per-actor, if needed at all
 	# Skill::DynamicInfo::clear;
 	my ($ownerType, $hook, $actor) = @{{
-		'010F' => [Skill::OWNER_CHAR, 'packet_charSkills'],
+		'010F' => [Skill::OWNER_CHAR, 'packet_charSkills', $char],
 		'0235' => [Skill::OWNER_HOMUN, 'packet_homunSkills', $char->{homunculus}],
 		'029D' => [Skill::OWNER_MERC, 'packet_mercSkills', $char->{mercenary}],
-		'0B32' => [Skill::OWNER_CHAR, 'packet_charSkills'],
+		'0B32' => [Skill::OWNER_CHAR, 'packet_charSkills', $char],
 	}->{$args->{switch}}};
 
-	my $skillsIDref = $actor ? \@{$actor->{slave_skillsID}} : \@skillsID;
-	delete @{$char->{skills}}{@$skillsIDref};
+	my $skillsIDref;
+	if ($ownerType == Skill::OWNER_CHAR) {
+		$skillsIDref = \@skillsID;
+		delete @{$char->{skills}}{@$skillsIDref};
+	} elsif ($ownerType == Skill::OWNER_HOMUN) {
+		$skillsIDref = \@{$char->{homunculus}->{slave_skillsID}};
+		delete @{$char->{homunculus}->{skills}}{@$skillsIDref};
+	} elsif ($ownerType == Skill::OWNER_MERC) {
+		$skillsIDref = \@{$char->{mercenary}->{slave_skillsID}};
+		delete @{$char->{mercenary}->{skills}}{@$skillsIDref};
+	}
 	@$skillsIDref = ();
 
-	# TODO: $actor can be undefined here
-	undef @{$actor->{slave_skillsID}};
 	for (my $i = 4; $i < $args->{RAW_MSG_SIZE}; $i += $skill_info->{len}) {
 		my $skill;
 		@{$skill}{@{$skill_info->{keys}}} = unpack($skill_info->{types}, substr($msg, $i, $skill_info->{len}));
@@ -9328,7 +9335,7 @@ sub skills_list {
 		my $handle = Skill->new(idn => $skill->{ID})->getHandle;
 
 		foreach(@{$skill_info->{keys}}) {
-			$char->{skills}{$handle}{$_} = $skill->{$_};
+			$actor->{skills}{$handle}{$_} = $skill->{$_};
 		}
 
 		binAdd($skillsIDref, $handle) unless defined binFind($skillsIDref, $handle);


### PR DESCRIPTION
Fixes #3913 

Each actor now holds their own skill list.

Possible problem is that I don't know actually how skills are handled in the server, if they are coded as a character skill then their use must remain in AI::Corelogic, if however slaves are their own separate entity with cooldowns of their own then it would probably be wise to move their skill usage to their AI.

![58121ea4deb7469df1977f96e9d7dff3](https://github.com/user-attachments/assets/2d4d4a09-0758-45a9-bf6a-24a781825675)

EDIT:
It does seem char and slave are completely independent, I'll move the skill use logic to their AI

EDIT2:
Done, just gotta test it

Edit 3:

Video showing it working:
[Youtube](https://youtu.be/PK9ckS35uNg)