### PR TITLE
Remove bugged actors

### DIFF
--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -3196,6 +3196,8 @@ sub processAutoAttack {
 
 	Benchmark::begin("ai_autoAttack") if DEBUG;
 
+	return if (AI::inQueue("attack"));
+	
 	return if (!$field);
 	if ((AI::isIdle || AI::is(qw/route follow sitAuto take items_gather items_take/) || (AI::action eq "mapRoute" && AI::args->{stage} eq 'Getting Map Solution'))
 	     # Don't auto-attack monsters while taking loot, and itemsTake/GatherAuto >= 2

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -48,6 +48,7 @@ use Utils::Exceptions;
 sub iterate {
 	Benchmark::begin("ai_prepare") if DEBUG;
 	processWipeOldActors();
+	processActorAvoid();
 	processGetPlayerInfo();
 	processMisc();
 	processReAddMissingPortals();
@@ -262,6 +263,39 @@ sub processWipeOldActors {
 
 		$timeout{'ai_wipe_check'}{'time'} = time;
 		debug "Wiped old\n", "ai", 2;
+	}
+}
+
+sub processActorAvoid {
+	my $realMyPos = calcPosFromPathfinding($field, $char);
+	my $max_dist = $config{clientSight} + 1;
+	my $max_to_delete = $max_dist*2;
+
+	if (timeOut($timeout{'avoidDistantActors'}{'time'}, 1)) {
+		$timeout{'avoidDistantActors'}{'time'} = time;
+		foreach my $list ($playersList, $monstersList, $npcsList, $petsList, $portalsList, $slavesList, $elementalsList) {
+			for my $actor (@$list) {
+				my $realActorPos = calcPosition($actor);
+				my $realActorDist = blockDistance($realMyPos, $realActorPos);
+
+				if ($realActorDist > $max_to_delete) {
+					warning TF("Removing way out of sight actor %s at (%d, %d) (distance: %d > max %d)\n", $actor, $actor->{pos_to}{x}, $actor->{pos_to}{y}, $realActorDist, $max_to_delete);
+					$list->remove($actor);
+
+				} elsif ($realActorDist > $max_dist) {
+					if ($actor->{avoid} == 0) {
+						warning TF("Avoiding out of sight actor %s at (%d, %d) (distance: %d > max %d)\n", $actor, $actor->{pos_to}{x}, $actor->{pos_to}{y}, $realActorDist, $max_dist);
+					}
+					$actor->{avoid} = 1;
+
+				} else {
+					if ($actor->{avoid} == 1) {
+						warning TF("Stopped avoiding now in bounds actor %s at (%d, %d) (distance: %d <= max %d)\n", $actor, $actor->{pos_to}{x}, $actor->{pos_to}{y}, $realActorDist, $max_dist);
+					}
+					$actor->{avoid} = 0;
+				}
+			}
+		}
 	}
 }
 

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -11133,6 +11133,9 @@ sub monster_ranged_attack {
 		$monster->{movetoattack_pos} = {%coords1};
 		$monster->{movetoattack_time} = time;
 	}
+	
+	$char->{movetoattack_targetID} = $ID;
+
 	$char->{movetoattack_pos} = {%coords2};
 	$char->{movetoattack_time} = time;
 	debug "Received Failed to attack target - you: $coords2{x},$coords2{y} - monster: $coords1{x},$coords1{y} - range $range\n", "parseMsg_move";

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -2086,24 +2086,6 @@ sub actor_display {
 	$actor->{time_move} = time;
 	$actor->{time_move_calc} = calcTime(\%coordsFrom, \%coordsTo, $actor->{walk_speed});
 
-	# Ignore actors with a distance greater than clientSight. Useful for vending (so you don't spam
-	# too many packets in prontera and cause server lag). As a side effect, you won't be able to "see" actors
-	# beyond clientSight.
-	if ($config{clientSight}) {
-		# TODO: Is there any situation where we should use calcPosFromPathfinding or calcPosFromTime here?
-		my $realMyPos = calcPosition($char);
-		my $realActorPos = calcPosition($actor);
-		my $realActorDist = blockDistance($realMyPos, $realActorPos);
-
-		if ($realActorDist >= $config{clientSight}) {
-			my ($actor_type) = $object_class =~ /\:\:(\w+)$/;
-			warning TF("Avoiding out of sight %s: '%s' at (%d, %d) (distance: %d >= max %d) - check clientSight in config.txt\n", $actor_type, $actor->{name}, $actor->{pos_to}{x}, $actor->{pos_to}{y}, $realActorDist, $config{clientSight});
-			$actor->{avoid} = 1;
-		} else {
-			$actor->{avoid} = 0;
-		}
-	}
-
 
 	if (UNIVERSAL::isa($actor, "Actor::Player")) {
 		# None of this stuff should matter if the actor isn't a player... => does matter for a guildflag npc!


### PR DESCRIPTION
Sometimes the server won't send the packet that informs that a monster has died and the client will keep thinking forever that the monster is there (this happens in the normal client also), this adds a routine that once a second removes actors that are twice the distance of clientSight from the character, also moves the avoid to corelogic and adds the removal of avoided actors who are now close.

This also fixes the bug where 'attack' would be added multiple times in the AI queue as seen below.
![image](https://github.com/user-attachments/assets/c37339c9-cb6f-422a-9854-b6c4db7d30be)
