### PR TITLE
Collection of small changes

### DIFF
--- a/plugins/NewAStarAvoid/NewAStarAvoid.pl
+++ b/plugins/NewAStarAvoid/NewAStarAvoid.pl
@@ -8,6 +8,7 @@ use Plugins;
 use Utils;
 use Log qw(message debug error warning);
 use Data::Dumper;
+$Data::Dumper::Sortkeys = 1;
 
 Plugins::register('NewAStarAvoid', 'Enables smart pathing using the dynamic aspect of D* Lite pathfinding', \&onUnload);
 
@@ -78,8 +79,8 @@ my %area_spell_type_obstacles = (
 );
 
 my %portals_obstacles = (
-	weight => 1000,
-	dist => 10,
+	weight => 5000,
+	dist => 12,
 );
 
 my %obstaclesList;
@@ -424,6 +425,8 @@ sub on_PathFindingReset {
 	return unless (@obstacles > 0);
 	
 	my $args = $hookargs->{args};
+
+	return if ($args->{field}->name ne $field->name);
 	
 	#Log::warning "[test] on_PathFindingReset: Using grided info for ".@obstacles." obstacles.\n";
 	
@@ -479,7 +482,7 @@ sub create_changes_array {
 	
 	my @changes_array;
 	
-	my ($min_x, $min_y, $max_x, $max_y) = Utils::getSquareEdgesFromCoord($field, $obstacle_pos, $max_distance);
+	my ($min_x, $min_y, $max_x, $max_y) = $field->getSquareEdgesFromCoord($obstacle_pos, $max_distance);
 	
 	my @y_range = ($min_y..$max_y);
 	my @x_range = ($min_x..$max_x);

--- a/plugins/eventMacro/eventMacro.pl
+++ b/plugins/eventMacro/eventMacro.pl
@@ -33,7 +33,8 @@ my $hooks = Plugins::addHooks(
 );
 
 my $chooks = Commands::register(
-	['eventMacro', "eventMacro plugin", \&commandHandler]
+	['eventMacro', "eventMacro plugin", \&commandHandler],
+	['emacro', "eventMacro plugin", \&commandHandler]
 );
 
 my $file_handle;

--- a/plugins/eventMacro/eventMacro/Condition/FreeSkillPoints.pm
+++ b/plugins/eventMacro/eventMacro/Condition/FreeSkillPoints.pm
@@ -17,11 +17,10 @@ sub _get_val {
 sub validate_condition {
 	my ( $self, $callback_type, $callback_name, $args ) = @_;
 	
-	if ($callback_type eq 'hook') {
-		return $self->SUPER::validate_condition if $callback_name eq 'packet/stat_info' && $args && $args->{type} != 12;
-	} elsif ($callback_type eq 'variable') {
+	if ($callback_type eq 'variable') {
 		$self->update_validator_var($callback_name, $args);
 	}
+	
 	return $self->SUPER::validate_condition(  $self->validator_check );
 }
 

--- a/plugins/eventMacro/eventMacro/Core.pm
+++ b/plugins/eventMacro/eventMacro/Core.pm
@@ -478,7 +478,7 @@ sub create_callbacks {
 
 				next unless (defined $cond_indexes);
 
-				if ($hash_complement =~ /^[a-zA-Z\d]+$/) {
+				if ($hash_complement =~ /^[a-zA-Z\d_]+$/) {
 					foreach my $condition_index (@{$cond_indexes}) {
 						$self->{Event_Related_Static_Variables}{accessed_hash}{$var}{$hash_complement}{$automacro_index}{$condition_index} = 1;
 					}
@@ -636,7 +636,7 @@ sub activated_sub_callback {
 		if ($call->{type} eq 'accessed_array') {
 			next if ($value !~ /^\d+$/);
 		} elsif ($call->{type} eq 'accessed_hash') {
-			next if ($value !~ /^[a-zA-Z\d]+$/);
+			next if ($value !~ /^[a-zA-Z\d_]+$/);
 		}
 
 		my $call_complements = $self->{Dynamic_Variable_Complements}{$call->{type}}{$call->{name}}{$call->{complement}};
@@ -1411,6 +1411,10 @@ sub manage_event_callbacks {
 	}
 
 	if (defined $event_type_automacro_call_index) {
+		
+		my %hookArgs;
+		Plugins::callHook("eventMacro_before_call_check", \%hookArgs);
+		return if ($hookArgs{return});
 
 		my $automacro = $self->{Automacro_List}->get($event_type_automacro_call_index);
 
@@ -1479,9 +1483,13 @@ sub AI_start_checker {
 		if (!$automacro->get_parameter('self_interruptible') && defined $self->{Macro_Runner} && !$self->{Macro_Runner}->self_interruptible && $self->{Macro_Runner}->get_caller_name eq $automacro->get_name()) {
 			next;
 		}
+		
+		my %hookArgs;
+		Plugins::callHook("eventMacro_before_call_check", \%hookArgs);
+		return if ($hookArgs{return});
 
 		message "[eventMacro] Conditions met for automacro '".$automacro->get_name()."', calling macro '".$automacro->get_parameter('call')."'\n", "system";
-
+	
 		$self->call_macro($automacro);
 
 		return;

--- a/plugins/eventMacro/eventMacro/Data.pm
+++ b/plugins/eventMacro/eventMacro/Data.pm
@@ -11,7 +11,7 @@ our @perl_name;
 
 our $valid_var_characters = qr/\.?[a-zA-Z][a-zA-Z\d_]*/;
 
-our $general_variable_qr = qr/(?:\$$valid_var_characters(?:\[\d+\]|\{[a-zA-Z\d]+\})?|\@$valid_var_characters|\%$valid_var_characters)/;
+our $general_variable_qr = qr/(?:\$$valid_var_characters(?:\[\d+\]|\{[a-zA-Z\d_]+\})?|\@$valid_var_characters|\%$valid_var_characters)/;
 
 our $general_wider_variable_qr = qr/(?:\$$valid_var_characters(?:\[.+?\]|\{.+?\})?|\@$valid_var_characters|\%$valid_var_characters)/;
 
@@ -21,7 +21,7 @@ our $array_variable_qr = qr/\@$valid_var_characters/;
 our $accessed_array_variable_qr = qr/\$$valid_var_characters\[\d+\]/;
 
 our $hash_variable_qr = qr/\%$valid_var_characters/;
-our $accessed_hash_variable_qr = qr/\$$valid_var_characters\{[a-zA-Z\d]+\}/;
+our $accessed_hash_variable_qr = qr/\$$valid_var_characters\{[a-zA-Z\d_]+\}/;
 
 our $macro_keywords_character = '&';
 

--- a/plugins/eventMacro/eventMacro/FileParser.pm
+++ b/plugins/eventMacro/eventMacro/FileParser.pm
@@ -174,6 +174,7 @@ sub parseMacroFile {
 			}
 			elsif ($_ =~ /^}.*?{$/ && $inBlock > 0) {push(@perl_lines, $_)}
 			elsif ($_ =~ /{$/) {$inBlock++;	push(@perl_lines, $_)}
+			elsif ($_ =~ /^}.*/ && $inBlock > 0) {$inBlock--;	push(@perl_lines, $_)}
 			else {push(@perl_lines, $_)}
 			next;
 

--- a/plugins/eventMacro/eventMacro/Runner.pm
+++ b/plugins/eventMacro/eventMacro/Runner.pm
@@ -929,7 +929,7 @@ sub define_next_valid_command {
 		# Goto flow command
 		######################################
 		} elsif ($self->{current_line} =~ /^goto\s/) {
-			my ($label) = $self->{current_line} =~ /^goto\s+([a-zA-Z][a-zA-Z\d]*)/;
+			my ($label) = $self->{current_line} =~ /^goto\s+([a-zA-Z][a-zA-Z\d_]*)/;
 			if (exists $self->{label}->{$label}) {
 				debug "[eventMacro] Script is a goto flow command.\n", "eventMacro", 3;
 				$self->line_index($self->{label}->{$label});
@@ -1984,7 +1984,7 @@ sub find_and_define_key_index {
 			$self->error("Empty key of hash or index of array after parsing");
 			return;
 
-		} elsif ($type eq 'hash' && $parsed_key_index !~ /[a-zA-Z\d]+/) {
+		} elsif ($type eq 'hash' && $parsed_key_index !~ /[a-zA-Z\d_]+/) {
 			$self->error("Invalid syntax in key of hash (only use letters and numbers)");
 			return;
 
@@ -2094,7 +2094,7 @@ sub parse_keywords {
 
 	return unless @pair;
 	if ($pair[0] eq 'arg') {
-		return $command =~ /$macro_keywords_character(arg)\s*\(\s*(".*?",\s*(\d+|\$[a-zA-Z][a-zA-Z\d]*))\s*\)/
+		return $command =~ /$macro_keywords_character(arg)\s*\(\s*(".*?",\s*(\d+|\$[a-zA-Z][a-zA-Z\d_]*))\s*\)/
 	} elsif ($pair[0] eq 'random') {
 		return $command =~ /$macro_keywords_character(random)\s*\(\s*(".*?")\s*\)/
 	}

--- a/plugins/eventMacro/eventMacro/Utilities.pm
+++ b/plugins/eventMacro/eventMacro/Utilities.pm
@@ -573,7 +573,7 @@ sub find_accessed_variable {
 			return if ($complement !~ /^\d+$/ && !find_variable($complement));
 
 		} elsif ($type eq 'accessed_hash') {
-			return if ($complement !~ /^[a-zA-Z\d]+$/ && !find_variable($complement));
+			return if ($complement !~ /^[a-zA-Z\d_]+$/ && !find_variable($complement));
 		}
 
 		my $original_name = ('$'.$name.$open_bracket.$complement.$close_bracket);

--- a/src/Field.pm
+++ b/src/Field.pm
@@ -744,14 +744,32 @@ sub loadByName {
 sub nameToBaseName {
 	my ($self, $name) = @_;
 
-	my ($instanceID);
+	my ($instanceID, $baseName);
+	
+	my %hookArgs = (
+		field => $self,
+		name => $name,
+		return => 0
+	);
+	Plugins::callHook('field_nameToBaseName', \%hookArgs);
 
-	if ($name =~ /^(\w{3})(\d@.*)/) { # instanced maps, ex: 0021@cata
+	if ($hookArgs{return}) {
+		if (exists $hookArgs{baseName}) {
+			$baseName = $hookArgs{baseName};
+		}
+		if (exists $hookArgs{instanceID}) {
+			$instanceID = $hookArgs{instanceID};
+		}
+		
+	} elsif ($name =~ /^(\w{3})(\d@.*)/) { # instanced maps, ex: 0021@cata
 		$instanceID = $1;
-		$name = $2;
+		$baseName = $2;
+		
+	} else {
+		$baseName = $name;
 	}
 
-	return ($name, $instanceID);
+	return ($baseName, $instanceID);
 }
 
 sub sourceName {

--- a/src/Network/DirectConnection.pm
+++ b/src/Network/DirectConnection.pm
@@ -327,6 +327,10 @@ sub checkConnection {
 	my $self = shift;
 
 	return if ($Settings::no_connect);
+	
+	my %plugin_args = ( return => 0 );
+	Plugins::callHook('checkConnection' => \%plugin_args);
+	return if ($plugin_args{return});
 
 	if ($self->getState() == Network::NOT_CONNECTED && (!$self->{remote_socket} || !$self->{remote_socket}->connected) && timeOut($timeout_ex{'master'}) && !$conState_tries) {
 		my $master = $masterServer = $masterServers{$config{master}};

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2311,6 +2311,7 @@ typedef enum <unnamed-tag> {
 			Plugins::callHook('player_connected', {player => $actor});
 		} else {
 			debug "Unknown Connected: $args->{type} - \n", "parseMsg";
+			Plugins::callHook('unknown_connected', {unknown => $actor});
 		}
 
 	} elsif ($args->{switch} eq "007B" ||
@@ -5850,9 +5851,13 @@ sub deal_begin {
 	if ($args->{type} == 0) {
 		error T("That person is too far from you to trade.\n"), "deal";
 		Plugins::callHook('error_deal', {type => $args->{type}});
+		undef %outgoingDeal;
+		
 	} elsif ($args->{type} == 2) {
 		error T("That person is in another deal.\n"), "deal";
 		Plugins::callHook('error_deal', {type => $args->{type}});
+		undef %outgoingDeal;
+		
 	} elsif ($args->{type} == 3) {
 		if (%incomingDeal) {
 			$currentDeal{name} = $incomingDeal{name};
@@ -5871,12 +5876,17 @@ sub deal_begin {
 		}
 		message TF("Engaged Deal with %s\n", $currentDeal{name}), "deal";
 		Plugins::callHook('engaged_deal', {name => $currentDeal{name}});
+		
 	} elsif ($args->{type} == 5) {
 		error T("That person is opening storage.\n"), "deal";
 		Plugins::callHook('error_deal', {type =>$args->{type}});
+		undef %outgoingDeal;
+		
 	} else {
 		error TF("Deal request failed (unknown error %s).\n", $args->{type}), "deal";
 		Plugins::callHook('error_deal', {type =>$args->{type}});
+		undef %outgoingDeal;
+		
 	}
 }
 
@@ -7843,6 +7853,11 @@ sub deal_add_you {
 	}
 
 	my $id = unpack('v',$args->{ID});
+	
+	if ($id == 0) {
+		message "You added Zeny to Deal (suposedly $currentDeal{'you_zeny'} z).\n";
+		return;
+	}
 
 	return unless ($id > 0);
 

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -283,6 +283,7 @@ sub iterate {
 		} elsif ($dist_to_npc <= $max_npc_dist) {
 			my ($from,$to) = split /=/, $self->{mapSolution}[0]{portal};
 			if (($self->{actor}{zeny} >= $portals_lut{$from}{dest}{$to}{cost}) || ($char->inventory->getByNameID(7060) && $portals_lut{$from}{dest}{$to}{allow_ticket})) {
+				debug TF("[mapRoute] Calling setNpcTalk to teleport using NPC at %s (%s,%s) - dest (%s %s,%s).\n", $field->baseName, $self->{mapSolution}[0]{pos}{x}, $self->{mapSolution}[0]{pos}{y}, $self->{dest}{map}, $self->{dest}{pos}{x}, $self->{dest}{pos}{y}), "route";
 				# We have enough money for this service.
 				$self->setNpcTalk();
 

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -150,6 +150,11 @@ sub iterate {
 	# If the Route task bails out with an error then our subtaskDone() method will set
 	# an error in this task too. In that case we don't want to continue.
 	return if ($self->getSubtask() || $self->getStatus() != Task::RUNNING);
+	
+	my %hookArgs;
+	$hookArgs{args} = $self;
+	Plugins::callHook("MapRoute_iterate_start", \%hookArgs);
+	return if ($hookArgs{return});
 
 	my @solution;
 	if (!$self->{mapSolution}) {

--- a/src/Task/Route.pm
+++ b/src/Task/Route.pm
@@ -596,6 +596,12 @@ sub iterate {
 					}
 				}
 				
+				my %hookArgs;
+				$hookArgs{args} = $self;
+				$hookArgs{pos} = $current_calc_pos;
+				Plugins::callHook("route_before_move", \%hookArgs);
+				return if ($hookArgs{return});
+				
 				if (!$self->{start} && $current_pos_to->{x} == $self->{next_pos}{x} && $current_pos_to->{y} == $self->{next_pos}{y}) {
 					debug "[Route] Not sending next step ($self->{next_pos}{x}, $self->{next_pos}{y}) because our pos_to is the same as it.\n", "route";
 					if ($self->{lastStep} == 1 && !$self->{sendAttackWithMove} && $self->{meetingSubRoute}) {


### PR DESCRIPTION
This are a few small changes I made in my personal branches over the last few months and have not yet sent to the master branch.

Updates:
Adds a hook to attack process for custom traget dropping (AI::Attack::process)
Adds hooks to both processDeal and processDealAuto for custom deal manipulation
Adds a check so autostorage will only start when ai_canOpenStorage() is true
Adds a return to processFollow so it will only move forward when AI is follow or similiar
Addds a hook to nameToBaseName in field creation to use in custom map instances (eg. izlude_a)
Addes hooks after configmodify and bulkconfigmodify (post_configModify)
Makes bulkConfigModify create missing keys
Adds a checkSelfCondition key '_inInventoryID' which checks for inventory items by ID
Adds a hook to checkConnection for custom connection autorization
Adds unknown_connected hook
Correctly undefines %outgoingDeal when errors occur
Adds MapRoute_iterate_start hook for custom maproute steps
Adds route_before_move hook for custom "wait befone next step" logic
Fixes NewAStarAvoid
Adds secondary command for eventMacro "emacro" for easier use
Fixes emacro condition FreeSkillPoints
Adds a hook before an automacro is triggered for custom automacro blocking (eventMacro_before_call_check)
Allows underline in emacro variable names
Adds the possibility of using provided args to determine the storageauto npc and sequence instead of getting it from the config