### PR TITLE
Minimum package support 0A15 (PACKET_ZC_GOLDPCCAFE_POINT)

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -12329,4 +12329,11 @@ sub repute_info {
 	}
 }
 
+# 0A15 - PACKET_ZC_GOLDPCCAFE_POINT
+# TODO: this package is not supported yet.
+sub gold_pc_cafe_point {
+	my ($self, $args) = @_;
+	debug TF("[gold_pc_cafe_point] isActive=%d, mode=%d, point=%d, playedTime=%d\n", $args->{isActive}, $args->{mode}, $args->{point}, $args->{playedTime});
+}
+
 1;

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -635,6 +635,7 @@ sub new {
 		'0A10' => ['storage_items_nonstackable', 'v Z24 a*', [qw(len title itemInfo)]],
 		'0A12' => ['rodex_open_write', 'Z24 C', [qw(name result)]],   # 27
 		'0A14' => ['rodex_check_player', 'V v2', [qw(char_id class base_level)]],
+		'0A15' => ['gold_pc_cafe_point', 'C2 V2', [qw(isActive mode point playedTime)]], # 12
 		'0A18' => ['map_loaded', 'V a3 C2 v C', [qw(syncMapSync coords xSize ySize font sex)]], # 14
 		'0A1A' => ['roulette_window', 'C V C2 v V3', [qw(result serial stage price additional_item gold silver bronze)]],
 		'0A1C' => ['roulette_info', 'v V a*', [qw(len serial roulette_info)]],

--- a/src/Network/Receive/kRO/Sakexe_0.pm
+++ b/src/Network/Receive/kRO/Sakexe_0.pm
@@ -627,6 +627,7 @@ sub new {
 		'0A10' => ['storage_items_nonstackable', 'v Z24 a*', [qw(len title itemInfo)]],
 		'0A12' => ['rodex_open_write', 'Z24 C', [qw(name result)]],   # 27
 		'0A14' => ['rodex_check_player', 'V v2', [qw(char_id class base_level)]],
+		'0A15' => ['gold_pc_cafe_point', 'C2 V2', [qw(isActive mode point playedTime)]], # 12
 		'0A18' => ['map_loaded', 'V a3 C2 v C', [qw(syncMapSync coords xSize ySize font sex)]], # 14
 		'0A1A' => ['roulette_window', 'C V C2 v V3', [qw(result serial stage price additional_item gold silver bronze)]],
 		'0A1C' => ['roulette_info', 'v V a*', [qw(len serial roulette_info)]],


### PR DESCRIPTION
This query solves the problem: https://github.com/OpenKore/openkore/issues/3907
```
<< Received packet:      0A15 [12 bytes]   2024.12.17 09:12:57
  0>  15 0A 01 01 35 00 00 00    AF 00 00 00                ....5.......
[2024.12.17 09:12:57.41] Packet Parser: Unknown switch: 0A15

#if PACKETVER >= 20140611
struct PACKET_ZC_GOLDPCCAFE_POINT {
	// Note: 2014-04-30 has 1 byte less, but those packets are only functional after 2014-06-11Ragexe
	uint16 PacketType;
	int8 isActive; //< 1 = yes, 0 = no
	int8 mode;
	int32 point;
	int32 playedTime;
} __attribute__((packed));
DEFINE_PACKET_HEADER(ZC_GOLDPCCAFE_POINT , 0x0a15);
#endif // PACKETVER >= 20140611
```

If you get the error "Received unknown packet", just add a new packet to therecvpackets.txt file:
```
0A15 12
```

I haven't tested this functionality!


https://github.com/rathena/rathena/pull/7410
https://rathena.org/board/topic/139548-goldpc-shop/
![image](https://github.com/user-attachments/assets/2195fdf3-5400-4c62-897f-d5c59d4da74a)


