### PR TITLE
fix(Win32): prevent crash when turning ai off

### DIFF
--- a/src/Interface/Win32.pm
+++ b/src/Interface/Win32.pm
@@ -16,6 +16,7 @@ use Plugins;
 use Globals;
 use Settings;
 use Misc;
+use Translation qw(T TF);
 
 use Win32::GUI;
 use Win32::GUI::Constants qw(WS_CHILD WS_VISIBLE WS_VSCROLL ES_LEFT ES_MULTILINE ES_READONLY ES_AUTOVSCROLL MB_OK MB_ICONERROR);


### PR DESCRIPTION
Crash was occurring on line 1027 when attempting to translate the text "Paused" due to missing module import