### PR TITLE
Fix minimap indicators spam

### DIFF
--- a/src/Network/Receive.pm
+++ b/src/Network/Receive.pm
@@ -1256,6 +1256,7 @@ sub map_loaded {
 	# assertClass($char, 'Actor::You');
 	$syncMapSync = pack('V1',$args->{syncMapSync}); # unused, should we keep this for legacy compatibility?
 	main::initMapChangeVars();
+	$ai_v{minimap_indicator_context_time} = time;
 
 	if ($net->version == 1) {
 		$net->setState(4);
@@ -3067,7 +3068,22 @@ sub homunculus_info {
 # Minimap indicator.
 sub minimap_indicator {
 	my ($self, $args) = @_;
+	
+	my $is_recent_map_change = $ai_v{minimap_indicator_context_time}
+		&& !timeOut($ai_v{minimap_indicator_context_time}, 12);
+	my $is_npc_dialog_context = $ai_v{'npc_talk'} && $ai_v{'npc_talk'}{'time'}
+		&& !timeOut($ai_v{'npc_talk'}{'time'}, 8)
+		&& $talk{ID} && $args->{npcID} && $talk{ID} eq $args->{npcID};
 
+	unless ($is_recent_map_change || $is_npc_dialog_context) {
+		debug TF("Ignoring minimap indicator packet outside map change/matching NPC dialog context (npcID=%s, type=%s, effect=%s, show=%s)\n",
+			unpack('V1', $args->{npcID}),
+			defined $args->{type} ? $args->{type} : '-',
+			defined $args->{effect} ? $args->{effect} : '-',
+			$args->{show}), 'parseMsg';
+		return;
+	}
+	
 	my $color_str = "[R:$args->{red}, G:$args->{green}, B:$args->{blue}, A:$args->{alpha}]";
 	my $indicator = T("minimap indicator");
 	if (defined $args->{type}) {
@@ -7221,6 +7237,7 @@ sub map_change {
 	}
 	AI::SlaveManager::setMapChanged ();
 	$ai_v{portalTrace_mapChanged} = time;
+	$ai_v{minimap_indicator_context_time} = time;
 
 	my %coords = (
 		x => $args->{x},
@@ -7294,6 +7311,7 @@ sub map_changed {
 	}
 	AI::SlaveManager::setMapChanged ();
 	$ai_v{portalTrace_mapChanged} = time;
+	$ai_v{minimap_indicator_context_time} = time;
 
 	if ($args->{'url'} =~ /.*\:\d+/) {
 		$map_ip = $args->{url};


### PR DESCRIPTION
Only handle minimap indicator packets when they are relevant: after a recent map change or during a matching NPC dialog. Adds $ai_v{minimap_indicator_context_time} updates in map_loaded, map_change and map_changed, and modifies minimap_indicator to accept packets only within a 12s window after map change or 8s of an NPC dialog (matching talk ID). Ignored packets are now logged via debug and returned early to avoid processing stray indicators.

Spam examples:

```txt
Você equipou [Visual] Rosas Aladas de Hermes (55) - Visual para cabeça (Topo) (tipo 1024)
Desconhecido #95 adicionou o indicador indicador no minimapa na localização 192, 109 de cor [R:255, G:128, B:0, A:0]
NPC Pai Nervoso (9) adicionou o indicador indicador no minimapa na localização 173, 77 de cor [R:255, G:128, B:0, A:0]
```
```txt
Senha do armazém informada corretamente.
NPC Oficial do Éden (5) adicionou o indicador efeito desconhecido 10 na localização 177, 111 de cor [R:255, G:128, B:0, A:0]
Item Armazenado: Elixir Celestial (148) x 3 - Consumível Especial
Item removido do inventário: Elixir Celestial (29) x 3
NPC Oficial do Éden (5) adicionou o indicador efeito desconhecido 10 na localização 177, 111 de cor [R:255, G:128, B:0, A:0]
```
```txt
Você ganhou 1,980 zeny.
0 itens vendidos.
Venda concluída.
Desconhecido #95 adicionou o indicador indicador no minimapa na localização 192, 109 de cor [R:255, G:128, B:0, A:0]
NPC Pai Nervoso (9) adicionou o indicador indicador no minimapa na localização 173, 77 de cor [R:255, G:128, B:0, A:0]
```
```txt
Item Apareceu: Uvas (0) x 1 (161, 84)
Desconhecido #95 adicionou o indicador indicador no minimapa na localização 192, 109 de cor [R:255, G:128, B:0, A:0]
NPC Pai Nervoso (9) adicionou o indicador indicador no minimapa na localização 173, 77 de cor [R:255, G:128, B:0, A:0]
```