### PR TITLE
add per-map retry blocking for go/save-warp/route-teleport with bounded block tracking

### DIFF
--- a/src/Task/CalcMapRoute.pm
+++ b/src/Task/CalcMapRoute.pm
@@ -103,12 +103,14 @@ sub new {
 	} else {
 		$self->{noGoCommand} = 0;
 	}
+	$self->{noGoCommandMaps} = $args{noGoCommandMaps} || {};
 
 	if (exists $args{noTeleSpawn}) {
 		$self->{noTeleSpawn} = $args{noTeleSpawn}
 	} else {
 		$self->{noTeleSpawn} = 0;
 	}
+	$self->{noGoCommandMaps} = $args{noGoCommandMaps} || {};
 
 	if (exists $args{noAirship}) {
 		$self->{noAirship} = $args{noAirship}
@@ -186,11 +188,19 @@ sub iterate {
 			}
 		}
 
-		$self->populateOpenListWithGoCommands() unless ($self->{noGoCommand});
+		$self->populateOpenListWithGoCommands(
+			"$self->{source}{map} $self->{source}{x} $self->{source}{y}",
+			{ walk => 0, zeny => 0, zeny_covered_by_tickets => 0, amount_of_tickets_used => 0 },
+			undef,
+		) unless ($self->{noGoCommand});
 
 		delete $self->{tempPortalsSaveMap} if (exists $self->{tempPortalsSaveMap});
 		if (!$self->{noTeleSpawn} && canUseTeleport(2) && $self->isSaveMapSetAndValid()) {
-			$self->populateOpenListWithWarpToSaveMap();
+			$self->populateOpenListWithWarpToSaveMap(
+				"$self->{source}{map} $self->{source}{x} $self->{source}{y}",
+				{ walk => 0, zeny => 0, zeny_covered_by_tickets => 0, amount_of_tickets_used => 0 },
+				undef,
+			);
 		}
 
 		# Initializes the openlist with airships walkable from the starting point.
@@ -376,6 +386,11 @@ sub searchStep {
 		}
 
 		# get all children of each openlist.
