### PR TITLE
Enhance auto-repair system with advanced options

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -387,6 +387,15 @@ tankersList
 
 repairAuto 0
 repairAuto_list
+repairAuto_npc
+repairAuto_standpoint
+repairAuto_distance 3
+repairAuto_maxDistance
+repairAuto_npc_steps c r0 c c r0 n
+repairAuto_useSkill 0
+repairAuto_equipAfter 1
+repairAuto_warp 0
+repairAuto_inTownOnly 0
 
 status_mapProperty 0
 status_mapType 0


### PR DESCRIPTION
Added new configuration options for auto-repair, including NPC selection, distance, skill usage, and in-town-only restriction. Refactored and expanded the repair logic in CoreLogic.pm to support equipping after repair, skill-based repair, and improved NPC interaction and routing.

#Reworked:
**repairAuto** _\<boolean flag>_ - Now an NPC can handle the repair, it is no longer directly tied to the repair skill
**repairAuto_list** _\<short equipment name/id>_ - Now also supports ids

#These works the same as autoSell/autoStorage rules:
**repairAuto_npc** _\<map name> \<x> \<y>_
**repairAuto_standpoint** _\<map name> \<x> \<y>_
**repairAuto_distance** _\<number>_
**repairAuto_maxDistance** _\<number>_
**repairAuto_npc_steps** _\<NPC conversation codes>_

#New:
**repairAuto_useSkill** _\<boolean flag>_ - Uses Weapon Repair (108) skill for repair, instead of NPC
**repairAuto_equipAfter** _\<boolean flag>_ - Automatically equips gear after repair
**repairAuto_warp** _\<boolean flag>_ - Allow use of warp items (eg. Butterlfy Wing) for faster repair
**repairAuto_inTownOnly** _\<boolean flag>_ - AI will only queue repairAuto when in town
