### PR TITLE
Make maxWalkPath configurable in Field.pm

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -234,6 +234,10 @@ route_tryToGuessMissingPortalByDistance 1
 route_reAddMissingPortals 1
 route_randomFactor 0
 
+# Maximum walking path distance (client setting). Default: 17
+# This corresponds to max_walk_path in server configuration
+maxWalkPathDistance 17
+
 runFromTarget 0
 runFromTarget_inAdvance 0
 runFromTarget_dist 5

--- a/src/Field.pm
+++ b/src/Field.pm
@@ -46,7 +46,7 @@ use Compress::Zlib;
 use File::Spec;
 use Log qw(message);
 
-use Globals qw($masterServer %mapAlias_lut %maps_lut %cities_lut);
+use Globals qw($masterServer %mapAlias_lut %maps_lut %cities_lut %config);
 use Modules 'register';
 use Settings;
 use FastUtils;
@@ -418,10 +418,10 @@ sub canMove {
 
 	my $dist = blockDistance($from, $to);
 
-	# This 17 is actually set at
+	# This value is actually set at
 	# hercules conf\map\battle\client.conf max_walk_path (which is by default 17, can be higher)
-	# TODO: Change this 17 to a config key with default value 17
-	if ($dist > 17) {
+	my $maxWalkPath = $config{maxWalkPathDistance} || 17;
+	if ($dist > $maxWalkPath) {
 		return 0;
 	}
 


### PR DESCRIPTION
- Replace hardcoded value 17 with configurable maxWalkPathDistance
- Add maxWalkPathDistance config option with default value 17
- Corresponds to server's max_walk_path setting (hercules/rathena)
- Maintains backward compatibility with default behavior

Resolves TODO in Field.pm line 423