+		$self->populateOpenListWithGoCommands($dest, $closelist->{$parent}, $parent) unless ($self->{noGoCommand});
+		if (!$self->{noTeleSpawn} && canUseTeleport(2) && $self->isSaveMapSetAndValid()) {
+			$self->populateOpenListWithWarpToSaveMap($dest, $closelist->{$parent}, $parent);
+		}
+		
 		# explore connected portals and NPC warps
 		foreach my $child (keys %{$portals_los{$dest}}) {
 			next unless $portals_los{$dest}{$child}; # next if no child
@@ -428,28 +443,33 @@ sub searchStep {
 
 # Add @go commands to openlist
 sub populateOpenListWithGoCommands {
-	my ($self) = @_;
+	my ($self, $from_node, $baseCost, $parent) = @_;
+	return unless $from_node;
 
-	# set current map vars
-	my $current_map = $self->{source}{map};
-	my $current_x   = $self->{source}{x};
-	my $current_y   = $self->{source}{y};
-	my $from_node   = "$current_map $current_x $current_y";
+	my ($current_map) = split / /, $from_node, 2;
+	return unless $self->isGoCommandAllowedOnMap($current_map);
 
 	# iterate through the commands
 	foreach my $portal (keys %portals_commands) {
 		foreach my $dest (keys %{$portals_commands{$portal}{dest}}) {
 			my $to_node = $portals_commands{$portal}{dest}{$dest}{map} . " " . $portals_commands{$portal}{dest}{$dest}{x} . " " . $portals_commands{$portal}{dest}{$dest}{y};
 			my $key = "$from_node=$to_node";
+			my $walk = ($baseCost->{walk} || 0) + ($routeWeights{COMMAND} || 20);
+			my $zeny = $baseCost->{zeny} || 0;
+			my $zeny_covered_by_tickets = $baseCost->{zeny_covered_by_tickets} || 0;
+			my $amount_of_tickets_used = $baseCost->{amount_of_tickets_used} || 0;
+
+			next if (exists $self->{closelist}{$key} && $self->{closelist}{$key}{walk} <= $walk);
+			next if (exists $self->{openlist}{$key} && $self->{openlist}{$key}{walk} <= $walk);
 
 			# add @go option as a synthetic portal
 			$self->{openlist}{$key} = {
-				parent                   => undef,
-				walk                     => $routeWeights{COMMAND} || 20,
-				zeny                     => 0,
+				parent                   => $parent,
+				walk                     => $walk,
+				zeny                     => $zeny,
 				allow_ticket             => 0,
-				zeny_covered_by_tickets  => 0,
-				amount_of_tickets_used   => 0,
+				zeny_covered_by_tickets  => $zeny_covered_by_tickets,
+				amount_of_tickets_used   => $amount_of_tickets_used,
 				is_command               => 1,
 				command                  => $portals_commands{$portal}{dest}{$dest}{command},
 			};
@@ -457,20 +477,18 @@ sub populateOpenListWithGoCommands {
 	}
 }
 
+
 # Add teleport lv 2 (or butterfly wing) to openlist
 sub populateOpenListWithWarpToSaveMap {
-	my ($self) = @_;
+	my ($self, $from_node, $baseCost, $parent) = @_;
+	return unless $from_node;
 	
 	return unless ($config{saveMap_warp});
+	my ($current_map) = split / /, $from_node, 2;
+	return unless $self->isWarpToSaveMapAllowedOnMap($current_map);
 	return unless ($self->isWarpToSaveMapMinDistanceReached());
 	my $saveMapDestination = $self->resolveSaveMapDestination();
 	return unless ($saveMapDestination);
-
-	# set current map vars
-	my $current_map = $self->{source}{map};
-	my $current_x   = $self->{source}{x};
-	my $current_y   = $self->{source}{y};
-	my $from_node   = "$current_map $current_x $current_y";
 	
 	my $dest_map = $saveMapDestination->{map};
 	my $dest_x = $saveMapDestination->{x};
@@ -481,14 +499,21 @@ sub populateOpenListWithWarpToSaveMap {
 	debug "CalcMapRoute - Adding savemap '".( $dest )."' to openlist.\n", "calc_map_route";
 
 	my $key = "$from_node=$dest";
+	my $walk = ($baseCost->{walk} || 0) + ($routeWeights{WARPTOSAVEMAP} || 200);
+	my $zeny = $baseCost->{zeny} || 0;
+	my $zeny_covered_by_tickets = $baseCost->{zeny_covered_by_tickets} || 0;
+	my $amount_of_tickets_used = $baseCost->{amount_of_tickets_used} || 0;
+
+	return if (exists $self->{closelist}{$key} && $self->{closelist}{$key}{walk} <= $walk);
+	return if (exists $self->{openlist}{$key} && $self->{openlist}{$key}{walk} <= $walk);
 
 	$self->{openlist}{$key} = {
-		parent                   => undef,
-		walk                     => $routeWeights{WARPTOSAVEMAP} || 200,
-		zeny                     => 0,
+		parent                   => $parent,
+		walk                     => $walk,
+		zeny                     => $zeny,
 		allow_ticket             => 0,
-		zeny_covered_by_tickets  => 0,
-		amount_of_tickets_used   => 0,
+		zeny_covered_by_tickets  => $zeny_covered_by_tickets,
+		amount_of_tickets_used   => $amount_of_tickets_used,
 		is_teleportToSaveMap     => 1,
 	};
 
@@ -496,6 +521,20 @@ sub populateOpenListWithWarpToSaveMap {
 	$self->{tempPortalsSaveMap}{$dest}{'dest'}{$dest}{'x'} = $dest_x;
 	$self->{tempPortalsSaveMap}{$dest}{'dest'}{$dest}{'y'} = $dest_y;
 	$self->{tempPortalsSaveMap}{$dest}{dest}{$dest}{enabled} = 1;
+}
+
+sub isGoCommandAllowedOnMap {
+	my ($self, $map) = @_;
+	return 0 if !$map;
+	return 0 if hashSafeGetValue($self->{noGoCommandMaps}, $map);
+	return 1;
+}
+
+sub isWarpToSaveMapAllowedOnMap {
+	my ($self, $map) = @_;
+	return 0 if !$map;
+	return 0 if hashSafeGetValue($self->{noTeleSpawnMaps}, $map);
+	return 1;
 }
 
 sub isWarpToSaveMapMinDistanceReached {

--- a/src/Task/MapRoute.pm
+++ b/src/Task/MapRoute.pm
@@ -36,6 +36,11 @@ use AI qw(ai_useTeleport);
 
 
 # Error constants.
+use constant {
+	MAP_BLOCK_EXPIRATION => 600,
+	MAP_BLOCK_MAX => 20,
+};
+
 use enum (
 	# Routing errors
 	qw(TOO_MUCH_TIME
@@ -114,7 +119,10 @@ sub new {
 	$self->{useManhattan} = 0 if (!defined $self->{useManhattan});
 
 	$self->{noGoCommand} = 0 if (!defined $self->{noGoCommand});
+	$self->{noGoCommandMaps} = {} if (!defined $self->{noGoCommandMaps});
 	$self->{noTeleSpawn} = 0 if (!defined $self->{noTeleSpawn});
+	$self->{noTeleSpawnMaps} = {} if (!defined $self->{noTeleSpawnMaps});
+	$self->{noRouteTeleportMaps} = {} if (!defined $self->{noRouteTeleportMaps});
 	$self->{noAirship} = 0 if (!defined $self->{noAirship});
 
 	# Watch for map change events. Pass a weak reference to ourselves in order
@@ -159,6 +167,11 @@ sub iterate {
 	Plugins::callHook("MapRoute_iterate_start", \%hookArgs);
 	return if ($hookArgs{return});
 
+	if (!defined $self->{mapBlockPruneTime} || timeOut($self->{mapBlockPruneTime}, 60)) {
+		$self->prunePerMapBlocks();
+		$self->{mapBlockPruneTime} = time;
+	}
+	
 	my @solution;
 	if (!$self->{mapSolution}) {
 		$self->initMapCalculator();
@@ -175,7 +188,10 @@ sub iterate {
 		delete $self->{timeout};
 		delete $timeout{'ai_portal_give_up'}{'time'};
 		delete $timeout{'ai_portal_wait'}{'time'};
+		delete $self->{teleport};
 		delete $self->{teleportTime};
+		delete $self->{sentTeleport};
+		delete $self->{teleportTries};
 		delete $self->{mapChanged};
 		delete $self->{missing_portal};
 		delete $self->{guess_portal};
@@ -194,8 +210,8 @@ sub iterate {
 				$self->{substage} = 'Waiting for Warp';
 				$messageSender->sendChat($go_cmd);
 			} else {
-				error TF("Failed to move using go command after %s tries, recalculating route and forbidding it.\n", $self->{mapSolution}[0]{retry}), "map_route";
-				$self->{noGoCommand} = 1;
+				error TF("Failed to move using go command after %s tries on map %s, recalculating route and forbidding go only on this map.\n", $self->{mapSolution}[0]{retry}, $field->baseName), "map_route";
+				$self->{noGoCommandMaps}{$field->baseName} = time;
 				$self->initMapCalculator();	# redo MAP router
 			}
 		}
@@ -215,8 +231,8 @@ sub iterate {
 				$self->{substage} = 'Waiting for Warp';
 				ai_useTeleport(2);
 			} else {
-				error TF("Failed to move to savepoint using teleport/butterfly wing after %s tries, recalculating route and forbidding it.\n", $self->{mapSolution}[0]{retry}), "map_route";
-				$self->{noTeleSpawn} = 1;
+				error TF("Failed to move to savepoint using teleport/butterfly wing after %s tries on map %s, recalculating route and forbidding teleport only on this map.\n", $self->{mapSolution}[0]{retry}, $field->baseName), "map_route";
+				$self->{noTeleSpawnMaps}{$field->baseName} = time;
 				$self->initMapCalculator();	# redo MAP router
 			}
 		}
@@ -625,7 +641,9 @@ sub iterate {
 			my $walk = 1;
 
 			# Teleport until we're close enough to the portal
-			$self->{teleport} = $config{route_teleport} if (!defined $self->{teleport});
+			if (!defined $self->{teleport} || $self->{mapChanged}) {
+				$self->{teleport} = $self->isRouteTeleportAllowedOnMap($field->baseName) ? $config{route_teleport} : 0;
+			}
 
 			if ($self->{teleport} && !$field->isCity
 			&& !existsInList($config{route_teleport_notInMaps}, $field->baseName)
@@ -670,8 +688,11 @@ sub iterate {
 					}
 
 				} elsif (timeOut($self->{teleportTime}, 4)) {
-					debug "Unable to teleport; falling back to walking.\n", "map_route";
+					debug TF("Unable to teleport on map %s; falling back to walking on this map.\n", $field->baseName), "map_route";
+					$self->{noRouteTeleportMaps}{$field->baseName} = time;
 					$self->{teleport} = 0;
+					delete $self->{sentTeleport};
+					delete $self->{teleportTime};
 				} else {
 					$walk = 0;
 				}
@@ -715,6 +736,37 @@ sub iterate {
 	}
 }
 
+sub prunePerMapBlocks {
+	my ($self) = @_;
+	my $now = time;
+
+	for my $bucketName (qw(noGoCommandMaps noTeleSpawnMaps noRouteTeleportMaps)) {
+		my $bucket = $self->{$bucketName};
+		next unless ($bucket && ref $bucket eq 'HASH');
+
+		foreach my $map (keys %{$bucket}) {
+			my $blockedAt = $bucket->{$map};
+			if (!defined($blockedAt) || $blockedAt !~ /^\d+(?:\.\d+)?$/) {
+				$blockedAt = $bucket->{$map} = $now;
+			}
+			delete $bucket->{$map} if (($now - $blockedAt) > MAP_BLOCK_EXPIRATION);
+		}
+
+		my @maps = sort { $bucket->{$a} <=> $bucket->{$b} } keys %{$bucket};
+		while (@maps > MAP_BLOCK_MAX) {
+			my $oldest = shift @maps;
+			delete $bucket->{$oldest};
+		}
+	}
+}
+
+sub isRouteTeleportAllowedOnMap {
+	my ($self, $map) = @_;
+	return 0 if !$map;
+	return 0 if ($self->{noRouteTeleportMaps}{$map});
+	return 1;
+}
+
 sub setNpcTalk {
 	my ($self) = @_;
 
@@ -743,7 +795,9 @@ sub initMapCalculator {
 		x => $self->{dest}{pos}{x},
 		y => $self->{dest}{pos}{y},
 		noGoCommand => $self->{noGoCommand},
+		noGoCommandMaps => $self->{noGoCommandMaps},
 		noTeleSpawn => $self->{noTeleSpawn},
+		noTeleSpawnMaps => $self->{noTeleSpawnMaps},
 		noAirship => $self->{noAirship},
 	);
 	$self->setSubtask($task);


### PR DESCRIPTION
Improve inter-map routing resilience by switching movement-helper failure handling from global toggles to per-map blocking, while preserving route cost integrity.

- Add per-map block state:
  - CalcMapRoute: noGoCommandMaps, noTeleSpawnMaps
  - MapRoute: noGoCommandMaps, noTeleSpawnMaps, noRouteTeleportMaps
- Pass per-map block maps from MapRoute into CalcMapRoute on recalculation.

- Update synthetic route option insertion:
  - populateOpenListWithGoCommands() and populateOpenListWithWarpToSaveMap() now accept (from_node, baseCost, parent)
  - preserve cumulative walk/zeny/ticket accounting when re-adding synthetic edges
  - avoid replacing equal-or-better open/closed entries
  - skip insertion when origin map is blocked via:
    - isGoCommandAllowedOnMap()
    - isWarpToSaveMapAllowedOnMap()

- Change retry failure behavior:
  - On @go exhaustion, block only current map in noGoCommandMaps and recalc.
  - On save-warp exhaustion, block only current map in noTeleSpawnMaps and recalc.
  - On route_teleport timeout, block only current map in noRouteTeleportMaps.

- Add bounded block-list maintenance:
  - MAP_BLOCK_EXPIRATION and MAP_BLOCK_MAX constants
  - periodic prunePerMapBlocks() in iterate()
  - expire old map blocks and cap each block bucket by oldest-first eviction
  - store block timestamps for pruning and legacy normalization.

This keeps failures localized to problematic maps, allows retries after map changes, and prevents unbounded growth of per-map block tracking during long sessions.