### PR TITLE
Add modes for teleportAuto_attackedWhenSitting

### DIFF
--- a/src/Misc.pm
+++ b/src/Misc.pm
@@ -3443,17 +3443,16 @@ sub updateDamageTables {
 						$monster, $player, $config{$player->{configPrefix}.'teleportAuto_maxDmgInLock'}), "teleport";
 					$teleport = 1;
 
-				} elsif (AI::inQueue("sitAuto")
-							&& $config{$player->{configPrefix}.'teleportAuto_attackedWhenSitting'} == 1
-							&& $damage) {
-					message TF("%s hit %s while you are sitting. Teleporting...\n",
-						$monster, $player), "teleport";
-					$teleport = 1;
-
-				} elsif (AI::inQueue("sitAuto")
-							&& $config{$player->{configPrefix}.'teleportAuto_attackedWhenSitting'} == 2) {
-					message TF("%s attacked %s while you are sitting. Teleporting...\n",
-						$monster, $player), "teleport";
+				} elsif (($player->{sitting} || AI::inQueue("sitAuto"))
+							&& $config{$player->{configPrefix}.'teleportAuto_attackedWhenSitting'}
+							&& ($damage || $config{$player->{configPrefix}.'teleportAuto_attackedWhenSitting'} == 2)) {
+					if ($damage) {
+						message TF("%s hit %s while you are sitting. Teleporting...\n",
+							$monster, $player), "teleport";
+					} else {
+						message TF("%s attacked %s while you are sitting. Teleporting...\n",
+							$monster, $player), "teleport";
+					}
 					$teleport = 1;
 
 				} elsif ($config{$player->{configPrefix}.'teleportAuto_totalDmg'}


### PR DESCRIPTION
The new condition checks the configured teleportAuto_attackedWhenSitting value and triggers when either actual damage occurred or the config is set to 2, also respects the player's explicit sitting state ($player->{sitting}) as well as the sitAuto AI queue. . The code now selects the appropriate message text ('hit' vs 'attacked') based on whether $damage is present, reducing duplicated logic and clarifying intent.

**teleportAuto_attackedWhenSitting <value>**

|Value|Description|
|---|---|
|0|Disabled.|
|1|Teleports when hit while sitting.|
|2|Teleports when attacked while sitting (even when not hit).|