### PR TITLE
fix: increases the retry move timeout

### DIFF
--- a/control/timeouts.txt
+++ b/control/timeouts.txt
@@ -26,8 +26,8 @@ poseidon_wait_reply 15
 # Activate AI after x seconds after the map's loaded
 ai 1
 
-ai_move_retry 0.25
-ai_move_giveup 1
+ai_move_retry 0.4
+ai_move_giveup 1.2
 
 ai_homunculus_standby 0.5
 ai_mercenary_standby 0.5


### PR DESCRIPTION
Clients uses 350ms as default value:
<img width="415" height="162" alt="image" src="https://github.com/user-attachments/assets/1bf6d05f-ee76-4010-b2d0-fd1167eb2293" />

considering the render time i added 50ms to avoid spam