### PR TITLE
Fix parsenpc steps in portals

### DIFF
--- a/src/Task/TalkNPC.pm
+++ b/src/Task/TalkNPC.pm
@@ -906,7 +906,8 @@ sub waitingForSteps {
 
 sub addSteps {
 	my ($self, $steps) = @_;
-	my @new_steps = parseArgs($steps);
+	
+	my @new_steps = parse_portal_conversation_args($steps);
 
 	debug "Task::TalkNPC::addSteps has been called with value '".$steps."'.\n", "ai_npcTalk";
 

--- a/src/Utils.pm
+++ b/src/Utils.pm
@@ -50,7 +50,7 @@ our @EXPORT = (
 	# Other stuff
 	qw(dataWaiting dumpHash formatNumber getCoordString getCoordString2
 	getFormattedDate getFormattedDateShort getHex giveHex getRange getTickCount
-	inRange judgeSkillArea makeCoordsDir makeCoordsXY makeCoordsFromTo makeDistMap makeIP encodeIP parseArgs
+	inRange judgeSkillArea makeCoordsDir makeCoordsXY makeCoordsFromTo makeDistMap makeIP encodeIP parseArgs parse_portal_conversation_args
 	quarkToString stringToQuark shiftPack swrite timeConvert timeOut
 	urldecode urlencode unShiftPack vocalString wrapText pin_encode)
 );
@@ -1570,6 +1570,45 @@ sub parseArgs {
 	}
 	$$r_last_arg_pos = $last_arg_pos if ($r_last_arg_pos);
 	return reverse @args;
+}
+
+sub parse_portal_conversation_args {
+    my ($command) = @_;
+    my @args;
+    my $i = 0;
+    my $len = length($command);
+
+    while ($i < $len) {
+        # Skip leading whitespace
+        $command =~ /\G\s*/gc;
+
+        # End of string
+        last if $i >= $len;
+
+        # Check current position
+        $i = pos($command);
+
+        # Handle quoted strings
+        if ($command =~ /\G(["'])(.*?)\1\s*/gc) {
+            push @args, $2;
+        }
+        # Handle regex r~/.../flags
+        elsif ($command =~ /\Gr~\/((?:\\\/|[^\/])+)\/([a-z]*)\s*/gc) {
+            my ($regex, $flags) = ($1, $2);
+            push @args, "r~/$regex/$flags";
+        }
+        # Handle normal token (non-whitespace)
+        elsif ($command =~ /\G(\S+)\s*/gc) {
+            push @args, $1;
+        } else {
+            # Fallback: skip one character
+            pos($command)++;
+        }
+
+        $i = pos($command);
+    }
+
+    return @args;
 }
 
 ##


### PR DESCRIPTION
When a portal like this exists:
prontera 282 200 gef_fild10 52 326 1700 1 c r~/(warp|telepor)/i c r~/orc dungeon/i

It was failing like this:

[2025.05.01 10:04:11.42] [test addSteps] step 1 'c r~/(warp|telepor)/i c r~/orc dungeon/i'
[2025.05.01 10:04:11.42] [test addSteps] new_steps 2 dump $VAR1 = [
          'c',
          'r~/(warp|telepor)/i',
          'c',
          'r~/orc',
          'dungeon/i'
        ];

This change fixes that.