### PR TITLE
Prevent repeated move packets

### DIFF
--- a/src/AI/Attack.pm
+++ b/src/AI/Attack.pm
@@ -523,17 +523,23 @@ sub main {
 	
 	# Here we check if we have finished moving to the meeting position to attack our target, only checks this if attackWaitApproachFinish is set to 1 in config
 	# If so sets sentApproach to 0
-	if (
-		$config{"attackWaitApproachFinish"} &&
-		($canAttack == 0 || $canAttack == -1) &&
-		$args->{sentApproach}
-	) {
-		if (!timeOut($char->{time_move}, $char->{time_move_calc})) {
-			debug TF("[Out of Range - Still Approaching - Waiting] %s (%d %d), target %s (%d %d), distance %d, maxDistance %d, dmgFromYou %d.\n", $char, $realMyPos->{x}, $realMyPos->{y}, $target, $realMonsterPos->{x}, $realMonsterPos->{y}, $realMonsterDist, $args->{attackMethod}{maxDistance}, $target->{dmgFromYou}), 'ai_attack';
-			return;
+	if ($args->{sentApproach}) {
+		if ($config{"attackWaitApproachFinish"}) {
+			if (!timeOut($char->{time_move}, $char->{time_move_calc})) {
+				debug TF("[attackWaitApproachFinish - Waiting] %s (%d %d), target %s (%d %d), distance %d, maxDistance %d, dmgFromYou %d.\n", $char, $realMyPos->{x}, $realMyPos->{y}, $target, $realMonsterPos->{x}, $realMonsterPos->{y}, $realMonsterDist, $args->{attackMethod}{maxDistance}, $target->{dmgFromYou}), 'ai_attack';
+				return;
+			} else {
+				debug TF("[attackWaitApproachFinish - Ended Approaching] %s (%d %d), target %s (%d %d), distance %d, maxDistance %d, dmgFromYou %d.\n", $char, $realMyPos->{x}, $realMyPos->{y}, $target, $realMonsterPos->{x}, $realMonsterPos->{y}, $realMonsterDist, $args->{attackMethod}{maxDistance}, $target->{dmgFromYou}), 'ai_attack';
+				$args->{sentApproach} = 0;
+			}
 		} else {
-			debug TF("[Out of Range - Ended Approaching] %s (%d %d), target %s (%d %d), distance %d, maxDistance %d, dmgFromYou %d.\n", $char, $realMyPos->{x}, $realMyPos->{y}, $target, $realMonsterPos->{x}, $realMonsterPos->{y}, $realMonsterDist, $args->{attackMethod}{maxDistance}, $target->{dmgFromYou}), 'ai_attack';
-			$args->{sentApproach} = 0;
+			if ($canAttack == 2) {
+				debug TF("[Approaching - Can now attack] %s (%d %d), target %s (%d %d), distance %d, maxDistance %d, dmgFromYou %d.\n", $char, $realMyPos->{x}, $realMyPos->{y}, $target, $realMonsterPos->{x}, $realMonsterPos->{y}, $realMonsterDist, $args->{attackMethod}{maxDistance}, $target->{dmgFromYou}), 'ai_attack';
+				$args->{sentApproach} = 0;
+			} elsif (timeOut($char->{time_move}, $char->{time_move_calc})) {
+				debug TF("[Approaching - Ended] Still no LOS/Range - %s (%d %d), target %s (%d %d), distance %d, maxDistance %d, dmgFromYou %d.\n", $char, $realMyPos->{x}, $realMyPos->{y}, $target, $realMonsterPos->{x}, $realMonsterPos->{y}, $realMonsterDist, $args->{attackMethod}{maxDistance}, $target->{dmgFromYou}), 'ai_attack';
+				$args->{sentApproach} = 0;
+			}
 		}
 	}
 	

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1427,6 +1427,7 @@ sub processAutoStorage {
 					getNPCInfo($config{storageAuto_npc}, $realpos);
 
 					ai_talkNPC($realpos->{pos}{x}, $realpos->{pos}{y}, $config{'storageAuto_npc_steps'});
+					AI::args->{'is_storageAuto'} = 1;
 				}
 
 				#delete $ai_v{temp}{storage_opened};

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -29,7 +29,7 @@ use Log qw(message debug warning error);
 use Network;
 use Plugins;
 use Misc qw(canUseTeleport portalExists);
-use Utils qw(timeOut blockDistance existsInList);
+use Utils qw(timeOut blockDistance existsInList calcPosFromPathfinding);
 use Utils::PathFinding;
 use Utils::Exceptions;
 use AI qw(ai_useTeleport);
@@ -170,7 +170,8 @@ sub iterate {
 	} elsif ( $self->{mapSolution}[0]{steps} ) {
 		my $min_npc_dist = 8;
 		my $max_npc_dist = 10;
-		my $dist_to_npc = blockDistance($self->{actor}{pos}, $self->{mapSolution}[0]{pos});
+		my $realPos = calcPosFromPathfinding($field, $self->{actor});
+		my $dist_to_npc = blockDistance($realPos, $self->{mapSolution}[0]{pos});
 		
 		if (!exists $self->{mapSolution}[0]{retry} || !defined $self->{mapSolution}[0]{retry}) {
 			$self->{mapSolution}[0]{retry} = 0;
@@ -193,17 +194,17 @@ sub iterate {
 					delete $self->{mapSolution}[0]{error};
 
 				} else {
-
-
+					if (!exists $self->{mapSolution}[0]{plugin_retry}) {
+						$self->{mapSolution}[0]{plugin_retry} = 0;
+					}
 					my %plugin_args = (
-						x            => $self->{mapSolution}[0]{pos}{x},
-						y            => $self->{mapSolution}[0]{pos}{y},
-						steps        => $self->{mapSolution}[0]{steps},
-						portal       => $self->{mapSolution}[0]{portal},
-						plugin_retry => $self->{mapSolution}[0]{plugin_retry}
+						'x'            => $self->{mapSolution}[0]{pos}{x},
+						'y'            => $self->{mapSolution}[0]{pos}{y},
+						'steps'        => $self->{mapSolution}[0]{steps},
+						'portal'       => $self->{mapSolution}[0]{portal},
+						'plugin_retry' => $self->{mapSolution}[0]{plugin_retry},
+						'return'       => 0
 					);
-					$plugin_args{plugin_retry} = 0 if (!defined $plugin_args{plugin_retry});
-					$plugin_args{return} = 0;
 
 					Plugins::callHook('npc_teleport_missing' => \%plugin_args);
 

--- a/src/Task/Route.pm
+++ b/src/Task/Route.pm
@@ -520,6 +520,16 @@ sub iterate {
 						return;
 					}
 				}
+				
+				if ($current_pos_to->{x} == $self->{next_pos}{x} && $current_pos_to->{y} == $self->{next_pos}{y}) {
+					debug "[Test] [Route] Not sending next step ($self->{next_pos}{x}, $self->{next_pos}{y}) because our pos_to is the same as it.\n", "route";
+					if ($self->{lastStep} == 1 && !$self->{sendAttackWithMove} && $self->{meetingSubRoute}) {
+						debug "[Test] [Route] Also ending task now ang giving back control to AI::Attack.\n", "route";
+						Plugins::callHook('route', {status => 'success'});
+						$self->setDone();
+					}
+					return;
+				}
 
 				if ($self->{start} || ($self->{last_pos}{x} != $current_pos->{x} || $self->{last_pos}{y} != $current_pos->{y})) {
 					$self->{time_step} = time;

--- a/src/Task/Route.pm
+++ b/src/Task/Route.pm
@@ -522,9 +522,9 @@ sub iterate {
 				}
 				
 				if ($current_pos_to->{x} == $self->{next_pos}{x} && $current_pos_to->{y} == $self->{next_pos}{y}) {
-					debug "[Test] [Route] Not sending next step ($self->{next_pos}{x}, $self->{next_pos}{y}) because our pos_to is the same as it.\n", "route";
+					debug "[Route] Not sending next step ($self->{next_pos}{x}, $self->{next_pos}{y}) because our pos_to is the same as it.\n", "route";
 					if ($self->{lastStep} == 1 && !$self->{sendAttackWithMove} && $self->{meetingSubRoute}) {
-						debug "[Test] [Route] Also ending task now ang giving back control to AI::Attack.\n", "route";
+						debug "[Route] Also ending task now ang giving back control to AI::Attack.\n", "route";
 						Plugins::callHook('route', {status => 'success'});
 						$self->setDone();
 					}

--- a/src/Task/TalkNPC.pm
+++ b/src/Task/TalkNPC.pm
@@ -349,6 +349,33 @@ sub iterate {
 				return unless ($self->addSteps($self->{sequence}));
 				$self->{stage} = TALKING_TO_NPC;
 				$self->{time} = time;
+			} else {
+				
+				if (!exists $self->{plugin_retry}) {
+					$self->{plugin_retry} = 0;
+				}
+				my %plugin_args = (
+					'x'            => $self->{x},
+					'y'            => $self->{y},
+					'nameID'       => $self->{nameID},
+					'sequence'     => $self->{sequence},
+					'plugin_retry' => $self->{plugin_retry},
+					'return'       => 0
+				);
+
+				Plugins::callHook('TalkNPC_npc_missing' => \%plugin_args);
+
+				if ($plugin_args{return}) {
+					$self->{plugin_retry}++;
+					$self->{x} = $plugin_args{x};
+					$self->{y} = $plugin_args{y};
+					$self->{nameID} = $plugin_args{nameID};
+					$self->{sequence} = $plugin_args{sequence};
+					warning "[TalkNPC] Could not find NPC, retry set by hookcall.\n", 'ai_npcTalk';
+					
+				} else {
+					$self->setError(NPC_NOT_FOUND, TF("Could not find an NPC."));
+				}
 			}
 		}
 


### PR DESCRIPTION
Currently Task Route sends multiple packets of character move to the same cell in a repeated manner, some servers really don't like that like idRO.

This change prevents the Task from sending a new move packet if it's destination is the same as the current character movement.

Also when this happens and you are in a meeting route to a targer, give back control to AI::Attack.