### PR TITLE
add 'k' sequence to approach npcs and portals to auto trigger talk

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -5522,19 +5522,24 @@ sub absunit {
 sub autoNpcTalk {
 	my ($ID, $nameID) = @_;
 
-	my $Index = AI::findAction("NPC");
-	if (!defined $Index) {
-		debug "An unexpected npc conversation has started, auto-creating a TalkNPC Task\n";
-		my $task = Task::TalkNPC->new(type => 'autotalk', nameID => $nameID, ID => $ID);
-		AI::queue("NPC", $task);
-		# TODO: The following npc_talk hook is only added on activation.
-		# Make the task module or AI listen to the hook instead
-		# and wrap up all the logic.
-		$task->activate;
-		Plugins::callHook('npc_autotalk', {
-			task => $task
-		});
-	}
+	return if (defined AI::findAction("NPC"));
+
+	my $routeIndex = AI::findAction("route");
+	return if (defined $routeIndex && AI::args($routeIndex)->getSubtask && UNIVERSAL::isa(AI::args($routeIndex)->getSubtask, 'Task::TalkNPC'));
+
+	my $routeIndex = AI::findAction("route", 1);
+	return if (defined $routeIndex && AI::args($routeIndex)->getSubtask && UNIVERSAL::isa(AI::args($routeIndex)->getSubtask, 'Task::TalkNPC'));
+
+	debug "An unexpected npc conversation has started, auto-creating a TalkNPC Task\n";
+	my $task = Task::TalkNPC->new(type => 'autotalk', nameID => $nameID, ID => $ID);
+	AI::queue("NPC", $task);
+	# TODO: The following npc_talk hook is only added on activation.
+	# Make the task module or AI listen to the hook instead
+	# and wrap up all the logic.
+	$task->activate;
+	Plugins::callHook('npc_autotalk', {
+		task => $task
+	});
 }
 
 return 1;

--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -218,7 +218,8 @@ our @EXPORT = (
 	solveItemLink
 	solveMessage
 	solveMSG
-	absunit/,
+	absunit
+	autoNpcTalk/,
 
 	# Npc buy and sell
 	qw/cancelNpcBuySell
@@ -5515,6 +5516,24 @@ sub absunit {
 		return 1;
 	} else {
 		return -1;
+	}
+}
+
+sub autoNpcTalk {
+	my ($ID, $nameID) = @_;
+
+	my $Index = AI::findAction("NPC");
+	if (!defined $Index) {
+		debug "An unexpected npc conversation has started, auto-creating a TalkNPC Task\n";
+		my $task = Task::TalkNPC->new(type => 'autotalk', nameID => $nameID, ID => $ID);
+		AI::queue("NPC", $task);
+		# TODO: The following npc_talk hook is only added on activation.
+		# Make the task module or AI listen to the hook instead
+		# and wrap up all the logic.
+		$task->activate;
+		Plugins::callHook('npc_autotalk', {
+			task => $task
+		});
 	}
 }
 

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -7411,20 +7411,9 @@ sub hat_effect {
 sub npc_talk {
 	my ($self, $args) = @_;
 
-	#Auto-create Task::TalkNPC if not active
-	if (!AI::is("NPC") && !(AI::is("route") && $char->args->getSubtask && UNIVERSAL::isa($char->args->getSubtask, 'Task::TalkNPC'))) {
-		my $nameID = unpack 'V', $args->{ID};
-		debug "An unexpected npc conversation has started, auto-creating a TalkNPC Task\n";
-		my $task = Task::TalkNPC->new(type => 'autotalk', nameID => $nameID, ID => $args->{ID});
-		AI::queue("NPC", $task);
-		# TODO: The following npc_talk hook is only added on activation.
-		# Make the task module or AI listen to the hook instead
-		# and wrap up all the logic.
-		$task->activate;
-		Plugins::callHook('npc_autotalk', {
-			task => $task
-		});
-	}
+	my $ID = $args->{ID};
+	my $nameID = unpack 'V', $ID;
+	autoNpcTalk($ID, $nameID);
 
 	$talk{ID} = $args->{ID};
 	$talk{nameID} = unpack 'V', $args->{ID};
@@ -7509,20 +7498,7 @@ sub npc_talk_responses {
 
 	my $ID = substr($msg, 4, 4);
 	my $nameID = unpack 'V', $ID;
-
-	# Auto-create Task::TalkNPC if not active
-	if (!AI::is("NPC") && !(AI::is("route") && $char->args->getSubtask && UNIVERSAL::isa($char->args->getSubtask, 'Task::TalkNPC'))) {
-		debug "An unexpected npc conversation has started, auto-creating a TalkNPC Task\n";
-		my $task = Task::TalkNPC->new(type => 'autotalk', nameID => $nameID, ID => $ID);
-		AI::queue("NPC", $task);
-		# TODO: The following npc_talk hook is only added on activation.
-		# Make the task module or AI listen to the hook instead
-		# and wrap up all the logic.
-		$task->activate;
-		Plugins::callHook('npc_autotalk', {
-			task => $task
-		});
-	}
+	autoNpcTalk($ID, $nameID);
 
 	$talk{ID} = $ID;
 	$talk{nameID} = $nameID;

--- a/tables/iRO/portals.txt
+++ b/tables/iRO/portals.txt
@@ -2780,7 +2780,7 @@ lhz_airport 143 49 lhz_airport 142 40 0 c r0 c r0
 izlude 206 55 airplane_01 244 58 1200 c r0 c r0
 
 # Rachel airship
-#(portal with dialog) ra_fild12 295 208 airplane_01 245 60 1200 c r0
+ra_fild12 295 208 airplane_01 245 60 1200 k c r0
 
 prt_fild03 371 256 prt_monk 25 248
 prt_monk 245 137 monk_in 98 183


### PR DESCRIPTION
Solution for rachel airport portal.
Rough code needs testing and cleaning.

If you stand beside the npc and do 'talknpc 294 200 k c r0' it works.
The problem is that when routing the AI is usually 'route' with a TalkNPC subtask, then this fails, needs fixing for that specific situation.