### PR TITLE
We fixed a typo in start.pl that prevented modules from loading correctly when the BUILDING_WX environment variable had values ​​of 2 or 3.

### DIFF
--- a/start.pl
+++ b/start.pl
@@ -26,13 +26,13 @@
 package StarterScript;
 
 BEGIN {
-	if ($ENV{BUILDING_WX} == 1 && $^O eq 'MSWin32') {
-		require Wx::Perl::Packager;
-	} elsif ($ENv{BUILDING_WX} == 2 && $^O eq 'MSWin32') {
-		require Tk;
-	} elsif ($ENv{BUILDING_WX} == 3 && $^O eq 'MSWin32') {
-		require Win32::GUI;
-	}
+       if ($ENV{BUILDING_WX} == 1 && $^O eq 'MSWin32') {
+               require Wx::Perl::Packager;
+       } elsif ($ENV{BUILDING_WX} == 2 && $^O eq 'MSWin32') {
+               require Tk;
+       } elsif ($ENV{BUILDING_WX} == 3 && $^O eq 'MSWin32') {
+               require Win32::GUI;
+       }
 }
 
 use strict;


### PR DESCRIPTION
We fixed a typo in start.pl that prevented modules from loading correctly when the BUILDING_WX environment variable had values ​​of 2 or 3.