### PR TITLE
Add saveMap warp, min-distance and route checks

### DIFF
--- a/control/config.txt
+++ b/control/config.txt
@@ -250,7 +250,9 @@ runFromTarget_noAttackMethodFallback_minStep 8
 saveMap
 saveMap_x
 saveMap_y
+saveMap_warp 0
 saveMap_warpToBuyOrSell 1
+saveMap_warp_minDistance
 saveMap_warpChatCommand
 memo1
 memo2

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -1425,8 +1425,7 @@ sub processAutoStorage {
 				}
 
 				# If warpToBuyOrSell is set, warp to saveMap if we haven't done so
-				if ($config{'saveMap'} ne "" && $config{'saveMap_warpToBuyOrSell'} && !$args->{warpedToSave}
-				    && !$field->isCity && $config{'saveMap'} ne $field->baseName) {
+				if (shouldUseWarpToSaveMapForBuyOrSell($args)) {
 					if ($char->{sitting}) {
 						message T("Standing up to auto-storage\n"), "teleport";
 						ai_setSuspend(0);
@@ -1888,8 +1887,7 @@ sub processAutoSell {
 				undef $args->{'warpedToSave'};
 			}
 
-			if ($config{'saveMap'} ne "" && $config{'saveMap_warpToBuyOrSell'} && !$args->{'warpedToSave'}
-			&& !$field->isCity && $config{'saveMap'} ne $field->baseName) {
+			if (shouldUseWarpToSaveMapForBuyOrSell($args)) {
 				if ($char->{sitting}) {
 					message T("Standing up to auto-sell\n"), "teleport";
 					ai_setSuspend(0);
@@ -2163,12 +2161,7 @@ sub processAutoBuy {
 				}
 
 				my $msgneeditem;
-				if (
-					$config{'saveMap'} ne "" &&
-					$config{'saveMap_warpToBuyOrSell'} &&
-					!$args->{warpedToSave} &&
-					!$field->isCity && $config{'saveMap'} ne $field->baseName
-				) {
+				if (shouldUseWarpToSaveMapForBuyOrSell($args)) {
 					if ($char->{sitting}) {
 						message T($msgneeditem."Standing up to auto-buy\n"), "teleport";
 						ai_setSuspend(0);
@@ -4052,6 +4045,78 @@ sub processFeed {
 		$messageSender->sendPetMenu(1);
 		$timeout{ai_petFeed}{time} = time;
 	}
+}
+
+sub shouldUseWarpToSaveMapForBuyOrSell {
+	my ($args) = @_;
+
+	return 0 if (!$config{'saveMap'} || !$config{'saveMap_warpToBuyOrSell'} || $args->{warpedToSave});
+	return 0 if ($field->isCity || $config{'saveMap'} eq $field->baseName);
+
+	my $minDistance = int($config{'saveMap_warp_minDistance'} || 0);
+	return 1 if ($minDistance <= 0);
+
+	my $distance = getDistanceToSaveMapFromCurrentPosition($args);
+	return 1 unless defined $distance;
+
+	return $distance >= $minDistance;
+}
+
+sub getDistanceToSaveMapFromCurrentPosition {
+	my ($args) = @_;
+
+	my $cacheKey = join('|',
+		$field->baseName,
+		$char->{pos_to}{x},
+		$char->{pos_to}{y},
+		(defined $config{'saveMap'} ? $config{'saveMap'} : ''),
+		(defined $config{'saveMap_x'} ? $config{'saveMap_x'} : ''),
+		(defined $config{'saveMap_y'} ? $config{'saveMap_y'} : ''),
+	);
+	if ($args && $args->{saveMapDistanceCache} && $args->{saveMapDistanceCache}{key} eq $cacheKey) {
+		return $args->{saveMapDistanceCache}{value};
+	}
+
+	require Task::CalcMapRoute;
+	my $saveMapDestination = Task::CalcMapRoute::resolveSaveMapDestination();
+	return unless ($saveMapDestination);
+
+	my $save_map = $saveMapDestination->{map};
+	my $save_x = int($saveMapDestination->{x});
+	my $save_y = int($saveMapDestination->{y});
+
+	if ($field->baseName eq $save_map) {
+		require Task::Route;
+		my @solution;
+		if (Task::Route->getRoute(\@solution, $field, $char->{pos_to}, {x => $save_x, y => $save_y})) {
+			my $distance = scalar(@solution);
+			$args->{saveMapDistanceCache} = { key => $cacheKey, value => $distance } if $args;
+			return $distance;
+		}
+		return;
+	}
+
+	require Task;
+	my $task = Task::CalcMapRoute->new(
+		targets => [{ map => $save_map, x => $save_x, y => $save_y }],
+		sourceMap => $field->baseName,
+		sourceX => $char->{pos_to}{x},
+		sourceY => $char->{pos_to}{y},
+		noGoCommand => 1,
+		noTeleSpawn => 1,
+		maxTime => 3,
+	);
+	$task->activate();
+
+	while ($task->getStatus() != Task::DONE) {
+		$task->iterate();
+	}
+
+	return if ($task->getError());
+	my $route = $task->getRoute();
+	my $distance = (!$route || !@{$route}) ? 0 : $route->[-1]{walk};
+	$args->{saveMapDistanceCache} = { key => $cacheKey, value => $distance } if $args;
+	return $distance;
 }
 
 sub processPartyShareAuto {

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -4051,7 +4051,7 @@ sub shouldUseWarpToSaveMapForBuyOrSell {
 	my ($args) = @_;
 
 	return 0 if (!$config{'saveMap'} || !$config{'saveMap_warpToBuyOrSell'} || $args->{warpedToSave});
-	return 0 if ($field->isCity || $config{'saveMap'} eq $field->baseName);
+	return 0 if ($config{'saveMap'} eq $field->baseName);
 
 	my $minDistance = int($config{'saveMap_warp_minDistance'} || 0);
 	return 1 if ($minDistance <= 0);
@@ -4065,40 +4065,9 @@ sub shouldUseWarpToSaveMapForBuyOrSell {
 sub getDistanceToSaveMapFromCurrentPosition {
 	my ($args) = @_;
 
-	my $cacheKey = join('|',
-		$field->baseName,
-		$char->{pos_to}{x},
-		$char->{pos_to}{y},
-		(defined $config{'saveMap'} ? $config{'saveMap'} : ''),
-		(defined $config{'saveMap_x'} ? $config{'saveMap_x'} : ''),
-		(defined $config{'saveMap_y'} ? $config{'saveMap_y'} : ''),
-	);
-	if ($args && $args->{saveMapDistanceCache} && $args->{saveMapDistanceCache}{key} eq $cacheKey) {
-		return $args->{saveMapDistanceCache}{value};
-	}
-
 	require Task::CalcMapRoute;
-	my $saveMapDestination = Task::CalcMapRoute::resolveSaveMapDestination();
-	return unless ($saveMapDestination);
-
-	my $save_map = $saveMapDestination->{map};
-	my $save_x = int($saveMapDestination->{x});
-	my $save_y = int($saveMapDestination->{y});
-
-	if ($field->baseName eq $save_map) {
-		require Task::Route;
-		my @solution;
-		if (Task::Route->getRoute(\@solution, $field, $char->{pos_to}, {x => $save_x, y => $save_y})) {
-			my $distance = scalar(@solution);
-			$args->{saveMapDistanceCache} = { key => $cacheKey, value => $distance } if $args;
-			return $distance;
-		}
-		return;
-	}
-
-	require Task;
-	my $task = Task::CalcMapRoute->new(
-		targets => [{ map => $save_map, x => $save_x, y => $save_y }],
+	my $calcTask = Task::CalcMapRoute->new(
+		targets => [{ map => $field->baseName, x => $char->{pos_to}{x}, y => $char->{pos_to}{y} }],
 		sourceMap => $field->baseName,
 		sourceX => $char->{pos_to}{x},
 		sourceY => $char->{pos_to}{y},
@@ -4106,16 +4075,24 @@ sub getDistanceToSaveMapFromCurrentPosition {
 		noTeleSpawn => 1,
 		maxTime => 3,
 	);
-	$task->activate();
 
-	while ($task->getStatus() != Task::DONE) {
-		$task->iterate();
+	my $saveMapDestination = $calcTask->resolveSaveMapDestination();
+	return unless ($saveMapDestination);
+
+	my $cacheKey = join('|',
+		$field->baseName,
+		$char->{pos_to}{x},
+		$char->{pos_to}{y},
+		$saveMapDestination->{map},
+		$saveMapDestination->{x},
+		$saveMapDestination->{y},
+	);
+	if ($args && $args->{saveMapDistanceCache} && $args->{saveMapDistanceCache}{key} eq $cacheKey) {
+		return $args->{saveMapDistanceCache}{value};
 	}
 
-	return if ($task->getError());
-	my $route = $task->getRoute();
-	my $distance = (!$route || !@{$route}) ? 0 : $route->[-1]{walk};
-	$args->{saveMapDistanceCache} = { key => $cacheKey, value => $distance } if $args;
+	my $distance = $calcTask->getDistanceToSaveMap($saveMapDestination->{map}, $saveMapDestination->{x}, $saveMapDestination->{y});
+	$args->{saveMapDistanceCache} = { key => $cacheKey, value => $distance } if ($args && defined $distance);
 	return $distance;
 }
 

--- a/src/AI/CoreLogic.pm
+++ b/src/AI/CoreLogic.pm
@@ -4053,11 +4053,11 @@ sub shouldUseWarpToSaveMapForBuyOrSell {
 	return 0 if (!$config{'saveMap'} || !$config{'saveMap_warpToBuyOrSell'} || $args->{warpedToSave});
 	return 0 if ($config{'saveMap'} eq $field->baseName);
 
+	my $distance = getDistanceToSaveMapFromCurrentPosition($args);
+	return 0 unless defined $distance;
+
 	my $minDistance = int($config{'saveMap_warp_minDistance'} || 0);
 	return 1 if ($minDistance <= 0);
-
-	my $distance = getDistanceToSaveMapFromCurrentPosition($args);
-	return 1 unless defined $distance;
 
 	return $distance >= $minDistance;
 }

--- a/src/Task/CalcMapRoute.pm
+++ b/src/Task/CalcMapRoute.pm
@@ -609,19 +609,30 @@ sub resolveSaveMapDestination {
 	return $candidates[0] if (@candidates == 1);
 
 	if ($target && $target->{map}) {
-		my $best;
-		my $bestWalk;
-		foreach my $candidate (@candidates) {
-			my $walk = $self->estimateWalkFromSaveMapSpawnToTarget($candidate, $target);
-			next unless defined $walk;
-			if (!defined $bestWalk || $walk < $bestWalk) {
-				$bestWalk = $walk;
-				$best = $candidate;
+		my $neighborMap = $self->getSaveMapNeighborFromWalkingRoute($dest_map, $target);
+		if (defined $neighborMap && $neighborMap ne '') {
+			my %neighborCandidates;
+			foreach my $portal (keys %portals_spawns) {
+				my ($portal_map) = split(/\s+/, $portal, 2);
+				next if (!defined $portal_map || $portal_map ne $neighborMap);
+				foreach my $dest (keys %{$portals_spawns{$portal}{dest}}) {
+					next if (hashSafeGetValue(\%portals_spawns, $portal, 'dest', $dest, 'map') ne $dest_map);
+					my $x = hashSafeGetValue(\%portals_spawns, $portal, 'dest', $dest, 'x');
+					my $y = hashSafeGetValue(\%portals_spawns, $portal, 'dest', $dest, 'y');
+					next if (!defined $x || !defined $y || $x eq '' || $y eq '');
+					$neighborCandidates{"$x $y"} = { map => $dest_map, x => $x, y => $y };
+				}
 			}
-		}
-		if ($best) {
-			$self->{saveMapDestinationCache} = { key => $cacheKey, value => $best };
-			return $best;
+
+			if (%neighborCandidates) {
+				my @bestCandidates = sort {
+					$a->{x} <=> $b->{x}
+					|| $a->{y} <=> $b->{y}
+				} values %neighborCandidates;
+
+				$self->{saveMapDestinationCache} = { key => $cacheKey, value => $bestCandidates[0] };
+				return $bestCandidates[0];
+			}
 		}
 	}
 
@@ -634,14 +645,15 @@ sub resolveSaveMapDestination {
 	return $candidates[0];
 }
 
-sub estimateWalkFromSaveMapSpawnToTarget {
-	my ($self, $spawn, $target) = @_;
+sub getSaveMapNeighborFromWalkingRoute {
+	my ($self, $saveMap, $target) = @_;
+	return unless ($target && $target->{map});
 
 	my $task = Task::CalcMapRoute->new(
 		targets => [{ map => $target->{map}, x => $target->{x}, y => $target->{y} }],
-		sourceMap => $spawn->{map},
-		sourceX => $spawn->{x},
-		sourceY => $spawn->{y},
+		sourceMap => $self->{source}{map},
+		sourceX => $self->{source}{x},
+		sourceY => $self->{source}{y},
 		noGoCommand => 1,
 		noTeleSpawn => 1,
 		maxTime => 3,
@@ -654,8 +666,23 @@ sub estimateWalkFromSaveMapSpawnToTarget {
 
 	return if ($task->getError());
 	my $route = $task->getRoute();
-	return 0 if (!$route || !@{$route});
-	return $route->[-1]{walk};
+	return if (!$route || !@{$route});
+
+	foreach my $step (@{$route}) {
+		my ($from, $to) = split(/=/, $step->{portal} || '', 2);
+		next unless (defined $from && defined $to);
+		my ($from_map) = split(/\s+/, $from, 2);
+		my ($to_map) = split(/\s+/, $to, 2);
+		next unless (defined $from_map && defined $to_map);
+
+		if ($to_map eq $saveMap) {
+			return $from_map;
+		} elsif ($from_map eq $saveMap) {
+			return $to_map;
+		}
+	}
+
+	return;
 }
 
 1;

--- a/src/Task/CalcMapRoute.pm
+++ b/src/Task/CalcMapRoute.pm
@@ -588,7 +588,9 @@ sub resolveSaveMapDestination {
 	if (defined $dest_x && defined $dest_y && $dest_x ne '' && $dest_y ne '') {
 		my $dest = $dest_map . " " . $dest_x . " " . $dest_y;
 		if (hashSafeGetValue(\%portals_spawns, $dest, 'dest', $dest)) {
-			$candidates{"$dest_x $dest_y"} = { map => $dest_map, x => $dest_x, y => $dest_y };
+			my $fixedSaveMapDestination = { map => $dest_map, x => $dest_x, y => $dest_y };
+			$self->{saveMapDestinationCache} = { key => $cacheKey, value => $fixedSaveMapDestination };
+			return $fixedSaveMapDestination;
 		}
 	}
 

--- a/src/Task/CalcMapRoute.pm
+++ b/src/Task/CalcMapRoute.pm
@@ -189,7 +189,7 @@ sub iterate {
 		$self->populateOpenListWithGoCommands() unless ($self->{noGoCommand});
 
 		delete $self->{tempPortalsSaveMap} if (exists $self->{tempPortalsSaveMap});
-		if (!$self->{noTeleSpawn} && canUseTeleport(2) && isSaveMapSetAndValid()) {
+		if (!$self->{noTeleSpawn} && canUseTeleport(2) && $self->isSaveMapSetAndValid()) {
 			$self->populateOpenListWithWarpToSaveMap();
 		}
 
@@ -460,6 +460,11 @@ sub populateOpenListWithGoCommands {
 # Add teleport lv 2 (or butterfly wing) to openlist
 sub populateOpenListWithWarpToSaveMap {
 	my ($self) = @_;
+	
+	return unless ($config{saveMap_warp});
+	return unless ($self->isWarpToSaveMapMinDistanceReached());
+	my $saveMapDestination = $self->resolveSaveMapDestination();
+	return unless ($saveMapDestination);
 
 	# set current map vars
 	my $current_map = $self->{source}{map};
@@ -467,9 +472,9 @@ sub populateOpenListWithWarpToSaveMap {
 	my $current_y   = $self->{source}{y};
 	my $from_node   = "$current_map $current_x $current_y";
 	
-	my $dest_map = hashSafeGetValue(\%config, 'saveMap');
-	my $dest_x = hashSafeGetValue(\%config, 'saveMap_x');
-	my $dest_y = hashSafeGetValue(\%config, 'saveMap_y');
+	my $dest_map = $saveMapDestination->{map};
+	my $dest_x = $saveMapDestination->{x};
+	my $dest_y = $saveMapDestination->{y};
 	
 	my $dest = $dest_map . " " . $dest_x . " " . $dest_y;
 
@@ -493,20 +498,162 @@ sub populateOpenListWithWarpToSaveMap {
 	$self->{tempPortalsSaveMap}{$dest}{dest}{$dest}{enabled} = 1;
 }
 
-sub isSaveMapSetAndValid {
-	my $dest_map = hashSafeGetValue(\%config, 'saveMap');
-	my $dest_x = hashSafeGetValue(\%config, 'saveMap_x');
-	my $dest_y = hashSafeGetValue(\%config, 'saveMap_y');
-	return 0 unless (defined $dest_map);
-	return 0 unless (defined $dest_x);
-	return 0 unless (defined $dest_y);
-	my $dest = $dest_map . " " . $dest_x . " " . $dest_y;
+sub isWarpToSaveMapMinDistanceReached {
+	my ($self) = @_;
 
-	return 0 unless (hashSafeGetValue(\%portals_spawns, $dest, 'dest', $dest));
+	my $minDistance = int(hashSafeGetValue(\%config, 'saveMap_warp_minDistance') || 0);
+	return 1 if ($minDistance <= 0);
 
+	my $saveMapDestination = $self->resolveSaveMapDestination();
+	return 1 unless ($saveMapDestination);
+
+	my $dest_map = $saveMapDestination->{map};
+	my $dest_x = $saveMapDestination->{x};
+	my $dest_y = $saveMapDestination->{y};
+
+	my $distance = $self->getDistanceToSaveMap($dest_map, $dest_x, $dest_y);
+	return ($distance >= $minDistance) if (defined $distance);
+
+	# If route distance cannot be calculated, don't block warp usage.
 	return 1;
 }
 
+sub getDistanceToSaveMap {
+	my ($self, $dest_map, $dest_x, $dest_y) = @_;
 
+	my $cacheKey = join('|', $self->{source}{map}, $self->{source}{x}, $self->{source}{y}, $dest_map, $dest_x, $dest_y);
+	if ($self->{saveMapDistanceCache} && $self->{saveMapDistanceCache}{key} eq $cacheKey) {
+		return $self->{saveMapDistanceCache}{value};
+	}
+
+	if ($self->{source}{map} eq $dest_map) {
+		my @solution;
+		if (Task::Route->getRoute(\@solution, $self->{source}{field}, {x => $self->{source}{x}, y => $self->{source}{y}}, {x => $dest_x, y => $dest_y})) {
+			my $distance = scalar(@solution);
+			$self->{saveMapDistanceCache} = { key => $cacheKey, value => $distance };
+			return $distance;
+		}
+		return;
+	}
+
+	my $task = Task::CalcMapRoute->new(
+		targets => [{ map => $dest_map, x => $dest_x, y => $dest_y }],
+		sourceMap => $self->{source}{map},
+		sourceX => $self->{source}{x},
+		sourceY => $self->{source}{y},
+		noGoCommand => 1,
+		noTeleSpawn => 1,
+		maxTime => 3,
+	);
+	$task->activate();
+
+	while ($task->getStatus() != Task::DONE) {
+		$task->iterate();
+	}
+
+	return if ($task->getError());
+	my $route = $task->getRoute();
+	my $distance = (!$route || !@{$route}) ? 0 : $route->[-1]{walk};
+	$self->{saveMapDistanceCache} = { key => $cacheKey, value => $distance };
+	return $distance;
+}
+
+sub isSaveMapSetAndValid {
+	my ($self) = @_;
+	return defined $self->resolveSaveMapDestination();
+}
+
+sub resolveSaveMapDestination {
+	my ($self) = @_;
+
+	my $target = ($self->{targets} && ref($self->{targets}) eq 'ARRAY' && @{$self->{targets}}) ? $self->{targets}[0] : undef;
+	my $cacheKey = join('|',
+		hashSafeGetValue(\%config, 'saveMap') // '',
+		hashSafeGetValue(\%config, 'saveMap_x') // '',
+		hashSafeGetValue(\%config, 'saveMap_y') // '',
+		($target && defined $target->{map}) ? $target->{map} : '',
+		($target && defined $target->{x}) ? $target->{x} : '',
+		($target && defined $target->{y}) ? $target->{y} : '',
+	);
+	if ($self->{saveMapDestinationCache} && $self->{saveMapDestinationCache}{key} eq $cacheKey) {
+		return $self->{saveMapDestinationCache}{value};
+	}
+
+	my $dest_map = hashSafeGetValue(\%config, 'saveMap');
+	return unless (defined $dest_map && $dest_map ne '');
+
+	my %candidates;
+	my $dest_x = hashSafeGetValue(\%config, 'saveMap_x');
+	my $dest_y = hashSafeGetValue(\%config, 'saveMap_y');
+	if (defined $dest_x && defined $dest_y && $dest_x ne '' && $dest_y ne '') {
+		my $dest = $dest_map . " " . $dest_x . " " . $dest_y;
+		if (hashSafeGetValue(\%portals_spawns, $dest, 'dest', $dest)) {
+			$candidates{"$dest_x $dest_y"} = { map => $dest_map, x => $dest_x, y => $dest_y };
+		}
+	}
+
+	foreach my $portal (keys %portals_spawns) {
+		foreach my $dest (keys %{$portals_spawns{$portal}{dest}}) {
+			next if (hashSafeGetValue(\%portals_spawns, $portal, 'dest', $dest, 'map') ne $dest_map);
+			my $x = hashSafeGetValue(\%portals_spawns, $portal, 'dest', $dest, 'x');
+			my $y = hashSafeGetValue(\%portals_spawns, $portal, 'dest', $dest, 'y');
+			next if (!defined $x || !defined $y || $x eq '' || $y eq '');
+			$candidates{"$x $y"} = { map => $dest_map, x => $x, y => $y };
+		}
+	}
+
+	my @candidates = values %candidates;
+	return unless @candidates;
+	return $candidates[0] if (@candidates == 1);
+
+	if ($target && $target->{map}) {
+		my $best;
+		my $bestWalk;
+		foreach my $candidate (@candidates) {
+			my $walk = $self->estimateWalkFromSaveMapSpawnToTarget($candidate, $target);
+			next unless defined $walk;
+			if (!defined $bestWalk || $walk < $bestWalk) {
+				$bestWalk = $walk;
+				$best = $candidate;
+			}
+		}
+		if ($best) {
+			$self->{saveMapDestinationCache} = { key => $cacheKey, value => $best };
+			return $best;
+		}
+	}
+
+	@candidates = sort {
+		$a->{x} <=> $b->{x}
+		|| $a->{y} <=> $b->{y}
+	} @candidates;
+
+	$self->{saveMapDestinationCache} = { key => $cacheKey, value => $candidates[0] };
+	return $candidates[0];
+}
+
+sub estimateWalkFromSaveMapSpawnToTarget {
+	my ($self, $spawn, $target) = @_;
+
+	my $task = Task::CalcMapRoute->new(
+		targets => [{ map => $target->{map}, x => $target->{x}, y => $target->{y} }],
+		sourceMap => $spawn->{map},
+		sourceX => $spawn->{x},
+		sourceY => $spawn->{y},
+		noGoCommand => 1,
+		noTeleSpawn => 1,
+		maxTime => 3,
+	);
+	$task->activate();
+
+	while ($task->getStatus() != Task::DONE) {
+		$task->iterate();
+	}
+
+	return if ($task->getError());
+	my $route = $task->getRoute();
+	return 0 if (!$route || !@{$route});
+	return $route->[-1]{walk};
+}
 
 1;


### PR DESCRIPTION
Introduce configurable warp-to-saveMap, min-distance behavior and route-based checks to avoid unnecessary teleports. Added new config entries (saveMap_warp, saveMap_warp_minDistance) and centralized warp eligibility into shouldUseWarpToSaveMapForBuyOrSell in CoreLogic. Implemented distance calculation and caching (getDistanceToSaveMap / getDistanceToSaveMapFromCurrentPosition) and improved Task::CalcMapRoute with helpers to resolve saveMap spawn destinations, estimate walk distances, and honor the min-distance threshold when populating warp options. Changes reduce redundant short-distance warps and improve routing accuracy while keeping fallbacks when route computation fails.