### PR TITLE
feat(otp): Introduce request_otp_login hook for TOTP generation

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -9,6 +9,7 @@ username
 password
 loginPinCode
 char
+otpSeed
 
 # Poseidon Settings: https://openkore.com/wiki/Poseidon
 # They must be the same as Query Server config in Poseidon.txt

--- a/control/sys.txt
+++ b/control/sys.txt
@@ -50,7 +50,7 @@ loadPlugins 2
 # loadPlugins_list <list>
 #   if loadPlugins is set to 2, this comma-separated list of plugin names (filename without the extension)
 #   specifies which plugin files to load at startup or when the "plugin load all" command is used.
-loadPlugins_list macro,profiles,breakTime,raiseStat,raiseSkill,map,reconnect,eventMacro,item_weight_recorder,xconf
+loadPlugins_list macro,profiles,breakTime,raiseStat,raiseSkill,map,reconnect,eventMacro,item_weight_recorder,xconf,OTP
 
 # skipPlugins_list <list>
 #   if loadPlugins is set to 3, this comma-separated list of plugin names (filename without the extension)

--- a/plugins/otp/otp.pl
+++ b/plugins/otp/otp.pl
@@ -1,0 +1,149 @@
+#############################################################################
+#
+# OTP Generator plugin by wizzello and pogramos
+#
+# Openkore: http://openkore.com/
+# Repository: https://github.com/wizzello/openkore-otp
+#
+# This source code is licensed under the MIT License.
+# See https://mit-license.org/
+#
+#############################################################################
+
+package OTP;
+
+use strict;
+use Plugins;
+
+Plugins::register(
+    'otp',
+    'Handles OTP requests by generating TOTP',
+    \&unload
+);
+
+# Add hook to listen for the custom OTP request event
+# This event must be triggered by OpenKore PR #4036
+my $hooks = Plugins::addHooks(
+    ['request_otp_login', \&generate]
+);
+
+sub generate {
+    my ($plugin, $args) = @_;
+    my $otp = $args->{otp};
+    my $seed = $args->{seed};
+
+    $$otp = _generate_otp($seed);
+}
+
+sub _generate_otp {
+    my ($base32_secret) = @_;
+    my $secret = _base32_decode($base32_secret);
+    my $time_step = 30;
+    my $counter = int(time() / $time_step);
+    my $high = ($counter >> 32) & 0xFFFFFFFF;
+    my $low  = $counter & 0xFFFFFFFF;
+    my $msg = pack("NN", $high, $low);
+    my $hash = _hmac_sha1($secret, $msg);
+
+    my $offset = ord(substr($hash, -1)) & 0x0f;
+    my $binary = ((ord(substr($hash, $offset, 1)) & 0x7f) << 24) |
+                 ((ord(substr($hash, $offset+1, 1)) & 0xff) << 16) |
+                 ((ord(substr($hash, $offset+2, 1)) & 0xff) << 8) |
+                 (ord(substr($hash, $offset+3, 1)) & 0xff);
+
+    my $otp = $binary % 1_000_000;
+    return sprintf("%06d", $otp);
+}
+
+sub _base32_decode {
+    my ($str) = @_;
+    $str =~ tr/A-Z2-7//cd;
+    my %map = map { substr("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", $_, 1) => $_ } 0..31;
+    my $bits = "";
+    foreach my $char (split //, uc($str)) {
+        my $val = $map{$char};
+        $bits .= sprintf("%05b", $val);
+    }
+    my $bytes = pack("B*", $bits);
+    return $bytes;
+}
+
+sub _sha1 {
+    my $msg = shift;
+
+    my @h = (
+        0x67452301,
+        0xEFCDAB89,
+        0x98BADCFE,
+        0x10325476,
+        0xC3D2E1F0
+    );
+
+    my $ml = length($msg) * 8;
+    $msg .= chr(0x80);
+    $msg .= chr(0x00) while ((length($msg) % 64) != 56);
+    my $high = ($ml >> 32) & 0xFFFFFFFF;
+    my $low  = $ml & 0xFFFFFFFF;
+    $msg .= pack("NN", $high, $low);
+
+    foreach my $chunk (unpack("(a64)*", $msg)) {
+        my @w = unpack("N16", $chunk);
+        push @w, 0 for (16..79);
+        for my $i (16..79) {
+            $w[$i] = _rol($w[$i-3] ^ $w[$i-8] ^ $w[$i-14] ^ $w[$i-16], 1);
+        }
+
+        my ($a, $b, $c, $d, $e) = @h;
+
+        for my $i (0..79) {
+            my ($f, $k);
+            if ($i <= 19) {
+                $f = ($b & $c) | ((~$b) & $d);
+                $k = 0x5A827999;
+            } elsif ($i <= 39) {
+                $f = $b ^ $c ^ $d;
+                $k = 0x6ED9EBA1;
+            } elsif ($i <= 59) {
+                $f = ($b & $c) | ($b & $d) | ($c & $d);
+                $k = 0x8F1BBCDC;
+            } else {
+                $f = $b ^ $c ^ $d;
+                $k = 0xCA62C1D6;
+            }
+
+            my $temp = (_rol($a,5) + $f + $e + $k + $w[$i]) & 0xFFFFFFFF;
+            $e = $d;
+            $d = $c;
+            $c = _rol($b,30);
+            $b = $a;
+            $a = $temp;
+        }
+
+        $h[0] = ($h[0] + $a) & 0xFFFFFFFF;
+        $h[1] = ($h[1] + $b) & 0xFFFFFFFF;
+        $h[2] = ($h[2] + $c) & 0xFFFFFFFF;
+        $h[3] = ($h[3] + $d) & 0xFFFFFFFF;
+        $h[4] = ($h[4] + $e) & 0xFFFFFFFF;
+    }
+
+    return pack("N5", @h);
+}
+
+sub _rol {
+    my ($val, $bits) = @_;
+    return (($val << $bits) | ($val >> (32 - $bits))) & 0xFFFFFFFF;
+}
+
+sub _hmac_sha1 {
+    my ($key, $data) = @_;
+    my $block_size = 64;
+    if (length($key) > $block_size) {
+        $key = sha1($key);
+    }
+    $key .= chr(0) x ($block_size - length($key));
+    my $o_key_pad = $key ^ (chr(0x5c) x $block_size);
+    my $i_key_pad = $key ^ (chr(0x36) x $block_size);
+    return _sha1($o_key_pad . sha1($i_key_pad . $data));
+}
+
+1;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -8006,7 +8006,7 @@ sub received_login_token {
     my $master = $masterServers{$config{master}};
     my $login_type = $args->{login_type};
 
-    if ($login_type == 0) {
+    if ($login_type eq 0) {
         # rAthena uses 0064 not 0825
         $messageSender->sendTokenToServer(
             $config{username},
@@ -8018,25 +8018,25 @@ sub received_login_token {
             $master->{OTP_ip},
             $master->{OTP_port}
         );
-    } 
-    elsif ($login_type == 400 || $login_type == 1000) {
+    
+    } elsif ($login_type eq 400 || $login_type == 1000) {
         die 'ERROR: otpSeed is not set in config.txt' unless $config{otpSeed};
 
         my $otp;
         Plugins::callHook('request_otp_login', { otp => \$otp, seed => $config{otpSeed} });
     	unless (defined $otp && length $otp) $otp = $interface->query(T('No Plugin returned a code, please enter your OTP: '));
         $messageSender->sendOtpToServer($otp);
-    } 
-    elsif ($login_type == 500) {
+    
+    } elsif ($login_type == 500) {
         error "Wrong OTP for account $config{username}\n", 'connection';
         my $otp = $interface->query(T('Please enter the OTP code: '));
         $messageSender->sendOtpToServer($otp);
-    } 
-    elsif ($login_type == 600) {
+    
+    } elsif ($login_type == 600) {
         error "Password Error for account $config{username}\n", 'connection';
         Misc::quit();
-    } 
-    else {
+    
+    } else {
         error "Unknown login_type $login_type\n", 'connection';
         Misc::quit();
     }

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -8024,7 +8024,15 @@ sub received_login_token {
 
         my $otp;
         Plugins::callHook('request_otp_login', { otp => \$otp, seed => $config{otpSeed} });
-    	unless (defined $otp && length $otp) $otp = $interface->query(T('No Plugin returned a code, please enter your OTP: '));
+    	unless (defined $otp && length $otp) { 
+			error "No Plugin returned a OTP code for account $config{username}\n", 'connection';
+			$otp = $interface->query(T(', please enter your OTP: ')); 
+		}
+        $messageSender->sendOtpToServer($otp);
+
+	} elsif ($login_type == 300) {
+        error "OTP token malformed for account $config{username}\n", 'connection';
+        my $otp = $interface->query(T('Please enter the OTP code: '));
         $messageSender->sendOtpToServer($otp);
     
     } elsif ($login_type == 500) {
@@ -8038,7 +8046,6 @@ sub received_login_token {
     
     } else {
         error "Unknown login_type $login_type\n", 'connection';
-        Misc::quit();
     }
 }
 

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -8046,6 +8046,7 @@ sub received_login_token {
     
     } else {
         error "Unknown login_type $login_type\n", 'connection';
+		Misc::quit();
     }
 }
 

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -8006,7 +8006,7 @@ sub received_login_token {
     my $master = $masterServers{$config{master}};
     my $login_type = $args->{login_type};
 
-    if ($login_type eq 0) {
+    if ($login_type == 0) {
         # rAthena uses 0064 not 0825
         $messageSender->sendTokenToServer(
             $config{username},
@@ -8019,7 +8019,7 @@ sub received_login_token {
             $master->{OTP_port}
         );
     
-    } elsif ($login_type eq 400 || $login_type == 1000) {
+    } elsif ($login_type == 400 || $login_type == 1000) {
         die 'ERROR: otpSeed is not set in config.txt' unless $config{otpSeed};
 
         my $otp;

--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -8024,7 +8024,7 @@ sub received_login_token {
 
         my $otp;
         Plugins::callHook('request_otp_login', { otp => \$otp, seed => $config{otpSeed} });
-        debug "Generated OTP: $otp\n", 'parseMsg', 2;
+    	unless (defined $otp && length $otp) $otp = $interface->query(T('No Plugin returned a code, please enter your OTP: '));
         $messageSender->sendOtpToServer($otp);
     } 
     elsif ($login_type == 500) {

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -769,6 +769,7 @@ sub new {
 		'0B8D' => ['repute_info', 'v C a*', [qw(len sucess reputeInfo)]], # -1
 		# 'C350' => ['senbei_vender_items_list'], #new senbei vender, need research
 		'0BA4' => ['homunculus_property', 'Z24 C v11 V4 V4 v2', [qw(name state level hunger intimacy atk matk hit critical def mdef flee aspd hp hp_max sp sp_max exp exp2 exp_max exp_max2 points_skill attack_range)]],
+		'0C23' => ['send_otp_login', 'a6 C', [qw(otp padding)]],
 	};
 
 	# Item RECORD Struct's

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -769,7 +769,7 @@ sub new {
 		'0B8D' => ['repute_info', 'v C a*', [qw(len sucess reputeInfo)]], # -1
 		# 'C350' => ['senbei_vender_items_list'], #new senbei vender, need research
 		'0BA4' => ['homunculus_property', 'Z24 C v11 V4 V4 v2', [qw(name state level hunger intimacy atk matk hit critical def mdef flee aspd hp hp_max sp sp_max exp exp2 exp_max exp_max2 points_skill attack_range)]],
-		'0C23' => ['send_otp_login', 'a6 C', [qw(otp padding)]],
+		'0C23' => ['send_otp_login', 'Z6 C', [qw(otp padding)]],
 	};
 
 	# Item RECORD Struct's

--- a/src/Network/Receive/ServerType0.pm
+++ b/src/Network/Receive/ServerType0.pm
@@ -769,7 +769,6 @@ sub new {
 		'0B8D' => ['repute_info', 'v C a*', [qw(len sucess reputeInfo)]], # -1
 		# 'C350' => ['senbei_vender_items_list'], #new senbei vender, need research
 		'0BA4' => ['homunculus_property', 'Z24 C v11 V4 V4 v2', [qw(name state level hunger intimacy atk matk hit critical def mdef flee aspd hp hp_max sp sp_max exp exp2 exp_max exp_max2 points_skill attack_range)]],
-		'0C23' => ['send_otp_login', 'Z6 C', [qw(otp padding)]],
 	};
 
 	# Item RECORD Struct's

--- a/src/Network/Send.pm
+++ b/src/Network/Send.pm
@@ -1428,6 +1428,22 @@ sub sendTokenToServer {
 	debug "Sent sendTokenLogin\n", "sendPacket", 2;
 }
 
+# Send OTP code for authentication (packet 0C23)
+# 0C23 <otp>.a6 <padding>.C
+# otp: 6-digit One-Time Password (TOTP)
+# padding: 0x00 (always 0)
+sub sendOtpToServer {
+    my ($self, $otp) = @_;
+
+    $self->sendToServer($self->reconstruct({
+        switch => 'send_otp_login',
+        otp    => $otp,
+        padding => 0x00,
+    }));
+
+    debug "Sent OTP login packet: $otp\n", "sendPacket", 2;
+}
+
 # encrypt password kRO/cRO version 2017-2018
 sub encrypt_password {
 	my ($self, $password) = @_;

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -339,6 +339,7 @@ sub new {
 		'0B19' => ['inventory_expansion_rejected'], #2
 		'0B1C' => ['ping'], #2
 		'0B21' => ['hotkey_change', 'v2 C V v', [qw(tab idx type id lvl)]],
+		'0C23' => ['send_otp_login', 'Z6 C', [qw(otp padding)]],
 	);
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 

--- a/src/Network/Send/ServerType0.pm
+++ b/src/Network/Send/ServerType0.pm
@@ -339,7 +339,7 @@ sub new {
 		'0B19' => ['inventory_expansion_rejected'], #2
 		'0B1C' => ['ping'], #2
 		'0B21' => ['hotkey_change', 'v2 C V v', [qw(tab idx type id lvl)]],
-		'0C23' => ['send_otp_login', 'Z6 C', [qw(otp padding)]],
+		'0C23' => ['send_otp_login', 'a6 C', [qw(otp padding)]],
 	);
 	$self->{packet_list}{$_} = $packets{$_} for keys %packets;
 


### PR DESCRIPTION
## Summary
Add a new request_otp_login hook to OpenKore’s received_login_token flow, enabling plugins to generate and supply a Time‑based One‑Time Password (TOTP) without altering core logic.

## Motivation
Existing plugins must patch core code or rely on brittle workarounds to intercept and halt the default sendTokenToServer call for OTP flows. By exposing a dedicated hook with a pass‑by‑reference OTP slot, we allow clean, maintainable 2FA/TOTP integrations.

## Changes

#### Receive.pm:
 - On login types 400/1000, call Plugins::callHook('request_otp_login', { otp => \$otp, seed => $config{otpSeed} }) before sending OTP.
#### Network/Send.pm:
 - Add sendOtpToServer($otp) wrapper for packet 0C23.
#### ServerType0.pm:
 - Register packet parser entry '0C23' => ['send_otp_login', 'a6 C', [qw(otp padding)]].
#### otp.pl (new plugin):
 - Pure‑Perl implementation of Base32‑decode, HMAC‑SHA1, and TOTP in a standalone plugin.
 - Listens on request_otp_login and writes the generated code back via the provided reference.
#### config.txt:
 - Introduce otpSeed parameter to supply the Base32 secret.

## Why Is This Necessary?
Modern Ragnarok servers (e.g., GNJOY LATAM, kRO) require TOTP during account login. Without a proper hook, plugins must hack core packet flows or duplicate functionality, leading to fragile maintenance. This change provides a first‑class extension point for any OTP/2FA plugin.

## Impact
- Backward compatible: Default behavior unchanged unless a plugin uses the new hook.
- No external dependencies: TOTP logic embedded in plugin.
- Easy adoption: Plugin authors can now implement OTP/TOTP purely in a plugin repository without core patches beyond PR #4036.